### PR TITLE
Add `chains` to all `Input` classes

### DIFF
--- a/alphafold3_pytorch/alphafold3.py
+++ b/alphafold3_pytorch/alphafold3.py
@@ -4594,6 +4594,7 @@ class Alphafold3(Module):
         pde_labels: Int['b n n'] | Int['b m m'] | None = None,
         plddt_labels: Int['b n'] | Int['b m'] | None = None,
         resolved_labels: Int['b n'] | Int['b m'] | None = None,
+        chains: Int['b 2'] | None = None,
         return_loss_breakdown = False,
         return_loss: bool = None,
         return_present_sampled_atoms: bool = False,

--- a/alphafold3_pytorch/inputs.py
+++ b/alphafold3_pytorch/inputs.py
@@ -168,7 +168,7 @@ class AtomInput:
     pde_labels:                 Int['n n'] | None = None
     plddt_labels:               Int[' n'] | None = None
     resolved_labels:            Int[' n'] | None = None
-    chains:                     Tuple[int | None, int | None] = (None, None)
+    chains:                     Int[" 2"] | None = None
 
     def dict(self):
         return asdict(self)
@@ -201,7 +201,7 @@ class BatchedAtomInput:
     pde_labels:                 Int['b n n'] | None = None
     plddt_labels:               Int['b n'] | None = None
     resolved_labels:            Int['b n'] | None = None
-    chains:                     Tuple[int | None, int | None] = (None, None)
+    chains:                     Int["b 2"] | None = None
 
     def dict(self):
         return asdict(self)
@@ -648,6 +648,10 @@ def molecule_to_atom_input(mol_input: MoleculeInput) -> AtomInput:
     if exists(atom_pos) and isinstance(atom_pos, list):
         atom_pos = torch.cat(atom_pos, dim=-2)
 
+    # coerce chain indices into a tensor
+
+    chains = tensor([default(chain, -1) for chain in i.chains]).long()
+
     # atom input
 
     atom_input = AtomInput(
@@ -666,7 +670,7 @@ def molecule_to_atom_input(mol_input: MoleculeInput) -> AtomInput:
         atom_parent_ids=i.atom_parent_ids,
         atom_ids=atom_ids,
         atompair_ids=atompair_ids,
-        chains=i.chains,
+        chains=chains,
     )
 
     return atom_input
