### PR TITLE
Revamp modified polymer residue support in `pdb_input_to_molecule_input()`

### DIFF
--- a/alphafold3_pytorch/inputs.py
+++ b/alphafold3_pytorch/inputs.py
@@ -321,7 +321,7 @@ class AtomDataset(Dataset):
 @typecheck
 def atom_ref_pos_to_atompair_inputs(
     atom_ref_pos: Float['m 3'],
-    atom_ref_space_uid: Int['m'] | None = None,
+    atom_ref_space_uid: Int[' m'] | None = None,
 ) -> Float['m m 5']:
 
     # Algorithm 5 - lines 2-6
@@ -696,7 +696,7 @@ class MoleculeLengthMoleculeInput:
     src_tgt_atom_indices:       Int['n 2']
     token_bonds:                Bool['n n'] | None = None
     one_token_per_atom:         List[bool] | None = None
-    is_molecule_mod:            Bool['n num_mods'] | Bool['n'] | None = None
+    is_molecule_mod:            Bool['n num_mods'] | Bool[' n'] | None = None
     molecule_atom_indices:      List[int | None] | None = None
     distogram_atom_indices:     List[int | None] | None = None
     missing_atom_indices:       List[Int[' _'] | None] | None = None

--- a/alphafold3_pytorch/inputs.py
+++ b/alphafold3_pytorch/inputs.py
@@ -57,6 +57,7 @@ from alphafold3_pytorch.life import (
 
 from alphafold3_pytorch.tensor_typing import Bool, Float, Int, typecheck
 from alphafold3_pytorch.utils.data_utils import (
+    PDB_INPUT_RESIDUE_MOLECULE_TYPE,
     get_pdb_input_residue_molecule_type,
     is_atomized_residue,
     is_polymer,
@@ -85,10 +86,6 @@ NUM_MOLECULE_IDS = len(HUMAN_AMINO_ACIDS) + len(RNA_NUCLEOTIDES) + len(DNA_NUCLE
 
 DEFAULT_NUM_MOLECULE_MODS = 5
 ADDITIONAL_MOLECULE_FEATS = 5
-
-PDB_INPUT_RESIDUE_MOLECULE_TYPE = Literal[
-    "protein", "rna", "dna", "mod_protein", "mod_rna", "mod_dna", "ligand"
-]
 
 CCD_COMPONENTS_FILEPATH = os.path.join('data', 'ccd_data', 'components.cif')
 CCD_COMPONENTS_SMILES_FILEPATH = os.path.join('data', 'ccd_data', 'components_smiles.json')

--- a/alphafold3_pytorch/utils/data_utils.py
+++ b/alphafold3_pytorch/utils/data_utils.py
@@ -2,6 +2,7 @@ from typing import Any, Dict, Literal, Set
 
 import numpy as np
 
+from alphafold3_pytorch.models.components.inputs import PDB_INPUT_RESIDUE_MOLECULE_TYPE
 from alphafold3_pytorch.tensor_typing import ChainType, ResidueType, typecheck
 
 # constants
@@ -36,6 +37,19 @@ def is_water(res_name: str, water_res_names: Set[str] = {"HOH", "WAT"}) -> bool:
 
 
 @typecheck
+def is_atomized_residue(
+    res_name: str, atomized_res_mol_types: Set[str] = {"ligand", "mod"}
+) -> bool:
+    """Check if a residue is an atomized residue using its residue molecule type string.
+
+    :param res_name: The name of the residue as a descriptive string.
+    :param atomized_res_mol_types: The set of atomized residue molecule types as strings.
+    :return: Whether the residue is an atomized residue.
+    """
+    return any(mol_type in res_name.lower() for mol_type in atomized_res_mol_types)
+
+
+@typecheck
 def get_residue_molecule_type(res_chem_type: str) -> RESIDUE_MOLECULE_TYPE:
     """Get the molecule type of a residue."""
     if "peptide" in res_chem_type.lower():
@@ -44,6 +58,21 @@ def get_residue_molecule_type(res_chem_type: str) -> RESIDUE_MOLECULE_TYPE:
         return "rna"
     elif "dna" in res_chem_type.lower():
         return "dna"
+    else:
+        return "ligand"
+
+
+@typecheck
+def get_pdb_input_residue_molecule_type(
+    res_chem_type: str, is_modified_polymer_residue: bool = False
+) -> PDB_INPUT_RESIDUE_MOLECULE_TYPE:
+    """Get the molecule type of a residue."""
+    if "peptide" in res_chem_type.lower():
+        return "mod_protein" if is_modified_polymer_residue else "protein"
+    elif "rna" in res_chem_type.lower():
+        return "mod_rna" if is_modified_polymer_residue else "rna"
+    elif "dna" in res_chem_type.lower():
+        return "mod_dna" if is_modified_polymer_residue else "dna"
     else:
         return "ligand"
 

--- a/alphafold3_pytorch/utils/data_utils.py
+++ b/alphafold3_pytorch/utils/data_utils.py
@@ -2,12 +2,14 @@ from typing import Any, Dict, Literal, Set
 
 import numpy as np
 
-from alphafold3_pytorch.models.components.inputs import PDB_INPUT_RESIDUE_MOLECULE_TYPE
 from alphafold3_pytorch.tensor_typing import ChainType, ResidueType, typecheck
 
 # constants
 
 RESIDUE_MOLECULE_TYPE = Literal["protein", "rna", "dna", "ligand"]
+PDB_INPUT_RESIDUE_MOLECULE_TYPE = Literal[
+    "protein", "rna", "dna", "mod_protein", "mod_rna", "mod_dna", "ligand"
+]
 
 
 @typecheck


### PR DESCRIPTION
* Revamps modified polymer residue support in `pdb_input_to_molecule_input()`
* Now, modified polymer residues should be "atomized" just like ligand atoms, but for these modified residues, they still retain their original polymer residue (molecule) type (e.g., a modified peptide/protein residue is still treated as a protein residue as far as `is_molecule_types` and `molecule_ids` are concerned)
* Also maybe fixes the flaky `pdb_input` unit test by moving the chain name to index mapping logic to be before the cropping logic
* **N.B.** Also fixes a small bug in assigning RNA and DNA indices into the `is_molecule_types` tensor