### PR TITLE
WeightedRigidAlign correction

### DIFF
--- a/alphafold3_pytorch/alphafold3.py
+++ b/alphafold3_pytorch/alphafold3.py
@@ -2292,9 +2292,9 @@ class ElucidatedAtomDiffusion(Module):
         # section 3.7.1 equation 2 - weighted rigid aligned ground truth
 
         atom_pos_aligned_ground_truth = self.weighted_rigid_align(
-            atom_pos_ground_truth,
-            denoised_atom_pos,
-            align_weights,
+            pred_coords = denoised_atom_pos,
+            true_coords = atom_pos_ground_truth,
+            weights = align_weights,
             mask = atom_mask
         )
 
@@ -2441,6 +2441,7 @@ class WeightedRigidAlign(Module):
         weights: Float['b n'],             # weights for each atom
         mask: Bool['b n'] | None = None    # mask for variable lengths
     ) -> Float['b n 3']:
+
         batch_size, num_points, dim = pred_coords.shape
 
         if exists(mask):
@@ -2453,12 +2454,12 @@ class WeightedRigidAlign(Module):
         weights = rearrange(weights, 'b n -> b n 1')
 
         # Compute weighted centroids
-        pred_centroid = (pred_coords * weights).sum(dim=1, keepdim=True) / weights.sum(dim=1, keepdim=True)
         true_centroid = (true_coords * weights).sum(dim=1, keepdim=True) / weights.sum(dim=1, keepdim=True)
+        pred_centroid = (pred_coords * weights).sum(dim=1, keepdim=True) / weights.sum(dim=1, keepdim=True)
 
         # Center the coordinates
-        pred_coords_centered = pred_coords - pred_centroid
         true_coords_centered = true_coords - true_centroid
+        pred_coords_centered = pred_coords - pred_centroid
 
         if num_points < (dim + 1):
             logger.warning(
@@ -2471,6 +2472,7 @@ class WeightedRigidAlign(Module):
 
         # Compute the SVD of the covariance matrix
         U, S, V = torch.svd(cov_matrix)
+        U_T = U.transpose(-2, -1)
 
         # Catch ambiguous rotation by checking the magnitude of singular values
         if (S.abs() <= 1e-15).any() and not (num_points < (dim + 1)):
@@ -2480,20 +2482,17 @@ class WeightedRigidAlign(Module):
                 + "`WeightedRigidAlign` cannot return a unique rotation."
             )
 
-        # Compute the rotation matrix
-        rot_matrix = einsum(U, V, 'b i j, b k j -> b i k')
-
+        det = torch.det(einsum(V, U_T, 'b i j, b j k -> b i k'))
         # Ensure proper rotation matrix with determinant 1
-        F = torch.eye(dim, dtype=cov_matrix.dtype, device=cov_matrix.device)[None].repeat(batch_size, 1, 1)
-        F[:, -1, -1] = torch.det(rot_matrix)
-        rot_matrix = einsum(U, F, V, "b i j, b j k, b l k -> b i l")
+        diag = torch.eye(dim, dtype=det.dtype, device=det.device)[None].repeat(batch_size, 1, 1)
+        diag[:, -1, -1] = det
+        rot_matrix = einsum(V, diag, U_T, "b i j, b j k, b k l -> b i l")
 
         # Apply the rotation and translation
-        aligned_coords = einsum(pred_coords_centered, rot_matrix, 'b n i, b j i -> b n j') + true_centroid
-        aligned_coords.detach_()
+        true_aligned_coords = einsum(rot_matrix, true_coords_centered, 'b i j, b n j -> b n i') + pred_centroid
+        true_aligned_coords.detach_()
 
-        return aligned_coords
-
+        return true_aligned_coords
 class ExpressCoordinatesInFrame(Module):
     """ Algorithm  29 """
 

--- a/tests/test_af3.py
+++ b/tests/test_af3.py
@@ -86,7 +86,7 @@ def test_weighted_rigid_align():
     assert (rmsd < 1e-5).all()
 
     random_augment_fn = CentreRandomAugmentation()
-    aligned_coords = align_fn(random_augment_fn(pred_coords), pred_coords, weights)
+    aligned_coords = align_fn(pred_coords, random_augment_fn(pred_coords), weights)
 
     # `pred_coords` should match a random augmentation of itself after alignment
 


### PR DESCRIPTION
Hi @lucidrains  I found the problem of not passing the test:

In the test code, the augmented input was placed at `pred_coords` position due to previous logic. Now we are aligning true to pred, the augmented input needs to be placed at the `true_coords` position. During training, we also want to align `true_coords` to `pred_coords`. I swapped these two positions in the test code and it passed.

Changes:
1. Swapped true and pred coordinates in input in `forward` of `ElucidatedAtomDiffusion` (Same as last time)
2. Modified `forward` of `WeightedRigidAlign` following steps from this paper: https://igl.ethz.ch/projects/ARAP/svd_rot.pdf. (Same as last time)
3. Moved `random_augment_fn(pred_coords)` from `pred_coords` to `true_coords` location in `test_weighted_rigid_align`. (New)

I'll did some small scale test for the module, and will test on actual diffusion generation tomorrow. I'll keep you posted.