### PR TITLE
Fixed swapping between true and predicted coordinates in WeightedRigidAlign

### DIFF
--- a/alphafold3_pytorch/alphafold3.py
+++ b/alphafold3_pytorch/alphafold3.py
@@ -2292,9 +2292,9 @@ class ElucidatedAtomDiffusion(Module):
         # section 3.7.1 equation 2 - weighted rigid aligned ground truth
 
         atom_pos_aligned_ground_truth = self.weighted_rigid_align(
-            atom_pos_ground_truth,
-            denoised_atom_pos,
-            align_weights,
+            pred_coords = denoised_atom_pos,
+            true_coords = atom_pos_ground_truth,
+            weights = align_weights,
             mask = atom_mask
         )
 
@@ -2489,10 +2489,10 @@ class WeightedRigidAlign(Module):
         rot_matrix = einsum(U, F, V, "b i j, b j k, b l k -> b i l")
 
         # Apply the rotation and translation
-        aligned_coords = einsum(pred_coords_centered, rot_matrix, 'b n i, b j i -> b n j') + true_centroid
-        aligned_coords.detach_()
+        aligned_true_coords = einsum(true_coords_centered, rot_matrix, 'b n i, b j i -> b n j') + true_centroid
+        aligned_true_coords.detach_()
 
-        return aligned_coords
+        return aligned_true_coords
 
 class ExpressCoordinatesInFrame(Module):
     """ Algorithm  29 """


### PR DESCRIPTION
Hi @lucidrains , thank you for your amazing work and continuing effort on recreating AF3 and other models! It's been tremendously helpful for us and the community in general.

While working with the diffusion module from this AF3 implementation, I found some potential issue with the weight rigid align algorithm. I made the following changes.

1. True and pred coordinates are swapped in input in `forward` of `ElucidatedAtomDiffusion`
2. The aligned coordinate output are now a sum of `true_coords_centered` and `true_centroid` in `forward` of `WeightedRigidAlign`

 I tested the diffusion module with these changes and can confirm it is now working correctly.