### PR TITLE
[fix] Apply different augmentation to each sample in CentreRandomAugmentation.

### DIFF
--- a/alphafold3_pytorch/alphafold3.py
+++ b/alphafold3_pytorch/alphafold3.py
@@ -2128,15 +2128,17 @@ class CentreRandomAugmentation(Module):
         """
         # Center the coordinates
         centered_coords = coords - coords.mean(dim=1, keepdim=True)
+        
+        batch_size = coords.shape[0]
 
         # Generate random rotation matrix
-        rotation_matrix = self._random_rotation_matrix(coords.device)
+        rotation_matrix = torch.stack([self._random_rotation_matrix(coords.device) for _ in range(batch_size)])
 
         # Generate random translation vector
-        translation_vector = self._random_translation_vector(coords.device)
+        translation_vector = torch.stack([self._random_translation_vector(coords.device) for _ in range(batch_size)]).unsqueeze(1)
 
         # Apply rotation and translation
-        augmented_coords = torch.einsum('bni,ij->bnj', centered_coords, rotation_matrix) + translation_vector
+        augmented_coords = torch.einsum('bni,bij->bnj', centered_coords, rotation_matrix) + translation_vector
 
         return augmented_coords
 


### PR DESCRIPTION
In Diffusion Module, augmentation is used to train more noisy samples, and each augmented sample should be assigned different noises.
In the original implementation, the same rotation and translation were applied to each augmented sample using a broadcasting mechanism, which is unreasonable.