### PR TITLE
Filter preprocessed assembly mmCIF files, fix various bugs in the filtering criterion functions, and optimize the clustering script

### DIFF
--- a/README.md
+++ b/README.md
@@ -196,18 +196,22 @@ assert sampled_atom_pos.shape == (1, (6 + 5), 3)
 
 ### PDB dataset curation
 
-To acquire the AlphaFold 3 PDB dataset, first download all complexes in the Protein Data Bank (PDB), and then preprocess them with the script referenced below. The PDB can be downloaded from the RCSB: https://www.wwpdb.org/ftp/pdb-ftp-sites#rcsbpdb. The Python script below (i.e., `filter_pdb_mmcifs.py`) assumes you have downloaded the PDB in the **mmCIF file format**, placing it at `data/pdb_data/unfiltered_mmcifs/`. On the RCSB website, navigate down to "Download Protocols", and follow the download instructions depending on your location.
+To acquire the AlphaFold 3 PDB dataset, first download all first-assembly (and asymmetric unit) complexes in the Protein Data Bank (PDB), and then preprocess them with the script referenced below. The PDB can be downloaded from the RCSB: https://www.wwpdb.org/ftp/pdb-ftp-sites#rcsbpdb. The Python script below (i.e., `filter_pdb_mmcifs.py`) assumes you have downloaded the PDB in the **mmCIF file format**, placing it at `data/pdb_data/unfiltered_assembly_mmcifs/` (and `data/pdb_data/unfiltered_asym_mmcifs/`, respectively). On the RCSB website, navigate down to "Download Protocols", and follow the download instructions depending on your location.
 
-For example, one can use the following command to download the PDB as a collection of mmCIF files:
+For example, one can use the following commands to download the PDB as a collection of mmCIF files:
 ```bash
+# For `assembly1` complexes
 rsync -rlpt -v -z --delete --port=33444 \
-rsync.rcsb.org::ftp_data/structures/divided/mmCIF/ ./data/pdb_data/unfiltered_mmcifs/
+rsync.rcsb.org::ftp_data/assemblies/mmCIF/divided/ ./data/pdb_data/unfiltered_assembly_mmcifs/
+# For asymmetric unit complexes
+rsync -rlpt -v -z --delete --port=33444 \
+rsync.rcsb.org::ftp_data/structures/divided/mmCIF/ ./data/pdb_data/unfiltered_asym_mmcifs/
 ```
 
 > WARNING: Downloading PDB can take up to 1TB of space.
 
-After downloading, you should have a directory formatted like this:
-https://files.rcsb.org/pub/pdb/data/structures/divided/mmCIF/
+After downloading, you should have two directories formatted like this:
+https://files.rcsb.org/pub/pdb/data/assemblies/mmCIF/divided/ & https://files.rcsb.org/pub/pdb/data/structures/divided/mmCIF/
 ```bash
 00/
 01/
@@ -216,9 +220,10 @@ https://files.rcsb.org/pub/pdb/data/structures/divided/mmCIF/
 zz/
 ```
 
-In this directory, unzip all the files:
+For these directories, unzip all the files:
 ```bash
-find . -type f -name "*.gz" -exec gzip -d {} \;
+find ./data/pdb_data/unfiltered_assembly_mmcifs/ -type f -name "*.gz" -exec gzip -d {} \;
+find ./data/pdb_data/unfiltered_asym_mmcifs/ -type f -name "*.gz" -exec gzip -d {} \;
 ```
 
 Next run the commands
@@ -233,12 +238,12 @@ find data/ccd_data/ -type f -name "*.gz" -exec gzip -d {} \;
 
 ### PDB dataset filtering
 
-Then run the following with `pdb_dir`, `ccd_dir`, and `mmcif_output_dir` replaced with the locations of your local copies of the PDB, CCD, and your desired dataset output directory (i.e., `./data/pdb_data/unfiltered_mmcifs/`, `./data/ccd_data/`, and `./data/pdb_data/mmcifs/`).
+Then run the following with `pdb_assembly_dir`, `pdb_asym_dir`, `ccd_dir`, and `mmcif_output_dir` replaced with the locations of your local copies of the first-assembly PDB, asymmetric unit PDB, CCD, and your desired dataset output directory (i.e., `./data/pdb_data/unfiltered_assembly_mmcifs/`, `./data/pdb_data/unfiltered_asym_mmcifs/`, `./data/ccd_data/`, and `./data/pdb_data/mmcifs/`).
 ```bash
-python scripts/filter_pdb_mmcifs.py --mmcif_dir <pdb_dir> --ccd_dir <ccd_dir> --output_dir <mmcif_output_dir>
+python scripts/filter_pdb_mmcifs.py --mmcif_assembly_dir <pdb_assembly_dir> --mmcif_asym_dir <pdb_asym_dir> --ccd_dir <ccd_dir> --output_dir <mmcif_output_dir>
 ```
 
