### PR TITLE
It is unnecessary to synchronize backward in gradient accumulation step.

### DIFF
--- a/alphafold3_pytorch/trainer.py
+++ b/alphafold3_pytorch/trainer.py
@@ -167,7 +167,7 @@ class Trainer:
                 with self.fabric.no_backward_sync(self.model, enabled = is_accumulating):
                     loss = self.model(**inputs)
 
-                self.fabric.backward(loss / self.grad_accum_every)
+                    self.fabric.backward(loss / self.grad_accum_every)
 
             print(f'loss: {loss.item():.3f}')
 


### PR DESCRIPTION
make backward function under `with self.fabric.no_backward_sync(self.model, enabled = is_accumulating)`.