### PR TITLE
Add standardized (template) SMILES strings for each residue

### DIFF
--- a/alphafold3_pytorch/life.py
+++ b/alphafold3_pytorch/life.py
@@ -17,9 +17,13 @@ def is_unique(arr):
 # human amino acids
 # reordered so [N][...][C][OH] - [OH] is removed for all peptides except last
 
+# NOTE: template SMILES were derived via `print([Chem.MolToSmiles(resname_to_mol[resname], canonical=False) for resname in resname_to_mol])`
+# to guarantee the order (and quantity) of atoms in the SMILES string perfectly matches the atoms in the residue template structure
+
 HUMAN_AMINO_ACIDS = dict(
     A = dict(
         smile = 'CC(C(=O)O)N',
+        # template_smile = 'NC(C=O)C',
         first_atom_idx = 5,
         last_atom_idx = 2,
         hydroxyl_idx = 4,
@@ -27,6 +31,7 @@ HUMAN_AMINO_ACIDS = dict(
     ),
     R = dict(
         smile = 'C(CC(C(=O)O)N)CN=C(N)N',
+        # template_smile = 'NC(C=O)CCCNC(N)=N',
         first_atom_idx = 6,
         last_atom_idx = 3,
         hydroxyl_idx = 5,
@@ -34,6 +39,7 @@ HUMAN_AMINO_ACIDS = dict(
     ),
     N = dict(
         smile = 'C(C(C(=O)O)N)C(=O)N',
+        # template_smile = 'NC(C=O)CC(=O)N',
         first_atom_idx = 5,
         last_atom_idx = 2,
         hydroxyl_idx = 4,
@@ -41,6 +47,7 @@ HUMAN_AMINO_ACIDS = dict(
     ),
     D = dict(
         smile = 'C(C(C(=O)O)N)C(=O)O',
+        # template_smile = 'NC(C=O)CC(=O)O',
         first_atom_idx = 5,
         last_atom_idx = 2,
         hydroxyl_idx = 8,
@@ -48,6 +55,7 @@ HUMAN_AMINO_ACIDS = dict(
     ),
     C = dict(
         smile = 'C(C(C(=O)O)N)S',
+        # template_smile = 'NC(C=O)CS',
         first_atom_idx = 5,
         last_atom_idx = 2,
         hydroxyl_idx = 4,
@@ -55,6 +63,7 @@ HUMAN_AMINO_ACIDS = dict(
     ),
     Q = dict(
         smile = 'C(CC(=O)N)C(C(=O)O)N',
+        # template_smile = 'NC(C=O)CCC(=O)N',
         first_atom_idx = 9,
         last_atom_idx = 6,
         hydroxyl_idx = 8,
@@ -62,6 +71,7 @@ HUMAN_AMINO_ACIDS = dict(
     ),
     E = dict(
         smile = 'C(CC(=O)O)C(C(=O)O)N',
+        # template_smile = 'NC(C=O)CCC(=O)O',
         first_atom_idx = 9,
         last_atom_idx = 6,
         hydroxyl_idx = 8,
@@ -69,6 +79,7 @@ HUMAN_AMINO_ACIDS = dict(
     ),
     G = dict(
         smile = 'C(C(=O)O)N',
+        # template_smile = 'NCC=O',
         first_atom_idx = 4,
         last_atom_idx = 1,
         hydroxyl_idx = 3,
@@ -76,6 +87,7 @@ HUMAN_AMINO_ACIDS = dict(
     ),
     H = dict(
         smile = 'C1=C(NC=N1)CC(C(=O)O)N',
+        # template_smile = 'NC(C=O)CC1=CNC=N1',
         first_atom_idx = 10,
         last_atom_idx = 7,
         hydroxyl_idx = 9,
@@ -83,6 +95,7 @@ HUMAN_AMINO_ACIDS = dict(
     ),
     I = dict(
         smile = 'CCC(C)C(C(=O)O)N',
+        # template_smile = 'NC(C=O)C(CC)C',
         first_atom_idx = 8,
         last_atom_idx = 5,
         hydroxyl_idx = 7,
@@ -90,6 +103,7 @@ HUMAN_AMINO_ACIDS = dict(
     ),
     L = dict(
         smile = 'CC(C)CC(C(=O)O)N',
+        # template_smile = 'NC(C=O)CC(C)C',
         first_atom_idx = 8,
         last_atom_idx = 5,
         hydroxyl_idx = 7,
@@ -97,6 +111,7 @@ HUMAN_AMINO_ACIDS = dict(
     ),
     K = dict(
         smile = 'C(CCN)CC(C(=O)O)N',
+        # template_smile = 'NC(C=O)CCCCN',
         first_atom_idx = 9,
         last_atom_idx = 6,
         hydroxyl_idx = 8,
@@ -104,6 +119,7 @@ HUMAN_AMINO_ACIDS = dict(
     ),
     M = dict(
         smile = 'CSCCC(C(=O)O)N',
+        # template_smile = 'NC(C=O)CCSC',
         first_atom_idx = 8,
         last_atom_idx = 5,
         hydroxyl_idx = 7,
@@ -111,6 +127,7 @@ HUMAN_AMINO_ACIDS = dict(
     ),
     F = dict(
         smile = 'C1=CC=C(C=C1)CC(C(=O)O)N',
+        # template_smile = 'NC(C=O)CC1=CC=CC=C1',
         first_atom_idx = 11,
         last_atom_idx = 8,
         hydroxyl_idx = 10,
@@ -118,6 +135,7 @@ HUMAN_AMINO_ACIDS = dict(
     ),
     P = dict(
         smile = 'C1CC(NC1)C(=O)O',
+        # template_smile = 'N1C(C=O)CCC1',
         first_atom_idx = 3,
         last_atom_idx = 5,
         hydroxyl_idx = 7,
@@ -125,6 +143,7 @@ HUMAN_AMINO_ACIDS = dict(
     ),
     S = dict(
         smile = 'C(C(C(=O)O)N)O',
+        # template_smile = 'NC(C=O)CO',
         first_atom_idx = 5,
         last_atom_idx = 2,
         hydroxyl_idx = 4,
@@ -132,6 +151,7 @@ HUMAN_AMINO_ACIDS = dict(
     ),
     T = dict(
         smile = 'CC(C(C(=O)O)N)O',
+        # template_smile = 'NC(C=O)C(O)C',
         first_atom_idx = 6,
         last_atom_idx = 3,
         hydroxyl_idx = 5,
@@ -139,6 +159,7 @@ HUMAN_AMINO_ACIDS = dict(
     ),
     W = dict(
         smile = 'C1=CC=C2C(=C1)C(=CN2)CC(C(=O)O)N',
+        # template_smile = 'NC(C=O)CC1=CNC2=C1C=CC=C2',
         first_atom_idx = 14,
         last_atom_idx = 11,
         hydroxyl_idx = 13,
@@ -146,6 +167,7 @@ HUMAN_AMINO_ACIDS = dict(
     ),
     Y = dict(
         smile = 'C1=CC(=CC=C1CC(C(=O)O)N)O',
+        # template_smile = 'NC(C=O)CC1=CC=C(O)C=C1',
         first_atom_idx = 11,
         last_atom_idx = 8,
         hydroxyl_idx = 10,
@@ -153,6 +175,7 @@ HUMAN_AMINO_ACIDS = dict(
     ),
     V = dict(
         smile = 'CC(C)C(C(=O)O)N',
+        # template_smile = 'NC(C=O)C(C)C',
         first_atom_idx = 7,
         last_atom_idx = 4,
         hydroxyl_idx = 6,
@@ -166,6 +189,7 @@ HUMAN_AMINO_ACIDS = dict(
 DNA_NUCLEOTIDES = dict(
     A = dict(
         smile = 'C1C(C(OC1N2C=NC3=C(N=CN=C32)N)COP(=O)(O)O)O',
+        # template_smile = 'OP(=O)(O)OCC1OC(N2C=NC3=C2N=CN=C3N)CC1O',
         complement = 'T',
         first_atom_idx = 20,
         last_atom_idx = 1,
@@ -174,6 +198,7 @@ DNA_NUCLEOTIDES = dict(
     ),
     C = dict(
         smile = 'C1C(C(OC1N2C=CC(=NC2=O)N)COP(=O)(O)O)O',
+        # template_smile = 'OP(=O)(O)OCC1OC(N2C(=O)N=C(N)C=C2)CC1O',
         complement = 'G',
         first_atom_idx = 17,
         last_atom_idx = 1,
@@ -182,6 +207,7 @@ DNA_NUCLEOTIDES = dict(
     ),
     G = dict(
         smile = 'C1C(C(OC1N2C=NC3=C2N=C(NC3=O)N)COP(=O)(O)O)O',
+        # template_smile = 'OP(=O)(O)OCC1OC(N2C=NC3=C2N=C(N)NC3=O)CC1O',
         complement = 'C',
         first_atom_idx = 21,
         last_atom_idx = 1,
@@ -190,6 +216,7 @@ DNA_NUCLEOTIDES = dict(
     ),
     T = dict(
         smile = 'CC1=CN(C(=O)NC1=O)C2CC(C(O2)COP(=O)(O)O)O',
+        # template_smile = 'OP(=O)(O)OCC1OC(N2C(=O)NC(=O)C(C)=C2)CC1O',
         complement = 'A',
         first_atom_idx = 19,
         last_atom_idx = 11,
@@ -201,6 +228,7 @@ DNA_NUCLEOTIDES = dict(
 RNA_NUCLEOTIDES = dict(
     A = dict(
         smile = 'C1=NC(=C2C(=N1)N(C=N2)C3C(C(C(O3)COP(=O)(O)O)O)O)N',
+        # template_smile = 'OP(=O)(O)OCC1OC(N2C=NC3=C2N=CN=C3N)C(O)C1O',
         complement = 'U',
         first_atom_idx = 19,
         last_atom_idx = 11,
@@ -209,6 +237,7 @@ RNA_NUCLEOTIDES = dict(
     ),
     C = dict(
         smile = 'C1=CN(C(=O)N=C1N)C2C(C(C(O2)COP(=O)([O-])[O-])O)O',
+        # template_smile = 'OP(=O)(O)OCC1OC(N2C(=O)N=C(N)C=C2)C(O)C1O',
         complement = 'G',
         first_atom_idx = 17,
         last_atom_idx = 10,
@@ -217,6 +246,7 @@ RNA_NUCLEOTIDES = dict(
     ),
     G = dict(
         smile = 'C1=NC2=C(N1C3C(C(C(O3)COP(=O)(O)O)O)O)N=C(NC2=O)N',
+        # template_smile = 'OP(=O)(O)OCC1OC(N2C=NC3=C2N=C(N)NC3=O)C(O)C1O',
         complement = 'C',
         first_atom_idx = 14,
         last_atom_idx = 7,
@@ -225,6 +255,7 @@ RNA_NUCLEOTIDES = dict(
     ),
     U = dict(
         smile = 'C1=CN(C(=O)NC1=O)C2C(C(C(O2)COP(=O)(O)O)O)O',
+        # template_smile = 'OP(=O)(O)OCC1OC(N2C(=O)NC(=O)C=C2)C(O)C1O',
         complement = 'A',
         first_atom_idx = 18,
         last_atom_idx = 10,
@@ -345,7 +376,9 @@ def remove_atom_from_mol(mol: Mol, atom_idx: int) -> Mol:
     return mol
 
 @typecheck
-def mol_from_template_mmcif_file(mmcif_filepath: str) -> Chem.Mol:
+def mol_from_template_mmcif_file(
+    mmcif_filepath: str, remove_hs: bool = True, remove_hydroxyl_oxygen: bool = True
+) -> Chem.Mol:
     """
     Load an RDKit molecule from a template mmCIF file.
 
@@ -354,6 +387,8 @@ def mol_from_template_mmcif_file(mmcif_filepath: str) -> Chem.Mol:
     positions as needed.
 
     :param mmcif_filepath: The path to a residue/ligand template mmCIF file.
+    :param remove_hs: Whether to remove hydrogens from the template molecule.
+    :param remove_hydroxyl_oxygen: Whether to remove the hydroxyl oxygen atom in each residue.
     :return: A corresponding template RDKit molecule.
     """
     # Parse the mmCIF file using Gemmi
@@ -378,12 +413,13 @@ def mol_from_template_mmcif_file(mmcif_filepath: str) -> Chem.Mol:
 
     # Add atoms to the molecule
     for row in atom_table:
-        atom_id = row['atom_id']
-        element = row['type_symbol']
-        x = float(row['model_Cartn_x'])
-        y = float(row['model_Cartn_y'])
-        z = float(row['model_Cartn_z'])
-
+        element = row["type_symbol"]
+        atom_id = row["atom_id"]
+        if remove_hs and element == "H":
+            continue
+        elif remove_hydroxyl_oxygen and atom_id == "OXT":
+            # NOTE: Hydroxyl oxygens are not present in the PDB's nucleotide residue templates
+            continue
         rd_atom = Chem.Atom(element)
         idx = mol.AddAtom(rd_atom)
         atom_id_to_idx[atom_id] = idx
@@ -393,11 +429,13 @@ def mol_from_template_mmcif_file(mmcif_filepath: str) -> Chem.Mol:
 
     # Set atom coordinates
     for row in atom_table:
-        atom_id = row['atom_id']
+        atom_id = row["atom_id"]
+        if atom_id not in atom_id_to_idx:
+            continue
         idx = atom_id_to_idx[atom_id]
-        x = float(row['model_Cartn_x'])
-        y = float(row['model_Cartn_y'])
-        z = float(row['model_Cartn_z'])
+        x = float(row["model_Cartn_x"])
+        y = float(row["model_Cartn_y"])
+        z = float(row["model_Cartn_z"])
         conf.SetAtomPosition(idx, rdGeometry.Point3D(x, y, z))
 
     # Add conformer to the molecule
@@ -414,6 +452,8 @@ def mol_from_template_mmcif_file(mmcif_filepath: str) -> Chem.Mol:
     for row in bond_table:
         atom_id1 = row["atom_id_1"]
         atom_id2 = row["atom_id_2"]
+        if atom_id1 not in atom_id_to_idx or atom_id2 not in atom_id_to_idx:
+            continue
         order = row["value_order"]
         aromatic_flag = row["pdbx_aromatic_flag"]
         stereo_config = row["pdbx_stereo_config"]
@@ -438,6 +478,21 @@ def mol_from_template_mmcif_file(mmcif_filepath: str) -> Chem.Mol:
     mol = mol.GetMol()
 
     return mol
+
+# pre-load all PDB amino acid and nucleotide residue templates as `rdkit.Chem` molecules
+
+resname_to_mol = {}
+for resnames in (amino_acid_constants.resnames, rna_constants.resnames, dna_constants.resnames):
+    for resname in resnames:
+        template_filepath = os.path.join(
+            os.path.dirname(os.path.abspath(__file__)), "chemical", f"{resname}.cif"
+        )
+        if os.path.exists(template_filepath):
+            resname_to_mol[resname] = mol_from_template_mmcif_file(template_filepath)
+        else:
+            print(
+                f"WARNING: Template residue file {template_filepath} not found, skipping pre-loading of this template..."
+            )
 
 # initialize rdkit.Chem with canonical SMILES
 
@@ -476,18 +531,3 @@ for entry in CHAINABLE_BIOMOLECULES:
         atom_reorder_indices = atom_reorder,
         rdchem_mol = mol
     )
-
-# pre-load all PDB amino acid and nucleotide residue templates as `rdkit.Chem` molecules
-
-resname_to_mol = {}
-for resnames in (amino_acid_constants.resnames, rna_constants.resnames, dna_constants.resnames):
-    for resname in resnames:
-        template_filepath = os.path.join(
-            os.path.dirname(os.path.abspath(__file__)), "chemical", f"{resname}.cif"
-        )
-        if os.path.exists(template_filepath):
-            resname_to_mol[resname] = mol_from_template_mmcif_file(template_filepath)
-        else:
-            print(
-                f"WARNING: Template residue file {template_filepath} not found, skipping pre-loading of this template..."
-            )


### PR DESCRIPTION
* Adds standardized (template) SMILES strings for each residue (n.b., had to use `canonical=False` for RDKit to not permute the atom ordering when starting with the mmCIF residue templates and exporting a SMILES string)
* These (template) SMILES strings perfectly match the order (and quantity) of the atoms within each template amino/nucleic acid residue, which will later on allow one to more easily inject real mmCIF residue coordinates into these template `Chem.Mol` objects
* The only thing left to consider if and when switching over to using these template SMILES strings is the atoms/coordinates of these template `Chem.Mol` objects should be masked whenever certain atoms in these residues are not present in an input mmCIF file