### PR TITLE
No longer try to coerce label atom IDs during training-time bond installation

### DIFF
--- a/alphafold3_pytorch/inputs.py
+++ b/alphafold3_pytorch/inputs.py
@@ -61,7 +61,6 @@ from alphafold3_pytorch.utils.data_utils import (
     get_pdb_input_residue_molecule_type,
     is_atomized_residue,
     is_polymer,
-    remove_last_digit_character,
 )
 from alphafold3_pytorch.utils.model_utils import exclusive_cumsum
 from alphafold3_pytorch.utils.utils import default, exists, first, identity
@@ -2450,14 +2449,12 @@ def pdb_input_to_molecule_input(
             ptnr2_atom_id = (
                 f"{bond.ptnr2_auth_asym_id}:{bond.ptnr2_auth_seq_id}:{bond.ptnr2_label_atom_id}"
             )
-            ptnr1_label_atom_id = remove_last_digit_character(bond.ptnr1_label_atom_id)
-            ptnr2_label_atom_id = remove_last_digit_character(bond.ptnr2_label_atom_id)
             try:
                 row_idx = get_token_index_from_composite_atom_id(
                     biomol,
                     bond.ptnr1_auth_asym_id,
                     int(bond.ptnr1_auth_seq_id),
-                    ptnr1_label_atom_id,
+                    bond.ptnr1_label_atom_id,
                     bond_atom_indices[ptnr1_atom_id],
                     ptnr1_is_polymer,
                 )
@@ -2473,7 +2470,7 @@ def pdb_input_to_molecule_input(
                     biomol,
                     bond.ptnr2_auth_asym_id,
                     int(bond.ptnr2_auth_seq_id),
-                    ptnr2_label_atom_id,
+                    bond.ptnr2_label_atom_id,
                     bond_atom_indices[ptnr2_atom_id],
                     ptnr2_is_polymer,
                 )

--- a/alphafold3_pytorch/utils/data_utils.py
+++ b/alphafold3_pytorch/utils/data_utils.py
@@ -171,15 +171,3 @@ def deep_merge_dicts(
             # Otherwise, set/overwrite the key in dict1 with dict2's value
             dict1[key] = value
     return dict1
-
-
-@typecheck
-def remove_last_digit_character(string: str) -> str:
-    """Remove the last digit character from a string.
-
-    :param string: The string to remove the last digit character from.
-    :return: The string with the last digit character removed
-    """
-    if len(string) > 1 and string[-1].isdigit():
-        return string[:-1]
-    return string


### PR DESCRIPTION
* No longer trying to coerce label atom IDs during training-time bond installation