### PR TITLE
[fix bug] make molecule_atom_indices to correct global indices

### DIFF
--- a/alphafold3_pytorch/alphafold3.py
+++ b/alphafold3_pytorch/alphafold3.py
@@ -3270,7 +3270,7 @@ class Alphafold3(Module):
         # handle offsets for molecule atom indices
 
         if exists(molecule_atom_indices):
-            molecule_atom_indices = molecule_atom_indices + F.pad(molecule_atom_lens, (-1, 1), value = 0)
+            molecule_atom_indices = molecule_atom_indices + F.pad(molecule_atom_lens.cumsum(dim = -1), (1, -1), value = 0)
 
         # get atom sequence length and molecule sequence length depending on whether using packed atomic seq
 


### PR DESCRIPTION
`molecule_atom_indices` should be a global index after processing, making it easier to retrieve the corresponding atom based on the token.

I believe this could be a bug, and the purpose of this PR is to fix it.