### PR TITLE
changed python requirements to >=3.10

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ authors = [
     { name = "Phil Wang", email = "lucidrains@gmail.com" }
 ]
 readme = "README.md"
-requires-python = ">= 3.8"
+requires-python = ">= 3.10"
 license = { file = "LICENSE" }
 keywords = [
     'artificial intelligence',
@@ -19,7 +19,7 @@ classifiers=[
     'Intended Audience :: Developers',
     'Topic :: Scientific/Engineering :: Artificial Intelligence',
     'License :: OSI Approved :: MIT License',
-    'Programming Language :: Python :: 3.8',
+    'Programming Language :: Python :: 3.10',
 ]
 
 dependencies = [


### PR DESCRIPTION
currently python>=3.8 is defined as requirement, but the code fails as the following feature support was added in python 3.10

https://peps.python.org/pep-0604/


example code that requires 3.10 can be found in `alphafold3_pytorch/tensor_typing.pytensor_typing.py`
```
IntType = int | np.int32 | np.int64
```
