### PR TITLE
Add basic Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,20 @@
+
+FROM pytorch/pytorch:2.3.0-cuda12.1-cudnn8-runtime
+
+## Add System Dependencies
+RUN apt-get update \
+    && DEBIAN_FRONTEND=noninteractive apt-get install --no-install-recommends -y \
+        build-essential \
+        git \
+        wget \
+    && rm -rf /var/lib/apt/lists/* \
+    && apt-get autoremove -y \
+    && apt-get clean
+
+## Change working directory
+WORKDIR /app/alphafold
+
+## Clone and install the LucidRains package + requirements
+RUN git clone https://github.com/lucidrains/alphafold3-pytorch . \
+    && git checkout main \
+    && python -m pip install .

--- a/README.md
+++ b/README.md
@@ -109,6 +109,19 @@ Then, add your module to `alphafold3_pytorch/alphafold3.py`, add your tests to `
 $ pytest tests/
 ```
 
+## Docker
+
+### Build Docker Container
+```bash
+docker build -t af3 .
+```
+
+### Run Container
+```bash
+## With GPUs
+docker run  --gpus all -it af3
+```
+
 ## Citations
 
 ```bibtex


### PR DESCRIPTION
This includes a basic Dockerfile for building an running AF3 library locally without managing the dependencies for PyTorch, etc.

Base Image: `pytorch/pytorch:2.3.0-cuda12.1-cudnn8-runtime`
Clones from the `main` branch of `https://github.com/lucidrains/alphafold3-pytorch` until a stable release is made (at which point we can update the source).