### PR TITLE
rollout pos should be named denoised_atom_pos

### DIFF
--- a/alphafold3_pytorch/alphafold3.py
+++ b/alphafold3_pytorch/alphafold3.py
@@ -3323,7 +3323,7 @@ class Alphafold3(Module):
 
             # rollout
 
-            pred_atom_pos = self.edm.sample(
+            denoised_atom_pos = self.edm.sample(
                 num_sample_steps = num_rollout_steps,
                 atom_feats = atom_feats,
                 atompair_feats = atompair_feats,


### PR DESCRIPTION
Fix the bug about [https://github.com/lucidrains/alphafold3-pytorch/pull/26#discussion_r1621905156](https://github.com/lucidrains/alphafold3-pytorch/pull/26#discussion_r1621905156)