### PR TITLE
Correct application of rotations to coordinates in `WeightedRigidAlign` within `alphafold3.py`

### DIFF
--- a/alphafold3_pytorch/alphafold3.py
+++ b/alphafold3_pytorch/alphafold3.py
@@ -2212,7 +2212,7 @@ class WeightedRigidAlign(Module):
             )
 
         # Compute the weighted covariance matrix
-        cov_matrix = einsum(true_coords_centered * weights, pred_coords_centered, 'b n i, b n j -> b i j')
+        cov_matrix = einsum(weights * true_coords_centered, pred_coords_centered, 'b n i, b n j -> b i j')
 
         # Compute the SVD of the covariance matrix
         U, S, V = torch.svd(cov_matrix)
@@ -2234,7 +2234,7 @@ class WeightedRigidAlign(Module):
         rot_matrix = einsum(U, F, V, "b i j, b j k, b l k -> b i l")
 
         # Apply the rotation and translation
-        aligned_coords = einsum(pred_coords_centered, rot_matrix, 'b n i, b i j -> b n j') + true_centroid
+        aligned_coords = einsum(pred_coords_centered, rot_matrix, 'b n i, b j i -> b n j') + true_centroid
         aligned_coords.detach_()
 
         return aligned_coords

--- a/tests/test_af3.py
+++ b/tests/test_af3.py
@@ -65,6 +65,14 @@ def test_weighted_rigid_align():
     rmsd = torch.sqrt(((pred_coords - aligned_coords) ** 2).sum(dim=-1).mean(dim=-1))
     assert (rmsd < 1e-5).all()
 
+    random_augment_fn = CentreRandomAugmentation()
+    aligned_coords = align_fn(random_augment_fn(pred_coords), pred_coords, weights)
+
+    # `pred_coords` should match a random augmentation of itself after alignment
+
+    rmsd = torch.sqrt(((pred_coords - aligned_coords) ** 2).sum(dim=-1).mean(dim=-1))
+    assert (rmsd < 1e-5).all()
+
 def test_weighted_rigid_align_with_mask():
     pred_coords = torch.randn(2, 100, 3)
     true_coords = torch.randn(2, 100, 3)


### PR DESCRIPTION
* Also adds a check to see if the rotations returned by `WeightedRigidAlign` are unique (thanks @pytorch3d!)
* Lastly, updates the unit test for `WeightedRigidAlign` to more carefully test the correctness of both `WeightedRigidAlign` and `CentreRandomAugmentation`