-See the script for more options. Each mmCIF that successfully passes
+See the script for more options. Each first-assembly mmCIF that successfully passes
 all processing steps will be written to `mmcif_output_dir` within a subdirectory
 named according to the mmCIF's second and third PDB ID characters (e.g. `5c`).
 

--- a/README.md
+++ b/README.md
@@ -26,6 +26,8 @@ A fork with full Lightning + Hydra support is being maintained by <a href="https
 
 - <a href="https://github.com/amorehead">Alex</a> for the PDB dataset preparation script!
 
+- <a href="https://github.com/milot-mirdita">Milot</a> for optimizing the PDB dataset clustering script!
+
 - <a href="https://github.com/patrick-kidger">Patrick</a> for <a href="https://docs.kidger.site/jaxtyping/">jaxtyping</a>, <a href="https://github.com/fferflo">Florian</a> for <a href="https://github.com/fferflo/einx">einx</a>, and of course, <a href="https://github.com/arogozhnikov">Alex</a> for <a href="https://einops.rocks/">einops</a>
 
 ## Install

--- a/README.md
+++ b/README.md
@@ -210,6 +210,10 @@ rsync.rcsb.org::ftp_data/structures/divided/mmCIF/ ./data/pdb_data/unfiltered_as
 
 > WARNING: Downloading PDB can take up to 1TB of space.
 
