### PR TITLE
Make `align_weights` in `alphafold3.py` perfectly match Equation 4 in the AF3 supplement

### DIFF
--- a/alphafold3_pytorch/alphafold3.py
+++ b/alphafold3_pytorch/alphafold3.py
@@ -2021,8 +2021,9 @@ class ElucidatedAtomDiffusion(Module):
 
             # section 3.7.1 equation 4
 
-            align_weights = torch.where(atom_is_dna | atom_is_rna, nucleotide_loss_weight, align_weights)
-            align_weights = torch.where(atom_is_ligand, ligand_loss_weight, align_weights)
+            # upweighting of nucleotide and ligand atoms is additive per equation 4
+            align_weights = torch.where(atom_is_dna | atom_is_rna, 1 + nucleotide_loss_weight, align_weights)
+            align_weights = torch.where(atom_is_ligand, 1 + ligand_loss_weight, align_weights)
 
         # section 3.7.1 equation 2 - weighted rigid aligned ground truth
 


### PR DESCRIPTION
* Right now, nucleotide and ligand atom weights are set to 5 and 10, respectively.
* This change brings these atom weights in line with what is described in Equation 4 of the AF3 supplement. That is, these respective atom weights of 5 and 10 should be *added* to the default protein atom weight of 1. This would now make the nucleotide and ligand atom weights 6 and 11, respectively.