@@ -1050,6 +1054,10 @@ def molecule_lengthed_molecule_input_to_atom_input(mol_input: MoleculeLengthMole
     if exists(atom_pos) and isinstance(atom_pos, list):
         atom_pos = torch.cat(atom_pos, dim=-2)
 
+    # coerce chain indices into a tensor
+
+    chains = tensor([default(chain, -1) for chain in i.chains]).long()
+
     # atom input
 
     atom_input = AtomInput(
@@ -1070,7 +1078,7 @@ def molecule_lengthed_molecule_input_to_atom_input(mol_input: MoleculeLengthMole
         atom_parent_ids=i.atom_parent_ids,
         atom_ids=atom_ids,
         atompair_ids=atompair_ids,
-        chains=i.chains,
+        chains=chains,
     )
 
     return atom_input

--- a/alphafold3_pytorch/inputs.py
+++ b/alphafold3_pytorch/inputs.py
@@ -9,7 +9,7 @@ from itertools import groupby
 from collections import defaultdict
 from collections.abc import Iterable
 from dataclasses import asdict, dataclass, field
-from typing import Any, Callable, List, Literal, Set, Tuple, Type
+from typing import Any, Callable, Dict, List, Literal, Set, Tuple, Type
 
 import einx
 from einops import pack
@@ -168,6 +168,7 @@ class AtomInput:
     pde_labels:                 Int['n n'] | None = None
     plddt_labels:               Int[' n'] | None = None
     resolved_labels:            Int[' n'] | None = None
+    chains:                     Tuple[int | None, int | None] = (None, None)
 
     def dict(self):
         return asdict(self)
@@ -200,6 +201,7 @@ class BatchedAtomInput:
     pde_labels:                 Int['b n n'] | None = None
     plddt_labels:               Int['b n'] | None = None
     resolved_labels:            Int['b n'] | None = None
+    chains:                     Tuple[int | None, int | None] = (None, None)
 
     def dict(self):
         return asdict(self)
@@ -400,6 +402,7 @@ class MoleculeInput:
     pae_labels:                 Int['n n'] | None = None
     pde_labels:                 Int[' n'] | None = None
     resolved_labels:            Int[' n'] | None = None
+    chains:                     Tuple[int | None, int | None] = (None, None)
     add_atom_ids:               bool = False
     add_atompair_ids:           bool = False
     directed_bonds:             bool = False
@@ -663,6 +666,7 @@ def molecule_to_atom_input(mol_input: MoleculeInput) -> AtomInput:
         atom_parent_ids=i.atom_parent_ids,
         atom_ids=atom_ids,
         atompair_ids=atompair_ids,
+        chains=i.chains,
     )
 
     return atom_input
@@ -699,6 +703,7 @@ class MoleculeLengthMoleculeInput:
     pae_labels:                 Int['n n'] | None = None
     pde_labels:                 Int[' n'] | None = None
     resolved_labels:            Int[' n'] | None = None
+    chains:                     Tuple[int | None, int | None] = (None, None)
     add_atom_ids:               bool = False
     add_atompair_ids:           bool = False
     directed_bonds:             bool = False
@@ -1065,6 +1070,7 @@ def molecule_lengthed_molecule_input_to_atom_input(mol_input: MoleculeLengthMole
         atom_parent_ids=i.atom_parent_ids,
         atom_ids=atom_ids,
         atompair_ids=atompair_ids,
+        chains=i.chains,
     )
 
     return atom_input
@@ -1097,6 +1103,7 @@ class Alphafold3Input:
     pae_labels:                 Int['n n'] | None = None
     pde_labels:                 Int[' n'] | None = None
     resolved_labels:            Int[' n'] | None = None
+    chains:                     Tuple[int | None, int | None] = (None, None)
     add_atom_ids:               bool = False
     add_atompair_ids:           bool = False
     directed_bonds:             bool = False
@@ -1500,6 +1507,7 @@ def alphafold3_input_to_molecule_lengthed_molecule_input(alphafold3_input: Alpha
         template_mask=i.template_mask,
         msa_mask=i.msa_mask,
         atom_parent_ids=atom_parent_ids,
+        chains=i.chains,
         add_atom_ids=i.add_atom_ids,
         add_atompair_ids=i.add_atompair_ids,
         directed_bonds=i.directed_bonds,
@@ -1514,7 +1522,12 @@ def alphafold3_input_to_molecule_lengthed_molecule_input(alphafold3_input: Alpha
 @typecheck
 @dataclass
 class PDBInput:
-    mmcif_filepath: str
+    """Dataclass for PDB inputs."""
+
+    mmcif_filepath: str | None = None
+    biomol: Biomolecule | None = None
+    chains: Tuple[str | None, str | None] = (None, None)
+    cropping_config: Dict[str, float | int] | None = None
     msa_dir: str | None = None
     templates_dir: str | None = None
     add_atom_ids: bool = False
@@ -1526,16 +1539,58 @@ class PDBInput:
 
     def __post_init__(self):
         """Run post-init checks."""
-        if not os.path.exists(self.mmcif_filepath):
-            raise FileNotFoundError(f"mmCIF file not found: {self.mmcif_filepath}.")
-        if not self.mmcif_filepath.endswith(".cif"):
+
+        if exists(self.mmcif_filepath):
+            if not os.path.exists(self.mmcif_filepath):
+                raise FileNotFoundError(f"mmCIF file not found: {self.mmcif_filepath}.")
+            if not self.mmcif_filepath.endswith(".cif"):
+                raise ValueError(
+                    f"mmCIF file `{self.mmcif_filepath}` must have a `.cif` file extension."
+                )
+        elif not exists(self.biomol):
             raise ValueError(
-                f"mmCIF file `{self.mmcif_filepath}` must have a `.cif` file extension."
+                "Either an mmCIF file or a `Biomolecule` object must be provided."
             )
 
-        if self.msa_dir is not None and not os.path.exists(self.msa_dir):
-            raise FileNotFoundError(f"Provided MSA directory not found: {self.msa_dir}.")
-        if self.templates_dir is not None and not os.path.exists(self.templates_dir):
+        if exists(self.chains):
+            assert exists(self.chains[0]) or (
+                exists(self.chains[0]) and exists(self.chains[1])
+            ), "At least one (sampled) chain ID must be provided for training and evaluation."
+
+        if exists(self.cropping_config):
+            assert self.cropping_config.keys() == {
+                "contiguous_weight",
+                "spatial_weight",
+                "spatial_interface_weight",
+                "n_res",
+            }, (
+                f"Invalid cropping config keys: {self.cropping_config.keys()}. "
+                "Please ensure that the cropping config has the correct keys."
+            )
+            assert (
+                sum(
+                    [
+                        self.cropping_config["contiguous_weight"],
+                        self.cropping_config["spatial_weight"],
+                        self.cropping_config["spatial_interface_weight"],
+                    ]
+                )
+                == 1.0
+            ), (
+                f"Invalid cropping config weights: ({self.cropping_config['contiguous_weight']}, {self.cropping_config['spatial_weight']}, {self.cropping_config['spatial_interface_weight']}). "
+                "Please ensure that the cropping config weights sum to 1.0."
+            )
+            assert self.cropping_config["n_res"] > 0, (
+                f"Invalid number of residues for cropping: {self.cropping_config['n_res']}. "
+                "Please ensure that the number of residues for cropping is greater than 0."
+            )
+
+        if exists(self.msa_dir) and not os.path.exists(self.msa_dir):
+            raise FileNotFoundError(
+                f"Provided MSA directory not found: {self.msa_dir}."
+            )
+
+        if exists(self.templates_dir) and not os.path.exists(self.templates_dir):
             raise FileNotFoundError(
                 f"Provided templates directory not found: {self.templates_dir}."
             )
@@ -1973,26 +2028,47 @@ def find_mismatched_symmetry(asym_ids: np.ndarray, entity_ids: np.ndarray, sym_i
 
 
 @typecheck
-def pdb_input_to_molecule_input(pdb_input: PDBInput) -> MoleculeInput:
+def pdb_input_to_molecule_input(
+    pdb_input: PDBInput, biomol: Biomolecule | None = None
+) -> MoleculeInput:
     """Convert a PDBInput to a MoleculeInput."""
     i = pdb_input
 
-    # construct a `Biomolecule` object from the input PDB mmCIF file
+    # acquire a `Biomolecule` object for the given `PDBInput`
 
-    filepath = pdb_input.mmcif_filepath
-    file_id = os.path.splitext(os.path.basename(filepath))[0]
-    assert os.path.exists(filepath), f"PDB input file `{filepath}` does not exist."
+    if not exists(biomol) and exists(i.biomol):
+        biomol = i.biomol
+    else:
+        # construct a `Biomolecule` object from the input PDB mmCIF file
 
-    mmcif_object = mmcif_parsing.parse_mmcif_object(
-        filepath=filepath,
-        file_id=file_id,
-    )
+        filepath = pdb_input.mmcif_filepath
+        file_id = os.path.splitext(os.path.basename(filepath))[0]
+        assert os.path.exists(filepath), f"PDB input file `{filepath}` does not exist."
 
-    biomol = (
-        _from_mmcif_object(mmcif_object)
-        if "assembly" in file_id
-        else get_assembly(_from_mmcif_object(mmcif_object))
-    )
+        mmcif_object = mmcif_parsing.parse_mmcif_object(
+            filepath=filepath,
+            file_id=file_id,
+        )
+        biomol = (
+            _from_mmcif_object(mmcif_object)
+            if "assembly" in file_id
+            else get_assembly(_from_mmcif_object(mmcif_object))
+        )
+
+    # crop the `Biomolecule` object during training only
+
+    if i.training:
+        assert exists(
+            i.cropping_config
+        ), "A cropping configuration must be provided during training."
+        biomol = biomol.crop(
+            contiguous_weight=i.cropping_config["contiguous_weight"],
+            spatial_weight=i.cropping_config["spatial_weight"],
+            spatial_interface_weight=i.cropping_config["spatial_interface_weight"],
+            n_res=i.cropping_config["n_res"],
+            chain_1=i.chains[0],
+            chain_2=i.chains[1],
+        )
 
     # retrieve features directly available within the `Biomolecule` object
 
@@ -2348,6 +2424,18 @@ def pdb_input_to_molecule_input(pdb_input: PDBInput) -> MoleculeInput:
         ]
     )
 
+    # map (sampled) chain IDs to indices
+
+    chain_id_1, chain_id_2 = i.chains
+    chain_id_to_idx = {
+        chain_id: chain_idx
+        for (chain_id, chain_idx) in zip(biomol.chain_id, biomol.chain_index)
+    }
+    if exists(chain_id_1):
+        chain_id_1 = chain_id_to_idx[chain_id_1]
+    if exists(chain_id_2):
+        chain_id_2 = chain_id_to_idx[chain_id_2]
+
     # create molecule input
 
     molecule_input = MoleculeInput(
@@ -2358,7 +2446,9 @@ def pdb_input_to_molecule_input(pdb_input: PDBInput) -> MoleculeInput:
         molecule_ids=molecule_ids,
         token_bonds=token_bonds,
         additional_molecule_feats=additional_molecule_feats,
-        additional_token_feats=default(additional_token_feats, torch.zeros(num_tokens, 2)),
+        additional_token_feats=default(
+            additional_token_feats, torch.zeros(num_tokens, 2)
+        ),
         is_molecule_types=is_molecule_types,
         missing_atom_indices=missing_atom_indices,
         missing_token_indices=missing_token_indices,
@@ -2369,6 +2459,7 @@ def pdb_input_to_molecule_input(pdb_input: PDBInput) -> MoleculeInput:
         template_mask=template_mask,
         msa_mask=msa_mask,
         atom_parent_ids=atom_parent_ids,
+        chains=(chain_id_1, chain_id_2),
         add_atom_ids=i.add_atom_ids,
         add_atompair_ids=i.add_atompair_ids,
         directed_bonds=i.directed_bonds,
@@ -2394,7 +2485,7 @@ class PDBDataset(Dataset):
         contiguous_weight: float = 0.2,
         spatial_weight: float = 0.4,
         spatial_interface_weight: float = 0.4,
-        crop_size: int | None = None,
+        crop_size: int = 384,
         training: bool | None = None,  # extra training flag placed by Alex on PDBInput
         **pdb_input_kwargs,
     ):
@@ -2410,14 +2501,17 @@ class PDBDataset(Dataset):
         }
         self.sampler = sampler
         self.sample_type = sample_type
-        self.contiguous_weight = contiguous_weight
-        self.spatial_weight = spatial_weight
-        self.spatial_interface_weight = spatial_interface_weight
-        self.crop_size = crop_size
         self.training = training
         self.pdb_input_kwargs = pdb_input_kwargs
 
-        assert len(self) > 0, f'no valid mmcifs / pdbs found at {str(folder)}'
+        self.cropping_config = {
+            "contiguous_weight": contiguous_weight,
+            "spatial_weight": spatial_weight,
+            "spatial_interface_weight": spatial_interface_weight,
+            "n_res": crop_size,
+        }
+
+        assert len(self) > 0, f"No valid mmCIFs / PDBs found at {str(folder)}"
 
     def __len__(self):
         """Return the number of PDB mmCIF files in the dataset."""
@@ -2425,17 +2519,15 @@ class PDBDataset(Dataset):
 
     def __getitem__(self, idx: int | str) -> PDBInput:
         """Return a PDBInput object for the specified index."""
-        kwargs = self.pdb_input_kwargs
-        if exists(self.training):
-            kwargs = {**kwargs, "training": self.training}
-
         sampled_id = None
 
         if exists(self.sampler):
             if self.sample_type == "clustered":
-                sampled_id, = self.sampler.cluster_based_sample(1)
+                (sampled_id,) = self.sampler.cluster_based_sample(1)
             else:
-                sampled_id, = self.sampler.sample(1)
+                (sampled_id,) = self.sampler.sample(1)
+
+        pdb_id, chain_id_1, chain_id_2 = None, None, None
 
         if exists(sampled_id):
             pdb_id, chain_id_1, chain_id_2 = sampled_id
@@ -2452,27 +2544,21 @@ class PDBDataset(Dataset):
 
         if not exists(mmcif_filepath):
             raise FileNotFoundError(f"mmCIF file for PDB ID {pdb_id} not found.")
+        if not os.path.exists(mmcif_filepath):
+            raise FileNotFoundError(f"mmCIF file {mmcif_filepath} not found.")
 
-        if exists(self.training) and self.training:
-            mmcif_object = mmcif_parsing.parse_mmcif_object(
-                mmcif_filepath,
-                file_id=pdb_id,
-            )
-            biomol = _from_mmcif_object(mmcif_object)
+        cropping_config = None
 
-            if exists(sampled_id):
-                biomol = biomol.crop(
-                    contiguous_weight=self.contiguous_weight,
-                    spatial_weight=self.spatial_weight,
-                    spatial_interface_weight=self.spatial_interface_weight,
-                    n_res=self.crop_size,
-                    chain_1=chain_id_1,
-                    chain_2=chain_id_2,
-                )
+        if self.training:
+            cropping_config = self.cropping_config
 
-            pdb_input = PDBInput(biomol=biomol, **kwargs)
-        else:
-            pdb_input = PDBInput(mmcif_filepath=str(mmcif_filepath), **kwargs)
+        pdb_input = PDBInput(
+            mmcif_filepath=str(mmcif_filepath),
+            chains=(chain_id_1, chain_id_2),
+            cropping_config=cropping_config,
+            training=self.training,
+            **self.pdb_input_kwargs,
+        )
 
         return pdb_input
 

--- a/tests/test_input.py
+++ b/tests/test_input.py
@@ -186,7 +186,17 @@ def test_pdbinput_input():
     if os.path.exists(filepath.replace(".cif", "-sampled.cif")):
         os.remove(filepath.replace(".cif", "-sampled.cif"))
 
-    train_pdb_input = PDBInput(filepath, training=True)
+    train_pdb_input = PDBInput(
+        filepath,
+        chains=("A", "B"),
+        cropping_config={
+            "contiguous_weight": 0.2,
+            "spatial_weight": 0.4,
+            "spatial_interface_weight": 0.4,
+            "n_res": 384,
+        },
+        training=True,
+    )
 
     eval_pdb_input = PDBInput(filepath)
 


### PR DESCRIPTION
* Adds `chains` to all `Input` classes
* Next steps include wiring the `chains` into how we select which val/test metrics to report for which (sampled) chains. In principle, we could just subsample the chain IDs for which we report train/val/test metrics uniformly, since cropping chains then subsampling metrics by the same (cropped) chain IDs should behave the same as not cropping chains then subsampling the metrics.
* In other words, I think we should just tag a small bit of logic in our metric reporting code that filters down the final reported metric values to only those chains that are denoted by `chains`. Also, if `chains` is `None`, I think we should just (like normal) report metric values for all chains in the input structure(s).