### PR TITLE
Fix context manager bug in `pdb_dataset_curation.py`

### DIFF
--- a/alphafold3_pytorch/pdb_dataset_curation.py
+++ b/alphafold3_pytorch/pdb_dataset_curation.py
@@ -711,6 +711,44 @@ def write_structure(structure: Structure, output_filepath: str):
 
 
 @typecheck
+@timeout_decorator.timeout(PROCESS_STRUCTURE_MAX_SECONDS, use_signals=False)
+def process_structure_with_timeout(filepath: str, output_dir: str, skip_existing: bool = False):
+    """
+    Given an input mmCIF file, create a new processed mmCIF file
+    using AlphaFold 3's PDB dataset filtering criteria under a
+    timeout constraint.
+    """
+    # Section 2.5.4 of the AlphaFold 3 supplement
+    structure = parse_structure(filepath)
+    output_file_dir = os.path.join(output_dir, structure.id[1:3])
+    output_filepath = os.path.join(output_file_dir, f"{structure.id}.cif")
+    if skip_existing and os.path.exists(output_filepath):
+        print(f"Skipping existing output file: {output_filepath}")
+        return
+    os.makedirs(output_file_dir, exist_ok=True)
+
+    # Filtering of targets
+    structure = filter_target(structure)
+    if exists(structure):
+        # Filtering of bioassemblies
+        structure = remove_hydrogens(structure)
+        structure = remove_all_unknown_residue_chains(structure, STANDARD_RESIDUES)
+        structure = remove_clashing_chains(structure)
+        structure = remove_excluded_ligands(structure, LIGAND_EXCLUSION_LIST)
+        structure = remove_non_ccd_atoms(structure, CCD_READER_RESULTS)
+        structure = remove_leaving_atoms(structure, CCD_READER_RESULTS)
+        structure = filter_large_ca_distances(structure)
+        structure = select_closest_chains(
+            structure, PROTEIN_RESIDUE_CENTER_ATOMS, NUCLEIC_ACID_RESIDUE_CENTER_ATOMS
+        )
+        structure = remove_crystallization_aids(structure, CRYSTALLOGRAPHY_METHODS)
+        if list(structure.get_chains()):
+            # Save processed structure
+            write_structure(structure, output_filepath)
+            print(f"Finished processing structure: {structure.id}")
+
+
+@typecheck
 def process_structure(args: Tuple[str, str, bool]):
     """
     Given an input mmCIF file, create a new processed mmCIF file
@@ -718,35 +756,7 @@ def process_structure(args: Tuple[str, str, bool]):
     """
     filepath, output_dir, skip_existing = args
     try:
-        with timeout_decorator.timeout(PROCESS_STRUCTURE_MAX_SECONDS, use_signals=False):
-            # Section 2.5.4 of the AlphaFold 3 supplement
-            structure = parse_structure(filepath)
-            output_file_dir = os.path.join(output_dir, structure.id[1:3])
-            output_filepath = os.path.join(output_file_dir, f"{structure.id}.cif")
-            if skip_existing and os.path.exists(output_filepath):
-                print(f"Skipping existing output file: {output_filepath}")
-                return
-            os.makedirs(output_file_dir, exist_ok=True)
-
-            # Filtering of targets
-            structure = filter_target(structure)
-            if exists(structure):
-                # Filtering of bioassemblies
-                structure = remove_hydrogens(structure)
-                structure = remove_all_unknown_residue_chains(structure, STANDARD_RESIDUES)
-                structure = remove_clashing_chains(structure)
-                structure = remove_excluded_ligands(structure, LIGAND_EXCLUSION_LIST)
-                structure = remove_non_ccd_atoms(structure, CCD_READER_RESULTS)
-                structure = remove_leaving_atoms(structure, CCD_READER_RESULTS)
-                structure = filter_large_ca_distances(structure)
-                structure = select_closest_chains(
-                    structure, PROTEIN_RESIDUE_CENTER_ATOMS, NUCLEIC_ACID_RESIDUE_CENTER_ATOMS
-                )
-                structure = remove_crystallization_aids(structure, CRYSTALLOGRAPHY_METHODS)
-                if list(structure.get_chains()):
-                    # Save processed structure
-                    write_structure(structure, output_filepath)
-                    print(f"Finished processing structure: {structure.id}")
+        process_structure_with_timeout(filepath, output_dir, skip_existing)
     except Exception as e:
         print(f"Skipping structure processing of {filepath} due to: {e}")
         structure_id = os.path.splitext(os.path.basename(filepath))[0]


### PR DESCRIPTION
* Fixes a context manager bug in `pdb_dataset_curation.py`.
* Sadly, it seems that the [`timeout-decorator`](https://github.com/pnpnpn/timeout-decorator) package does not support context manager usage currently. In which case, I've reverted to the previous way of timing out the `process_structure` function while ensuring it is compatible with Python `multiprocessing` (via `use_signals=False`).