+> NOTE: PDB also hosts snapshots on AWS: https://pdbsnapshots.s3.us-west-2.amazonaws.com/index.html.
+
+> TODO: Use a specific snapshot to make training reproducible.
+
 After downloading, you should have two directories formatted like this:
 https://files.rcsb.org/pub/pdb/data/assemblies/mmCIF/divided/ & https://files.rcsb.org/pub/pdb/data/structures/divided/mmCIF/
 ```bash

--- a/alphafold3_pytorch/common/biomolecule.py
+++ b/alphafold3_pytorch/common/biomolecule.py
@@ -721,10 +721,6 @@ def to_mmcif(
         mmcif_dict["_pdbx_struct_assembly.oligomeric_count"].append(
             str(pdbx_struct_assembly_oligomeric_count[assembly_id])
         )
-    assert mmcif_dict[
-        "_pdbx_struct_assembly_gen.assembly_id"
-    ], "No _pdbx_struct_assembly_gen.assembly_id entries found."
-    assert mmcif_dict["_pdbx_struct_assembly.id"], "No _pdbx_struct_assembly.id entries found."
 
     # Populate the _chem_comp table.
     for chem_comp in biomol.chem_comp_table:

--- a/alphafold3_pytorch/data/mmcif_parsing.py
+++ b/alphafold3_pytorch/data/mmcif_parsing.py
@@ -594,7 +594,7 @@ def _get_header(parsed_info: MmCIFDict) -> PdbHeader:
     if "_pdbx_audit_revision_history.revision_date" in parsed_info:
         header["release_date"] = get_release_date(parsed_info)
     else:
-        logging.warning("Could not determine release_date: %s", parsed_info["_entry.id"])
+        logging.warning("Could not determine release_date for entry: %s", parsed_info["_entry.id"])
 
     header["resolution"] = 0.00
     for res_key in (

--- a/scripts/filter_pdb_mmcifs.py
+++ b/scripts/filter_pdb_mmcifs.py
@@ -36,7 +36,7 @@ import glob
 import os
 import random
 from operator import itemgetter
-from typing import Dict, List, Set, Tuple
+from typing import Dict, List, Literal, Set, Tuple
 
 import numpy as np
 import pandas as pd
@@ -66,10 +66,67 @@ from alphafold3_pytorch.utils.utils import exists
 # Constants
 
 FILTER_STRUCTURE_MAX_SECONDS_PER_INPUT = (
-    120  # Maximum time allocated to filter a single structure (in seconds)
+    600  # Maximum time allocated to filter a single structure (in seconds)
 )
 
+EVALUATION_SPLITS = {"eval", "test"}
+
 # Helper functions
+
+
+@typecheck
+def impute_missing_assembly_metadata(
+    mmcif_object: MmcifObject, asym_mmcif_object: MmcifObject
+) -> MmcifObject:
+    """Impute missing assembly metadata from the asymmetric unit mmCIF."""
+    mmcif_object.header.update(asym_mmcif_object.header)
+    mmcif_object.covalent_bonds.extend(asym_mmcif_object.covalent_bonds)
+
+    # Impute structure method
+    if (
+        "_exptl.method" not in mmcif_object.raw_string
+        and "_exptl.method" in asym_mmcif_object.raw_string
+    ):
+        mmcif_object.raw_string["_exptl.method"] = asym_mmcif_object.raw_string["_exptl.method"]
+
+    # Impute release date
+    if (
+        "_pdbx_audit_revision_history.revision_date" not in mmcif_object.raw_string
+        and "_pdbx_audit_revision_history.revision_date" in asym_mmcif_object.raw_string
+    ):
+        mmcif_object.raw_string["_pdbx_audit_revision_history.revision_date"] = (
+            asym_mmcif_object.raw_string["_pdbx_audit_revision_history.revision_date"]
+        )
+
+    # Impute resolution
+    if (
+        "_refine.ls_d_res_high" not in mmcif_object.raw_string
+        and "_refine.ls_d_res_high" in asym_mmcif_object.raw_string
+    ):
+        mmcif_object.raw_string["_refine.ls_d_res_high"] = asym_mmcif_object.raw_string[
+            "_refine.ls_d_res_high"
+        ]
+    if (
+        "_em_3d_reconstruction.resolution" not in mmcif_object.raw_string
+        and "_em_3d_reconstruction.resolution" in asym_mmcif_object.raw_string
+    ):
+        mmcif_object.raw_string["_em_3d_reconstruction.resolution"] = asym_mmcif_object.raw_string[
+            "_em_3d_reconstruction.resolution"
+        ]
+    if (
+        "_reflns.d_resolution_high" not in mmcif_object.raw_string
+        and "_reflns.d_resolution_high" in asym_mmcif_object.raw_string
+    ):
+        mmcif_object.raw_string["_reflns.d_resolution_high"] = asym_mmcif_object.raw_string[
+            "_reflns.d_resolution_high"
+        ]
+
+    # Impute structure connectivity
+    for key in asym_mmcif_object.raw_string:
+        if key.startswith("_struct_conn.") and key not in mmcif_object.raw_string:
+            mmcif_object.raw_string[key] = asym_mmcif_object.raw_string[key]
+
+    return mmcif_object
 
 
 @typecheck
@@ -118,11 +175,15 @@ def filter_polymer_chains(
 def filter_resolved_chains(
     mmcif_object: MmcifObject, minimum_polymer_residues: int = 4
 ) -> MmcifObject | None:
-    """Filter based on number of resolved residues."""
+    """Filter polymer chains based on number of resolved residues."""
     chains_to_remove = {
         mmcif_object.structure[chain.id].get_full_id()
         for chain in mmcif_object.structure.get_chains()
-        if len(
+        if any(
+            is_polymer(mmcif_object.all_chem_comp_details[chain.id][res_index].type)
+            for res_index in range(len(mmcif_object.chain_to_seqres[chain.id]))
+        )
+        and len(
             [
                 res_index
                 for res_index in range(len(mmcif_object.chain_to_seqres[chain.id]))
@@ -191,9 +252,12 @@ def remove_polymer_chains_with_all_unknown_residues(mmcif_object: MmcifObject) -
     chains_to_remove = {
         chain.get_full_id()
         for chain in mmcif_object.structure.get_chains()
-        if not any(
+        if any(
             is_polymer(mmcif_object.all_chem_comp_details[chain.id][res_index].type)
-            and mmcif_object.chain_to_seqres[chain.id][res_index] != "X"
+            for res_index in range(len(mmcif_object.chain_to_seqres[chain.id]))
+        )
+        and not any(
+            mmcif_object.chain_to_seqres[chain.id][res_index] != "X"
             for res_index in range(len(mmcif_object.chain_to_seqres[chain.id]))
         )
     }
@@ -351,7 +415,11 @@ def remove_leaving_atoms(
     atoms_to_remove = set()
 
     for covalent_bond in mmcif_object.covalent_bonds:
-        if covalent_bond.leaving_atom_flag in {"one", "both"}:
+        bond_chain_ids_in_structure = (
+            covalent_bond.ptnr1_auth_asym_id in mmcif_object.structure
+            and covalent_bond.ptnr2_auth_asym_id in mmcif_object.structure
+        )
+        if covalent_bond.leaving_atom_flag in {"one", "both"} and bond_chain_ids_in_structure:
             # Identify the chemical types of the residues of the "partner 1" and "partner 2" bond atoms in the structure
             ptnr1_chain = mmcif_object.structure[covalent_bond.ptnr1_auth_asym_id]
             ptnr2_chain = mmcif_object.structure[covalent_bond.ptnr2_auth_asym_id]
@@ -401,10 +469,12 @@ def remove_leaving_atoms(
 
 @typecheck
 def filter_large_ca_distances(
-    mmcif_object: MmcifObject, max_distance: float = 10.0
+    mmcif_object: MmcifObject,
+    max_distance: float = 10.0,
+    min_num_residues_for_protein_classification: int = 10,
 ) -> MmcifObject:
     """
-    Identify chains with large sequential Ca-Ca atom distances to be removed.
+    Identify chains (to be removed) with any large sequential Ca-Ca atom distances.
 
     NOTE: This function currently does not account for residues
     with alternative Ca atom locations.
@@ -412,17 +482,29 @@ def filter_large_ca_distances(
     chains_to_remove = set()
 
     for chain in mmcif_object.structure.get_chains():
+        num_peptide_residues = sum(
+            1
+            for res_index in range(len(chain))
+            if "peptide" in mmcif_object.chem_comp_details[chain.id][res_index].type.lower()
+        )
+        if num_peptide_residues < min_num_residues_for_protein_classification:
+            # Only filter protein chains
+            continue
         ca_atoms = [
             res["CA"]
             for (res_index, res) in enumerate(chain)
             if "peptide" in mmcif_object.chem_comp_details[chain.id][res_index].type.lower()
             and "CA" in res
         ]
+        ca_ca_distance_in_range = True
         for i, ca1 in enumerate(ca_atoms[:-1]):
             ca2 = ca_atoms[i + 1]
             if (ca1 - ca2) > max_distance:
-                chains_to_remove.add(chain.get_full_id())
+                ca_ca_distance_in_range = False
                 break
+
+        if len(ca_atoms) > 1 and not ca_ca_distance_in_range:
+            chains_to_remove.add(chain.get_full_id())
 
     mmcif_object.chains_to_remove.update(chains_to_remove)
 
@@ -489,6 +571,16 @@ def select_closest_chains(
         return token_center_atoms
 
     @typecheck
+    def get_token_chain_id(token: TokenType) -> str:
+        """Get chain ID of a token."""
+        if isinstance(token, AtomType):
+            # For an Atom, navigate up twice to get to the Chain level
+            return token.get_parent().get_parent().id
+        elif isinstance(token, ResidueType):
+            # For a Residue, navigate up once to get to the Chain level
+            return token.get_parent().id
+
+    @typecheck
     def get_interface_tokens(
         tokens: List[TokenType],
         protein_residue_center_atoms: Dict[str, str],
@@ -496,16 +588,30 @@ def select_closest_chains(
         center_atom_interaction_distance: float = 15.0,
     ) -> List[TokenType]:
         """Get interface tokens."""
-        interface_tokens = set()
         token_center_atoms = get_token_center_atoms(
             tokens, protein_residue_center_atoms, nucleic_acid_residue_center_atoms
         )
-        token_center_atoms_array = np.array([atom.coord for atom in token_center_atoms])
+        token_center_atoms_coords_array = np.array([atom.coord for atom in token_center_atoms])
+        token_chains_array = np.array([get_token_chain_id(token) for token in tokens])
+
+        # Compute all pairwise distances
+        differences = (
+            token_center_atoms_coords_array[:, None, :]
+            - token_center_atoms_coords_array[None, :, :]
+        )
+        distances = np.linalg.norm(differences, axis=2)
+
+        # Create masks
+        token_self_mask = distances != 0
+        token_interface_mask = token_chains_array[:, None] != token_chains_array[None, :]
+        token_interaction_mask = distances < center_atom_interaction_distance
+        interface_distance_mask = token_self_mask & token_interface_mask & token_interaction_mask
+
+        interface_tokens = set()
         for token_index, token in enumerate(tokens):
-            token_center_atom = token_center_atoms_array[None, token_index]
-            distances = np.linalg.norm(token_center_atoms_array - token_center_atom, axis=1)
-            if np.any(distances < center_atom_interaction_distance).item():
+            if np.any(interface_distance_mask[token_index, :]):
                 interface_tokens.add(token)
+
         return list(interface_tokens)
 
     chains_to_remove = set()
@@ -590,7 +696,7 @@ def filter_structure_with_timeout(
     output_dir: str,
     min_cutoff_date: pd.Timestamp = pd.to_datetime("1970-01-01"),
     max_cutoff_date: pd.Timestamp = pd.to_datetime("2021-09-30"),
-    is_evaluation_set: bool = False,
+    split: Literal["train", "eval", "test"] = "train",
 ):
     """
     Given an input mmCIF file, create a new filtered mmCIF file
@@ -598,6 +704,10 @@ def filter_structure_with_timeout(
     timeout constraint.
     """
     # Section 2.5.4 of the AlphaFold 3 supplement
+    asym_filepath = os.path.join(
+        os.path.dirname(filepath).replace("unfiltered_assembly", "unfiltered_asym"),
+        os.path.basename(filepath).replace("-assembly1", ""),
+    )
     file_id = os.path.splitext(os.path.basename(filepath))[0]
     output_file_dir = os.path.join(output_dir, file_id[1:3])
     output_filepath = os.path.join(output_file_dir, f"{file_id}.cif")
@@ -605,6 +715,11 @@ def filter_structure_with_timeout(
 
     # Filtering of targets
     mmcif_object = mmcif_parsing.parse_mmcif_object(filepath, file_id)
+    asym_mmcif_object = mmcif_parsing.parse_mmcif_object(asym_filepath, file_id)
+    # NOTE: The assembly mmCIF does not contain the full header or the
+    # structure connectivity (i.e., bond) information, so we impute
+    # these from the asymmetric unit mmCIF
+    mmcif_object = impute_missing_assembly_metadata(mmcif_object, asym_mmcif_object)
     mmcif_object = prefilter_target(
         mmcif_object, min_cutoff_date=min_cutoff_date, max_cutoff_date=max_cutoff_date
     )
@@ -616,7 +731,7 @@ def filter_structure_with_timeout(
     mmcif_object = remove_hydrogens(mmcif_object, remove_waters=True)
     mmcif_object = remove_polymer_chains_with_all_unknown_residues(mmcif_object)
     mmcif_object = remove_clashing_chains(mmcif_object)
-    if is_evaluation_set:
+    if split in EVALUATION_SPLITS:
         # NOTE: The AlphaFold 3 supplement suggests the training dataset retains these (excluded) ligands
         mmcif_object = remove_excluded_ligands(mmcif_object, LIGAND_EXCLUSION_SET)
     mmcif_object = remove_non_ccd_atoms(mmcif_object, CCD_READER_RESULTS)
@@ -644,12 +759,12 @@ def filter_structure_with_timeout(
 
 
 @typecheck
-def filter_structure(args: Tuple[str, str, pd.Timestamp, pd.Timestamp, bool]):
+def filter_structure(args: Tuple[str, str, pd.Timestamp, pd.Timestamp, str]):
     """
     Given an input mmCIF file, create a new filtered mmCIF file
     using AlphaFold 3's PDB dataset filtering criteria.
     """
-    filepath, output_dir, min_cutoff_date, max_cutoff_date, is_evaluation_set = args
+    filepath, output_dir, min_cutoff_date, max_cutoff_date, split = args
     file_id = os.path.splitext(os.path.basename(filepath))[0]
     output_file_dir = os.path.join(output_dir, file_id[1:3])
     output_filepath = os.path.join(output_file_dir, f"{file_id}.cif")
@@ -660,7 +775,7 @@ def filter_structure(args: Tuple[str, str, pd.Timestamp, pd.Timestamp, bool]):
             output_dir,
             min_cutoff_date=min_cutoff_date,
             max_cutoff_date=max_cutoff_date,
-            is_evaluation_set=is_evaluation_set,
+            split=split,
         )
     except Exception as e:
         logger.info(f"Skipping structure filtering of {filepath} due to: {e}")
@@ -681,10 +796,17 @@ if __name__ == "__main__":
     )
     parser.add_argument(
         "-i",
-        "--mmcif_dir",
+        "--mmcif_assembly_dir",
         type=str,
-        default=os.path.join("data", "pdb_data", "unfiltered_mmcifs"),
-        help="Path to the input directory containing mmCIF files to filter.",
+        default=os.path.join("data", "pdb_data", "unfiltered_assembly_mmcifs"),
+        help="Path to the input directory containing `assembly1` mmCIF files to filter.",
+    )
+    parser.add_argument(
+        "-a",
+        "--mmcif_asym_dir",
+        type=str,
+        default=os.path.join("data", "pdb_data", "unfiltered_asym_mmcifs"),
+        help="Path to the input directory containing asymmetric unit mmCIF files with which to filter the `assembly1` mmCIF files.",
     )
     parser.add_argument(
         "-c",
@@ -722,9 +844,11 @@ if __name__ == "__main__":
     )
     parser.add_argument(
         "-e",
-        "--is_evaluation_set",
-        action="store_true",
-        help="Whether the dataset being filtered is an evaluation (e.g., validation or testing) set.",
+        "--split",
+        type=str,
+        choices=["train", "eval", "test"],
+        default="train",
+        help="To which split the filtered dataset should be assigned (i.e., `train`, `eval`, or `test`).",
     )
     parser.add_argument(
         "-n",
@@ -742,7 +866,12 @@ if __name__ == "__main__":
     )
     args = parser.parse_args()
 
-    assert os.path.exists(args.mmcif_dir), f"Input directory {args.mmcif_dir} does not exist."
+    assert os.path.exists(
+        args.mmcif_assembly_dir
+    ), f"Input assembly directory {args.mmcif_assembly_dir} does not exist."
+    assert os.path.exists(
+        args.mmcif_asym_dir
+    ), f"Input asymmetric unit directory {args.mmcif_asym_dir} does not exist."
     assert os.path.exists(args.ccd_dir), f"CCD directory {args.ccd_dir} does not exist."
     assert os.path.exists(
         os.path.join(args.ccd_dir, "chem_comp_model.cif")
@@ -770,10 +899,17 @@ if __name__ == "__main__":
             args.output_dir,
             args.min_cutoff_date,
             args.max_cutoff_date,
-            args.is_evaluation_set,
+            args.split,
         )
-        for filepath in glob.glob(os.path.join(args.mmcif_dir, "*", "*.cif"))
-        if not (
+        for filepath in glob.glob(os.path.join(args.mmcif_assembly_dir, "*", "*.cif"))
+        if "assembly1" in os.path.basename(filepath)
+        and os.path.exists(
+            os.path.join(
+                os.path.dirname(filepath).replace("unfiltered_assembly", "unfiltered_asym"),
+                os.path.basename(filepath).replace("-assembly1", ""),
+            )
+        )
+        and not (
             args.skip_existing
             and os.path.exists(
                 os.path.join(

--- a/tests/test_data_parsing.py
+++ b/tests/test_data_parsing.py
@@ -1,5 +1,6 @@
 """This file prepares unit tests for data parsing (e.g., mmCIF file I/O)."""
 
+import glob
 import os
 import random
 
@@ -10,22 +11,37 @@ from alphafold3_pytorch.data import mmcif_parsing
 
 os.environ["TYPECHECK"] = "True"
 
+# constants
 
-@pytest.mark.parametrize("mmcif_dir", [os.path.join("data", "pdb_data", "unfiltered_mmcifs")])
+ERRONEOUS_PDB_IDS = [
+    "3tob"  # NOTE: At residue index 97, ALY and LYS are assigned the same residue ID of 118 by the authors.
+]
+
+
+@pytest.mark.parametrize(
+    "mmcif_dir",
+    [
+        os.path.join("data", "pdb_data", "unfiltered_assembly_mmcifs"),
+        os.path.join("data", "pdb_data", "unfiltered_asym_mmcifs"),
+        os.path.join("data", "pdb_data", "mmcifs"),
+    ],
+)
 @pytest.mark.parametrize(
     "complex_id", ["100d", "1k7a", "384d", "4xij", "6adq", "7a4d", "7akd", "8a3j"]
 )
-def test_unfiltered_mmcif_object_parsing(mmcif_dir: str, complex_id: str) -> None:
-    """Tests mmCIF file parsing and `Biomolecule` object creation for unfiltered mmCIF files.
+def test_mmcif_object_parsing(mmcif_dir: str, complex_id: str) -> None:
+    """Tests parsing and `Biomolecule` object creation for mmCIF files.
 
-    :param mmcif_dir: The directory containing all (unfiltered) PDB mmCIF files.
+    :param mmcif_dir: A directory containing PDB mmCIF files.
     :param complex_id: The PDB ID of the complex to be tested.
     """
     complex_filepath = os.path.join(mmcif_dir, complex_id[1:3], f"{complex_id}.cif")
+    complex_filepaths = glob.glob(f"{complex_filepath[:-4]}*.cif")
 
-    if not os.path.exists(complex_filepath):
+    if not complex_filepaths:
         pytest.skip(f"File '{complex_filepath}' does not exist.")
 
+    complex_filepath = random.choice(complex_filepaths)
     with open(complex_filepath, "r") as f:
         mmcif_string = f.read()
 
@@ -52,59 +68,25 @@ def test_unfiltered_mmcif_object_parsing(mmcif_dir: str, complex_id: str) -> Non
         ), f"Failed to parse file '{complex_filepath}' into a `Biomolecule` object."
 
 
-@pytest.mark.parametrize("mmcif_dir", [os.path.join("data", "pdb_data", "mmcifs")])
 @pytest.mark.parametrize(
-    "complex_id", ["100d", "1k7a", "384d", "4xij", "6adq", "7a4d", "7akd", "8a3j"]
+    "mmcif_dir",
+    [
+        os.path.join("data", "pdb_data", "unfiltered_assembly_mmcifs"),
+        os.path.join("data", "pdb_data", "unfiltered_asym_mmcifs"),
+        os.path.join("data", "pdb_data", "mmcifs"),
+    ],
 )
-def test_filtered_mmcif_object_parsing(mmcif_dir: str, complex_id: str) -> None:
-    """Tests mmCIF file parsing and `Biomolecule` object creation for filtered mmCIF files.
-
-    :param mmcif_dir: The directory containing all (filtered) PDB mmCIF files.
-    :param complex_id: The PDB ID of the complex to be tested.
-    """
-    complex_filepath = os.path.join(mmcif_dir, complex_id[1:3], f"{complex_id}.cif")
-
-    if not os.path.exists(complex_filepath):
-        pytest.skip(f"File '{complex_filepath}' does not exist.")
-
-    with open(complex_filepath, "r") as f:
-        mmcif_string = f.read()
-
-    parsing_result = mmcif_parsing.parse(
-        file_id=complex_id,
-        mmcif_string=mmcif_string,
-        auth_chains=True,
-        auth_residues=True,
-    )
-
-    if parsing_result.mmcif_object is None:
-        print(f"Failed to parse file '{complex_filepath}'.")
-        raise list(parsing_result.errors.values())[0]
-    else:
-        try:
-            biomol = _from_mmcif_object(parsing_result.mmcif_object)
-        except Exception as e:
-            if "mmCIF contains an insertion code" in str(e):
-                pytest.skip(f"File '{complex_filepath}' contains an insertion code.")
-            else:
-                raise e
-        assert (
-            len(biomol.atom_positions) > 0
-        ), f"Failed to parse file '{complex_filepath}' into a `Biomolecule` object."
-
-
-@pytest.mark.parametrize("mmcif_dir", [os.path.join("data", "pdb_data", "unfiltered_mmcifs")])
 @pytest.mark.parametrize("num_random_complexes_to_parse", [500])
 @pytest.mark.parametrize("random_seed", [1])
-def test_unfiltered_random_mmcif_objects_parsing(
+def test_random_mmcif_objects_parsing(
     mmcif_dir: str,
     num_random_complexes_to_parse: int,
     random_seed: int,
 ) -> None:
-    """Tests mmCIF file parsing and `Biomolecule` object creation for a random batch
-    of unfiltered mmCIF files.
+    """Tests parsing and `Biomolecule` object creation for a random batch
+    of mmCIF files.
 
-    :param mmcif_dir: The directory containing all (unfiltered) PDB mmCIF files.
+    :param mmcif_dir: A directory containing PDB mmCIF files.
     :param num_random_complexes_to_parse: The number of random complexes to parse.
     :param random_seed: The random seed for reproducibility.
     """
@@ -138,92 +120,9 @@ def test_unfiltered_random_mmcif_objects_parsing(
             print(f"File '{random_complex_filepath}' does not exist.")
             continue
 
-        with open(random_complex_filepath, "r") as f:
-            mmcif_string = f.read()
-
-        parsing_result = mmcif_parsing.parse(
-            file_id=complex_id,
-            mmcif_string=mmcif_string,
-            auth_chains=True,
-            auth_residues=True,
-        )
-
-        if parsing_result.mmcif_object is None:
-            parsing_errors.append(list(parsing_result.errors.values())[0])
-            failed_complex_indices.append(complex_index)
-            failed_random_complex_filepaths.append(random_complex_filepath)
-        else:
-            try:
-                biomol = _from_mmcif_object(parsing_result.mmcif_object)
-            except Exception as e:
-                if "mmCIF contains an insertion code" in str(e):
-                    continue
-                else:
-                    parsing_errors.append(e)
-                    failed_complex_indices.append(complex_index)
-                    failed_random_complex_filepaths.append(random_complex_filepath)
-                    continue
-            if len(biomol.atom_positions) == 0:
-                parsing_errors.append(
-                    AssertionError(
-                        f"Failed to parse file '{random_complex_filepath}' into a `Biomolecule` object."
-                    )
-                )
-                failed_complex_indices.append(complex_index)
-                failed_random_complex_filepaths.append(random_complex_filepath)
-
-    if parsing_errors:
-        print(
-            f"Failed to parse {len(parsing_errors)} files at indices {failed_complex_indices}: '{failed_random_complex_filepaths}'."
-        )
-        for error in parsing_errors:
-            print(error)
-        raise error
-
-
-@pytest.mark.parametrize("mmcif_dir", [os.path.join("data", "pdb_data", "mmcifs")])
-@pytest.mark.parametrize("num_random_complexes_to_parse", [500])
-@pytest.mark.parametrize("random_seed", [1])
-def test_filtered_random_mmcif_objects_parsing(
-    mmcif_dir: str,
-    num_random_complexes_to_parse: int,
-    random_seed: int,
-) -> None:
-    """Tests mmCIF file parsing and `Biomolecule` object creation for a random batch
-    of filtered mmCIF files.
-
-    :param mmcif_dir: The directory containing all (filtered) PDB mmCIF files.
-    :param num_random_complexes_to_parse: The number of random complexes to parse.
-    :param random_seed: The random seed for reproducibility.
-    """
-    random.seed(random_seed)
-
-    if not os.path.exists(mmcif_dir):
-        pytest.skip(f"Directory '{mmcif_dir}' does not exist.")
-
-    parsing_errors = []
-    failed_complex_indices = []
-    failed_random_complex_filepaths = []
-    mmcif_subdirs = [
-        os.path.join(mmcif_dir, subdir)
-        for subdir in os.listdir(mmcif_dir)
-        if os.path.isdir(os.path.join(mmcif_dir, subdir))
-        and os.listdir(os.path.join(mmcif_dir, subdir))
-    ]
-    for complex_index in range(num_random_complexes_to_parse):
-        random_mmcif_subdir = random.choice(mmcif_subdirs)
-        mmcif_subdir_files = [
-            os.path.join(random_mmcif_subdir, mmcif_subdir_file)
-            for mmcif_subdir_file in os.listdir(random_mmcif_subdir)
-            if os.path.isfile(os.path.join(random_mmcif_subdir, mmcif_subdir_file))
-            and mmcif_subdir_file.endswith(".cif")
-        ]
-
-        random_complex_filepath = random.choice(mmcif_subdir_files)
-        complex_id = os.path.splitext(os.path.basename(random_complex_filepath))[0]
-
-        if not os.path.exists(random_complex_filepath):
-            print(f"File '{random_complex_filepath}' does not exist.")
+        if any(
+            id in os.path.basename(random_complex_filepath)[:4].lower() for id in ERRONEOUS_PDB_IDS
+        ):
             continue
 
         with open(random_complex_filepath, "r") as f:


### PR DESCRIPTION
* Switches to filtering preprocessed assembly mmCIF files
* Fixes various bugs in the filtering criterion functions, including incorrect assembly chain reduction (i.e., down to 20 chains total per complex)
* Optimizes the clustering script's arguments for MMseqs2 (thanks [Milot](https://github.com/milot-mirdita)!)