### PR TITLE
Fix cluster ID arrangement for chains

### DIFF
--- a/scripts/filter_pdb_mmcifs.py
+++ b/scripts/filter_pdb_mmcifs.py
@@ -38,7 +38,6 @@ import random
 from operator import itemgetter
 from typing import Dict, List, Literal, Set, Tuple
 from datetime import datetime
-from dateutil import parser as date_parser
 
 import numpy as np
 import timeout_decorator
@@ -140,7 +139,7 @@ def filter_pdb_release_date(
         "release_date" in mmcif_object.header
         and exists(mmcif_object.header["release_date"])
         and min_cutoff_date
-        <= date_parser.parse(mmcif_object.header["release_date"])
+        <= datetime.strptime(mmcif_object.header["release_date"], "%Y-%m-%d")
         <= max_cutoff_date
     )
 


### PR DESCRIPTION
Addressed the issue related to different chains being clustered together incorrectly. This version will now offset the cluster IDs for each chain mapping, as discussed in #93.

Moreover, I tried to speed up the initialization of WeightedPDBSampler by removing some redundant type checks. It seems that this decorator slows down the parallelization of Polars, and removing all type checks will cut down the time from ~40s initially to around ~9s. In this version, I kept most of the ones added by @amorehead, but I removed the decorator from `get_chain_count()`, as it will always return a tuple of integers (or raise an error). Similarly, I removed it from `calculate_weight()` since we already employ the `@typecheck` for `get_*_weight()` functions. This change shaves off around 15-20s off of the class initialization.

Finally, in continuation to the previous Pandas → Polars change, I've made a small change to the `filter_pdb_mmcifs.py` code. It will now expect that the format of the `release_date` field of a `mmcif_object` header to always be `%Y-%m-%d`. This should avoid some surprise cases where the parser infers the format to be `%Y-%d-%m`.