### PR TITLE
Add code necessary for overfitting experiments

### DIFF
--- a/alphafold3_pytorch/alphafold3.py
+++ b/alphafold3_pytorch/alphafold3.py
@@ -4833,6 +4833,7 @@ class Alphafold3(Module):
         plddt_labels: Int['b n'] | Int['b m'] | None = None,
         resolved_labels: Int['b n'] | Int['b m'] | None = None,
         chains: Int['b 2'] | None = None,
+        filepath: List[str] | None = None,
         return_loss_breakdown = False,
         return_loss: bool = None,
         return_present_sampled_atoms: bool = False,

--- a/alphafold3_pytorch/data/mmcif_writing.py
+++ b/alphafold3_pytorch/data/mmcif_writing.py
@@ -12,24 +12,15 @@ from alphafold3_pytorch.data.data_pipeline import get_assembly
 from alphafold3_pytorch.data.mmcif_parsing import MmcifObject, parse_mmcif_object
 from alphafold3_pytorch.utils.utils import exists
 
+
 def write_mmcif_from_filepath_and_id(
-    filepath: str,
-    file_id: str,
-    suffix: str = 'sampled',
-    **kwargs
+    input_filepath: str, output_filepath: str, file_id: str, **kwargs
 ):
-    mmcif_object = parse_mmcif_object(
-        filepath = filepath,
-        file_id = file_id
-    )
+    """Write an input mmCIF file to an output mmCIF filepath using the provided keyword arguments
+    (e.g., sampled coordinates)."""
+    mmcif_object = parse_mmcif_object(filepath=input_filepath, file_id=file_id)
+    return write_mmcif(mmcif_object, output_filepath=output_filepath, **kwargs)
 
-    output_filepath = filepath.replace(".cif", f"-{suffix}.cif")
-
-    return write_mmcif(
-        mmcif_object,
-        output_filepath = output_filepath,
-        **kwargs
-    )
 
 def write_mmcif(
     mmcif_object: MmcifObject,

--- a/alphafold3_pytorch/inputs.py
+++ b/alphafold3_pytorch/inputs.py
@@ -178,6 +178,7 @@ class AtomInput:
     plddt_labels:               Int[' n'] | None = None
     resolved_labels:            Int[' n'] | None = None
     chains:                     Int[" 2"] | None = None
+    filepath:                   str | None = None
 
     def dict(self):
         return asdict(self)
@@ -211,6 +212,7 @@ class BatchedAtomInput:
     plddt_labels:               Int['b n'] | None = None
     resolved_labels:            Int['b n'] | None = None
     chains:                     Int["b 2"] | None = None
+    filepath:                   List[str] | None = None
 
     def dict(self):
         return asdict(self)
@@ -412,6 +414,7 @@ class MoleculeInput:
     pde_labels:                 Int[' n'] | None = None
     resolved_labels:            Int[' n'] | None = None
     chains:                     Tuple[int | None, int | None] | None = (None, None)
+    filepath:                   str | None = None
     add_atom_ids:               bool = False
     add_atompair_ids:           bool = False
     directed_bonds:             bool = False
@@ -692,6 +695,7 @@ def molecule_to_atom_input(mol_input: MoleculeInput) -> AtomInput:
         atom_ids=atom_ids,
         atompair_ids=atompair_ids,
         chains=chains,
+        filepath=i.filepath,
     )
 
     return atom_input
@@ -729,6 +733,7 @@ class MoleculeLengthMoleculeInput:
     pde_labels:                 Int[' n'] | None = None
     resolved_labels:            Int[' n'] | None = None
     chains:                     Tuple[int | None, int | None] | None = (None, None)
+    filepath:                   str | None = None
     add_atom_ids:               bool = False
     add_atompair_ids:           bool = False
     directed_bonds:             bool = False
@@ -1115,6 +1120,7 @@ def molecule_lengthed_molecule_input_to_atom_input(mol_input: MoleculeLengthMole
         atom_ids = atom_ids,
         atompair_ids = atompair_ids,
         chains = chains,
+        filepath=i.filepath,
     )
 
     return atom_input
@@ -2582,6 +2588,7 @@ def pdb_input_to_molecule_input(
         template_mask=template_mask,
         msa_mask=msa_mask,
         chains=chains,
+        filepath=filepath,
         add_atom_ids=i.add_atom_ids,
         add_atompair_ids=i.add_atompair_ids,
         directed_bonds=i.directed_bonds,

--- a/alphafold3_pytorch/trainer.py
+++ b/alphafold3_pytorch/trainer.py
@@ -142,18 +142,24 @@ def collate_inputs_to_batched_atom_input(
 
     # separate input dictionary into keys and values
 
-    keys = atom_inputs[0].dict().keys()
+    keys = list(atom_inputs[0].dict().keys())
     atom_inputs = [i.dict().values() for i in atom_inputs]
 
     outputs = []
 
-    for grouped in zip(*atom_inputs):
+    for group_index, grouped in enumerate(zip(*atom_inputs)):
         # if all None, just return None
 
         not_none_grouped = [*filter(exists, grouped)]
 
         if len(not_none_grouped) == 0:
             outputs.append(None)
+            continue
+
+        # collate list of input filepath strings
+
+        if keys[group_index] == "filepath":
+            outputs.append(not_none_grouped)
             continue
 
         # default to empty tensor for any Nones

--- a/data/test/209d-assembly1.cif
+++ b/data/test/209d-assembly1.cif
@@ -1,0 +1,707 @@
+data_209D-ASSEMBLY1
+#
+loop_
+_audit_author.name
+_audit_author.pdbx_ordinal
+'Shinomiya, M.'  1
+'Chu, W.'        2
+'Carlson, R.G.'  3
+'Weaver, R.F.'   4
+'Takusagawa, F.' 5
+#
+_struct.entry_id                  XXXX
+_struct.title                     'Structural, physical and biological characteristics of RNA:DNA binding agent N8-actinomycin D'
+_struct.pdbx_model_details        ?
+_struct.pdbx_CASP_flag            ?
+_struct.pdbx_model_type_details   ?
+#
+_struct_keywords.entry_id        XXXX
+_struct_keywords.pdbx_keywords   DNA/ANTIBIOTIC
+_struct_keywords.text            'ACTINOMYCIN D, DACTINOMYCIN, N8-ACTINOMYCIN D, ANTIBIOTIC, ANTI CANCER, ANTITUMOR, CHROMOPHORE, DEPSIPEPTIDE, DNA-ANTIBIOTIC COMPLEX'
+#
+_exptl.entry_id          XXXX
+_exptl.method            'X-RAY DIFFRACTION'
+_exptl.crystals_number   ?
+#
+loop_
+_citation.id
+_citation.title
+_citation.journal_abbrev
+_citation.journal_volume
+_citation.page_first
+_citation.page_last
+_citation.year
+_citation.journal_id_ASTM
+_citation.country
+_citation.journal_id_ISSN
+_citation.journal_id_CSD
+_citation.book_publisher
+_citation.pdbx_database_id_PubMed
+_citation.pdbx_database_id_DOI
+primary 'Structural, Physical, and Biological Characteristics of RNA.DNA Binding Agent N8-Actinomycin D.' Biochemistry   34  8481 ? 1995 BICHAW US 0006-2960 0033 ? 7541244 10.1021/BI00026A032
+1       ?                                                                                                 J.Am.Chem.Soc. 116 2243 ? 1994 JACSAT US 0002-7863 0004 ? ?       10.1021/JA00085A002
+#
+loop_
+_citation_author.citation_id
+_citation_author.name
+_citation_author.ordinal
+_citation_author.identifier_ORCID
+primary 'Shinomiya, M.'  1 ?
+primary 'Chu, W.'        2 ?
+primary 'Carlson, R.G.'  3 ?
+primary 'Weaver, R.F.'   4 ?
+primary 'Takusagawa, F.' 5 ?
+#
+_atom_sites.entry_id                    XXXX
+_atom_sites.fract_transf_matrix[1][1]   0.016051
+_atom_sites.fract_transf_matrix[1][2]   0.009267
+_atom_sites.fract_transf_matrix[1][3]   0.000000
+_atom_sites.fract_transf_matrix[2][1]   0.000000
+_atom_sites.fract_transf_matrix[2][2]   0.018535
+_atom_sites.fract_transf_matrix[2][3]   0.000000
+_atom_sites.fract_transf_matrix[3][1]   0.000000
+_atom_sites.fract_transf_matrix[3][2]   0.000000
+_atom_sites.fract_transf_matrix[3][3]   0.023272
+_atom_sites.fract_transf_vector[1]      0.00000
+_atom_sites.fract_transf_vector[2]      0.00000
+_atom_sites.fract_transf_vector[3]      0.00000
+#
+_entry.id   209D-ASSEMBLY1
+#
+loop_
+_pdbx_chain_remapping.entity_id
+_pdbx_chain_remapping.label_asym_id
+_pdbx_chain_remapping.auth_asym_id
+_pdbx_chain_remapping.orig_label_asym_id
+_pdbx_chain_remapping.orig_auth_asym_id
+_pdbx_chain_remapping.applied_operations
+1 A A A A 1
+1 B B B B 1
+2 C C C C 1
+3 D A D A 1
+3 E B E B 1
+3 F C F C 1
+#
+_pdbx_entity_nonpoly.entity_id   3
+_pdbx_entity_nonpoly.name        water
+_pdbx_entity_nonpoly.comp_id     HOH
+#
+loop_
+_pdbx_entity_remapping.entity_id
+_pdbx_entity_remapping.orig_entity_id
+1 1
+2 2
+3 3
+#
+loop_
+_pdbx_audit_revision_history.revision_date
+1995-10-15
+2011-06-14
+2011-07-13
+2011-07-27
+2012-12-12
+2023-11-15
+#
+_refine.ls_d_res_high   3.00
+#
+_reflns.d_resolution_high   3.000
+#
+loop_
+_ma_target_entity_instance.asym_id
+_ma_target_entity_instance.entity_id
+_ma_target_entity_instance.details
+A 1 .
+B 1 .
+C 2 .
+A 3 .
+B 3 .
+C 3 .
+#
+loop_
+_ma_target_entity.entity_id
+_ma_target_entity.data_id
+_ma_target_entity.origin
+1 1 .
+1 1 .
+2 1 .
+3 1 .
+3 1 .
+3 1 .
+#
+loop_
+_atom_type.symbol
+C
+N
+O
+P
+#
+loop_
+_struct_asym.id
+_struct_asym.entity_id
+A 1
+B 1
+C 2
+A 3
+B 3
+C 3
+#
+loop_
+_entity.id
+_entity.type
+1 polymer
+2 polymer
+3 polymer
+#
+loop_
+_entity_poly.entity_id
+_entity_poly.type
+_entity_poly.pdbx_strand_id
+1 polydeoxyribonucleotide A,B
+2 polypeptide(L)          C
+3 polydeoxyribonucleotide A,B,C
+#
+loop_
+_pdbx_struct_assembly_gen.assembly_id
+#
+loop_
+_struct_conn.ptnr1_auth_seq_id
+_struct_conn.ptnr1_auth_comp_id
+_struct_conn.ptnr1_auth_asym_id
+_struct_conn.ptnr1_label_atom_id
+_struct_conn.pdbx_ptnr1_label_alt_id
+_struct_conn.ptnr2_auth_seq_id
+_struct_conn.ptnr2_auth_comp_id
+_struct_conn.ptnr2_auth_asym_id
+_struct_conn.ptnr2_label_atom_id
+_struct_conn.pdbx_ptnr2_label_alt_id
+_struct_conn.pdbx_leaving_atom_flag
+_struct_conn.pdbx_dist_value
+_struct_conn.pdbx_role
+_struct_conn.conn_type_id
+1  THR C C     ? 2  DVA C N  ? both 1.327 ? covale
+1  THR C OG1   ? 5  MVA C C  ? one  1.408 ? covale
+1  THR C N     ? 6  PXA C C0 ? one  1.334 ? covale
+2  DVA C C     ? 3  PRO C N  ? both 1.335 ? covale
+3  PRO C C     ? 4  SAR C N  ? both 1.346 ? covale
+4  SAR C C     ? 5  MVA C N  ? both 1.340 ? covale
+6  PXA C 'C0'' ? 7  THR C N  ? one  1.332 ? covale
+7  THR C C     ? 8  DVA C N  ? both 1.335 ? covale
+7  THR C OG1   ? 11 MVA C C  ? one  1.394 ? covale
+8  DVA C C     ? 9  PRO C N  ? both 1.348 ? covale
+9  PRO C C     ? 10 SAR C N  ? both 1.336 ? covale
+10 SAR C C     ? 11 MVA C N  ? both 1.345 ? covale
+1  DG  A N1    ? 8  DC  B N3 ? ?    ?     ? hydrog
+1  DG  A N2    ? 8  DC  B O2 ? ?    ?     ? hydrog
+1  DG  A O6    ? 8  DC  B N4 ? ?    ?     ? hydrog
+2  DA  A N1    ? 7  DT  B N3 ? ?    ?     ? hydrog
+2  DA  A N6    ? 7  DT  B O4 ? ?    ?     ? hydrog
+3  DA  A N1    ? 6  DT  B N3 ? ?    ?     ? hydrog
+3  DA  A N6    ? 6  DT  B O4 ? ?    ?     ? hydrog
+4  DG  A N1    ? 5  DC  B N3 ? ?    ?     ? hydrog
+4  DG  A N2    ? 5  DC  B O2 ? ?    ?     ? hydrog
+4  DG  A O6    ? 5  DC  B N4 ? ?    ?     ? hydrog
+5  DC  A N3    ? 4  DG  B N1 ? ?    ?     ? hydrog
+5  DC  A N4    ? 4  DG  B O6 ? ?    ?     ? hydrog
+5  DC  A O2    ? 4  DG  B N2 ? ?    ?     ? hydrog
+6  DT  A N3    ? 3  DA  B N1 ? ?    ?     ? hydrog
+6  DT  A O4    ? 3  DA  B N6 ? ?    ?     ? hydrog
+7  DT  A N3    ? 2  DA  B N1 ? ?    ?     ? hydrog
+7  DT  A O4    ? 2  DA  B N6 ? ?    ?     ? hydrog
+8  DC  A N3    ? 1  DG  B N1 ? ?    ?     ? hydrog
+8  DC  A N4    ? 1  DG  B O6 ? ?    ?     ? hydrog
+8  DC  A O2    ? 1  DG  B N2 ? ?    ?     ? hydrog
+#
+loop_
+_chem_comp.id
+_chem_comp.formula
+_chem_comp.formula_weight
+_chem_comp.mon_nstd_flag
+_chem_comp.name
+_chem_comp.type
+MVA 'C6 H13 N O2'     131.173 n  N-METHYLVALINE                                                         'L-peptide linking'
+DA  'C10 H14 N5 O6 P' 331.222 y  '2'-DEOXYADENOSINE-5'-MONOPHOSPHATE'                                   'DNA linking'
+PRO 'C5 H9 N O2'      115.130 y  PROLINE                                                                'L-peptide linking'
+DG  'C10 H14 N5 O7 P' 347.221 y  '2'-DEOXYGUANOSINE-5'-MONOPHOSPHATE'                                   'DNA linking'
+DVA 'C5 H11 N O2'     117.146 .  D-VALINE                                                               'D-peptide linking'
+THR 'C4 H9 N O3'      119.119 y  THREONINE                                                              'L-peptide linking'
+SAR 'C3 H7 N O2'      89.093  n  SARCOSINE                                                              'peptide linking'
+PXA 'C15 H11 N3 O4'   297.266 .  2-AMINO-1,9-DICARBONYL-4,6-DIMETHYL-10-DEHYDRO-3-OXO(8-AZA)PHENOXAZINE non-polymer
+DC  'C9 H14 N3 O7 P'  307.197 y  '2'-DEOXYCYTIDINE-5'-MONOPHOSPHATE'                                    'DNA linking'
+DT  'C10 H15 N2 O8 P' 322.208 y  'THYMIDINE-5'-MONOPHOSPHATE'                                           'DNA linking'
+UNK ?                 0.0     no 'UNKNOWN AMINO ACID RESIDUE'                                           'peptide linking'
+#
+loop_
+_pdbx_poly_seq_scheme.asym_id
+_pdbx_poly_seq_scheme.entity_id
+_pdbx_poly_seq_scheme.seq_id
+_pdbx_poly_seq_scheme.auth_seq_num
+_pdbx_poly_seq_scheme.pdb_seq_num
+_pdbx_poly_seq_scheme.mon_id
+_pdbx_poly_seq_scheme.auth_mon_id
+_pdbx_poly_seq_scheme.pdb_mon_id
+_pdbx_poly_seq_scheme.hetero
+A 3 1  1  1  DG  DG  DG  n
+A 3 2  2  2  DA  DA  DA  n
+A 3 3  3  3  DA  DA  DA  n
+A 3 4  4  4  DG  DG  DG  n
+A 3 5  5  5  DC  DC  DC  n
+A 3 6  6  6  DT  DT  DT  n
+A 3 7  7  7  DT  DT  DT  n
+A 3 8  8  8  DC  DC  DC  n
+B 3 1  1  1  DG  DG  DG  n
+B 3 2  2  2  DA  DA  DA  n
+B 3 3  3  3  DA  DA  DA  n
+B 3 4  4  4  DG  DG  DG  n
+B 3 5  5  5  DC  DC  DC  n
+B 3 6  6  6  DT  DT  DT  n
+B 3 7  7  7  DT  DT  DT  n
+B 3 8  8  8  DC  DC  DC  n
+C 3 1  1  1  THR THR THR n
+C 3 2  2  2  DVA DVA DVA n
+C 3 3  3  3  PRO PRO PRO n
+C 3 4  4  4  SAR SAR SAR n
+C 3 5  5  5  MVA MVA MVA n
+C 3 6  6  6  UNK UNK UNK n
+C 3 7  7  7  THR THR THR n
+C 3 8  8  8  DVA DVA DVA n
+C 3 9  9  9  PRO PRO PRO n
+C 3 10 10 10 SAR SAR SAR n
+C 3 11 11 11 MVA MVA MVA n
+#
+_pdbx_nonpoly_scheme.asym_id        C
+_pdbx_nonpoly_scheme.entity_id      3
+_pdbx_nonpoly_scheme.auth_seq_num   6
+_pdbx_nonpoly_scheme.pdb_seq_num    6
+_pdbx_nonpoly_scheme.auth_mon_id    PXA
+_pdbx_nonpoly_scheme.pdb_mon_id     PXA
+#
+loop_
+_atom_site.group_PDB
+_atom_site.id
+_atom_site.type_symbol
+_atom_site.label_atom_id
+_atom_site.label_alt_id
+_atom_site.label_comp_id
+_atom_site.label_asym_id
+_atom_site.label_entity_id
+_atom_site.label_seq_id
+_atom_site.pdbx_PDB_ins_code
+_atom_site.Cartn_x
+_atom_site.Cartn_y
+_atom_site.Cartn_z
+_atom_site.occupancy
+_atom_site.B_iso_or_equiv
+_atom_site.auth_seq_id
+_atom_site.auth_comp_id
+_atom_site.auth_asym_id
+_atom_site.auth_atom_id
+_atom_site.pdbx_PDB_model_num
+ATOM   1   O 'O5'' . DG  A 3 1  . 14.783  32.915 18.909 1.00 25.43 1  DG  A 'O5'' 1
+ATOM   2   C 'C5'' . DG  A 3 1  . 14.057  33.101 17.691 1.00 38.05 1  DG  A 'C5'' 1
+ATOM   3   C 'C4'' . DG  A 3 1  . 14.860  33.831 16.584 1.00 44.60 1  DG  A 'C4'' 1
+ATOM   4   O 'O4'' . DG  A 3 1  . 16.074  33.087 16.376 1.00 43.14 1  DG  A 'O4'' 1
+ATOM   5   C 'C3'' . DG  A 3 1  . 14.162  33.839 15.171 1.00 51.87 1  DG  A 'C3'' 1
+ATOM   6   O 'O3'' . DG  A 3 1  . 14.667  34.884 14.282 1.00 55.94 1  DG  A 'O3'' 1
+ATOM   7   C 'C2'' . DG  A 3 1  . 14.537  32.473 14.672 1.00 48.12 1  DG  A 'C2'' 1
+ATOM   8   C 'C1'' . DG  A 3 1  . 15.927  32.271 15.178 1.00 46.61 1  DG  A 'C1'' 1
+ATOM   9   N N9    . DG  A 3 1  . 16.220  30.828 15.399 1.00 49.90 1  DG  A N9    1
+ATOM   10  C C8    . DG  A 3 1  . 16.307  30.157 16.602 1.00 49.94 1  DG  A C8    1
+ATOM   11  N N7    . DG  A 3 1  . 16.582  28.888 16.485 1.00 44.22 1  DG  A N7    1
+ATOM   12  C C5    . DG  A 3 1  . 16.764  28.717 15.122 1.00 34.57 1  DG  A C5    1
+ATOM   13  C C6    . DG  A 3 1  . 17.150  27.568 14.435 1.00 22.49 1  DG  A C6    1
+ATOM   14  N N1    . DG  A 3 1  . 17.055  27.720 13.078 1.00 9.10  1  DG  A N1    1
+ATOM   15  C C2    . DG  A 3 1  . 16.767  28.882 12.436 1.00 8.43  1  DG  A C2    1
+ATOM   16  N N3    . DG  A 3 1  . 16.563  30.037 13.070 1.00 24.40 1  DG  A N3    1
+ATOM   17  C C4    . DG  A 3 1  . 16.486  29.863 14.421 1.00 40.25 1  DG  A C4    1
+ATOM   18  O O6    . DG  A 3 1  . 17.432  26.488 14.935 1.00 26.16 1  DG  A O6    1
+ATOM   19  N N2    . DG  A 3 1  . 16.632  28.816 11.113 1.00 7.71  1  DG  A N2    1
+ATOM   20  P P     . DA  A 3 2  . 14.423  35.164 12.680 1.00 54.43 2  DA  A P     1
+ATOM   21  O OP1   . DA  A 3 2  . 14.835  33.961 11.932 1.00 50.91 2  DA  A OP1   1
+ATOM   22  O OP2   . DA  A 3 2  . 15.126  36.440 12.383 1.00 53.07 2  DA  A OP2   1
+ATOM   23  O 'O5'' . DA  A 3 2  . 12.817  35.414 12.482 1.00 54.66 2  DA  A 'O5'' 1
+ATOM   24  C 'C5'' . DA  A 3 2  . 11.750  34.452 12.267 1.00 51.08 2  DA  A 'C5'' 1
+ATOM   25  C 'C4'' . DA  A 3 2  . 11.950  33.737 10.921 1.00 50.12 2  DA  A 'C4'' 1
+ATOM   26  O 'O4'' . DA  A 3 2  . 12.836  32.631 11.119 1.00 46.85 2  DA  A 'O4'' 1
+ATOM   27  C 'C3'' . DA  A 3 2  . 10.730  33.242 10.123 1.00 53.43 2  DA  A 'C3'' 1
+ATOM   28  O 'O3'' . DA  A 3 2  . 11.001  33.530 8.722  1.00 62.12 2  DA  A 'O3'' 1
+ATOM   29  C 'C2'' . DA  A 3 2  . 10.742  31.775 10.473 1.00 53.67 2  DA  A 'C2'' 1
+ATOM   30  C 'C1'' . DA  A 3 2  . 12.197  31.401 10.730 1.00 47.04 2  DA  A 'C1'' 1
+ATOM   31  N N9    . DA  A 3 2  . 12.363  30.396 11.817 1.00 42.23 2  DA  A N9    1
+ATOM   32  C C8    . DA  A 3 2  . 12.260  30.579 13.173 1.00 39.91 2  DA  A C8    1
+ATOM   33  N N7    . DA  A 3 2  . 12.549  29.527 13.889 1.00 35.91 2  DA  A N7    1
+ATOM   34  C C5    . DA  A 3 2  . 12.808  28.565 12.932 1.00 32.65 2  DA  A C5    1
+ATOM   35  C C6    . DA  A 3 2  . 13.241  27.246 13.045 1.00 29.64 2  DA  A C6    1
+ATOM   36  N N6    . DA  A 3 2  . 13.582  26.715 14.212 1.00 21.36 2  DA  A N6    1
+ATOM   37  N N1    . DA  A 3 2  . 13.352  26.533 11.917 1.00 31.00 2  DA  A N1    1
+ATOM   38  C C2    . DA  A 3 2  . 13.074  27.097 10.743 1.00 33.41 2  DA  A C2    1
+ATOM   39  N N3    . DA  A 3 2  . 12.805  28.374 10.494 1.00 36.09 2  DA  A N3    1
+ATOM   40  C C4    . DA  A 3 2  . 12.673  29.064 11.663 1.00 37.04 2  DA  A C4    1
+ATOM   41  P P     . DA  A 3 3  . 10.136  33.301 7.352  1.00 66.56 3  DA  A P     1
+ATOM   42  O OP1   . DA  A 3 3  . 10.730  34.276 6.408  1.00 62.73 3  DA  A OP1   1
+ATOM   43  O OP2   . DA  A 3 3  . 8.696   33.448 7.681  1.00 67.00 3  DA  A OP2   1
+ATOM   44  O 'O5'' . DA  A 3 3  . 10.354  31.745 6.783  1.00 65.48 3  DA  A 'O5'' 1
+ATOM   45  C 'C5'' . DA  A 3 3  . 9.565   31.142 5.694  1.00 63.71 3  DA  A 'C5'' 1
+ATOM   46  C 'C4'' . DA  A 3 3  . 9.972   29.686 5.176  1.00 62.37 3  DA  A 'C4'' 1
+ATOM   47  O 'O4'' . DA  A 3 3  . 10.258  28.775 6.263  1.00 62.00 3  DA  A 'O4'' 1
+ATOM   48  C 'C3'' . DA  A 3 3  . 8.858   28.850 4.460  1.00 60.19 3  DA  A 'C3'' 1
+ATOM   49  O 'O3'' . DA  A 3 3  . 9.456   27.685 3.834  1.00 56.94 3  DA  A 'O3'' 1
+ATOM   50  C 'C2'' . DA  A 3 3  . 8.042   28.385 5.655  1.00 58.49 3  DA  A 'C2'' 1
+ATOM   51  C 'C1'' . DA  A 3 3  . 9.126   27.897 6.559  1.00 53.02 3  DA  A 'C1'' 1
+ATOM   52  N N9    . DA  A 3 3  . 8.944   28.111 7.977  1.00 45.20 3  DA  A N9    1
+ATOM   53  C C8    . DA  A 3 3  . 8.597   29.255 8.651  1.00 45.06 3  DA  A C8    1
+ATOM   54  N N7    . DA  A 3 3  . 8.718   29.155 9.942  1.00 40.30 3  DA  A N7    1
+ATOM   55  C C5    . DA  A 3 3  . 9.251   27.885 10.101 1.00 35.60 3  DA  A C5    1
+ATOM   56  C C6    . DA  A 3 3  . 9.789   27.261 11.209 1.00 33.45 3  DA  A C6    1
+ATOM   57  N N6    . DA  A 3 3  . 9.741   27.887 12.381 1.00 34.39 3  DA  A N6    1
+ATOM   58  N N1    . DA  A 3 3  . 10.065  25.960 11.079 1.00 28.26 3  DA  A N1    1
+ATOM   59  C C2    . DA  A 3 3  . 10.126  25.442 9.859  1.00 29.85 3  DA  A C2    1
+ATOM   60  N N3    . DA  A 3 3  . 9.940   26.036 8.697  1.00 29.67 3  DA  A N3    1
+ATOM   61  C C4    . DA  A 3 3  . 9.462   27.275 8.906  1.00 36.46 3  DA  A C4    1
+ATOM   62  P P     . DG  A 3 4  . 8.734   26.365 3.230  1.00 64.54 4  DG  A P     1
+ATOM   63  O OP1   . DG  A 3 4  . 9.798   25.542 2.600  1.00 70.05 4  DG  A OP1   1
+ATOM   64  O OP2   . DG  A 3 4  . 7.578   26.770 2.399  1.00 63.27 4  DG  A OP2   1
+ATOM   65  O 'O5'' . DG  A 3 4  . 8.155   25.501 4.488  1.00 64.07 4  DG  A 'O5'' 1
+ATOM   66  C 'C5'' . DG  A 3 4  . 7.735   24.135 4.246  1.00 62.05 4  DG  A 'C5'' 1
+ATOM   67  C 'C4'' . DG  A 3 4  . 7.104   23.352 5.430  1.00 58.02 4  DG  A 'C4'' 1
+ATOM   68  O 'O4'' . DG  A 3 4  . 7.827   23.481 6.686  1.00 59.12 4  DG  A 'O4'' 1
+ATOM   69  C 'C3'' . DG  A 3 4  . 5.749   23.858 5.833  1.00 54.99 4  DG  A 'C3'' 1
+ATOM   70  O 'O3'' . DG  A 3 4  . 4.701   23.833 4.866  1.00 48.84 4  DG  A 'O3'' 1
+ATOM   71  C 'C2'' . DG  A 3 4  . 5.570   23.001 7.055  1.00 49.58 4  DG  A 'C2'' 1
+ATOM   72  C 'C1'' . DG  A 3 4  . 6.920   23.148 7.767  1.00 44.04 4  DG  A 'C1'' 1
+ATOM   73  N N9    . DG  A 3 4  . 6.789   24.192 8.804  1.00 31.13 4  DG  A N9    1
+ATOM   74  C C8    . DG  A 3 4  . 6.580   25.547 8.680  1.00 34.94 4  DG  A C8    1
+ATOM   75  N N7    . DG  A 3 4  . 6.424   26.173 9.821  1.00 32.78 4  DG  A N7    1
+ATOM   76  C C5    . DG  A 3 4  . 6.583   25.169 10.769 1.00 29.03 4  DG  A C5    1
+ATOM   77  C C6    . DG  A 3 4  . 6.530   25.242 12.204 1.00 28.54 4  DG  A C6    1
+ATOM   78  N N1    . DG  A 3 4  . 6.757   23.981 12.744 1.00 22.56 4  DG  A N1    1
+ATOM   79  C C2    . DG  A 3 4  . 6.926   22.819 12.011 1.00 27.33 4  DG  A C2    1
+ATOM   80  N N3    . DG  A 3 4  . 6.968   22.768 10.681 1.00 26.05 4  DG  A N3    1
+ATOM   81  C C4    . DG  A 3 4  . 6.774   23.964 10.135 1.00 25.02 4  DG  A C4    1
+ATOM   82  O O6    . DG  A 3 4  . 6.412   26.246 12.926 1.00 20.05 4  DG  A O6    1
+ATOM   83  N N2    . DG  A 3 4  . 7.156   21.676 12.645 1.00 29.94 4  DG  A N2    1
+ATOM   84  P P     . DC  A 3 5  . 3.580   24.965 5.119  1.00 47.25 5  DC  A P     1
+ATOM   85  O OP1   . DC  A 3 5  . 3.297   25.557 3.795  1.00 49.15 5  DC  A OP1   1
+ATOM   86  O OP2   . DC  A 3 5  . 4.024   25.831 6.240  1.00 41.86 5  DC  A OP2   1
+ATOM   87  O 'O5'' . DC  A 3 5  . 2.251   24.296 5.662  1.00 40.08 5  DC  A 'O5'' 1
+ATOM   88  C 'C5'' . DC  A 3 5  . 1.272   23.541 4.943  1.00 40.48 5  DC  A 'C5'' 1
+ATOM   89  C 'C4'' . DC  A 3 5  . 0.208   23.089 5.925  1.00 39.55 5  DC  A 'C4'' 1
+ATOM   90  O 'O4'' . DC  A 3 5  . 0.479   23.694 7.186  1.00 39.35 5  DC  A 'O4'' 1
+ATOM   91  C 'C3'' . DC  A 3 5  . -1.215  23.546 5.705  1.00 40.98 5  DC  A 'C3'' 1
+ATOM   92  O 'O3'' . DC  A 3 5  . -1.882  22.803 4.667  1.00 47.10 5  DC  A 'O3'' 1
+ATOM   93  C 'C2'' . DC  A 3 5  . -1.790  23.349 7.097  1.00 39.31 5  DC  A 'C2'' 1
+ATOM   94  C 'C1'' . DC  A 3 5  . -0.625  23.450 8.058  1.00 37.69 5  DC  A 'C1'' 1
+ATOM   95  C C5    . DC  A 3 5  . -0.836  26.877 9.501  1.00 32.37 5  DC  A C5    1
+ATOM   96  C C6    . DC  A 3 5  . -0.776  25.853 8.627  1.00 31.31 5  DC  A C6    1
+ATOM   97  N N1    . DC  A 3 5  . -0.731  24.550 9.060  1.00 33.45 5  DC  A N1    1
+ATOM   98  C C2    . DC  A 3 5  . -0.725  24.231 10.430 1.00 29.29 5  DC  A C2    1
+ATOM   99  N N3    . DC  A 3 5  . -0.761  25.244 11.297 1.00 30.88 5  DC  A N3    1
+ATOM   100 C C4    . DC  A 3 5  . -0.823  26.526 10.893 1.00 35.67 5  DC  A C4    1
+ATOM   101 O O2    . DC  A 3 5  . -0.649  23.089 10.871 1.00 23.03 5  DC  A O2    1
+ATOM   102 N N4    . DC  A 3 5  . -0.871  27.473 11.833 1.00 34.40 5  DC  A N4    1
+ATOM   103 P P     . DT  A 3 6  . -3.496  22.835 4.468  1.00 52.07 6  DT  A P     1
+ATOM   104 O OP1   . DT  A 3 6  . -3.827  22.248 3.146  1.00 49.64 6  DT  A OP1   1
+ATOM   105 O OP2   . DT  A 3 6  . -3.970  24.205 4.799  1.00 56.73 6  DT  A OP2   1
+ATOM   106 O 'O5'' . DT  A 3 6  . -3.975  21.787 5.645  1.00 54.16 6  DT  A 'O5'' 1
+ATOM   107 C 'C5'' . DT  A 3 6  . -5.295  21.382 6.109  1.00 54.99 6  DT  A 'C5'' 1
+ATOM   108 C 'C4'' . DT  A 3 6  . -5.192  20.244 7.193  1.00 55.60 6  DT  A 'C4'' 1
+ATOM   109 O 'O4'' . DT  A 3 6  . -4.293  20.684 8.238  1.00 50.77 6  DT  A 'O4'' 1
+ATOM   110 C 'C3'' . DT  A 3 6  . -6.516  19.864 7.915  1.00 59.69 6  DT  A 'C3'' 1
+ATOM   111 O 'O3'' . DT  A 3 6  . -6.592  18.498 8.474  1.00 63.22 6  DT  A 'O3'' 1
+ATOM   112 C 'C2'' . DT  A 3 6  . -6.480  20.917 9.008  1.00 53.65 6  DT  A 'C2'' 1
+ATOM   113 C 'C1'' . DT  A 3 6  . -5.016  21.059 9.414  1.00 41.62 6  DT  A 'C1'' 1
+ATOM   114 C C5    . DT  A 3 6  . -4.679  24.796 9.500  1.00 25.17 6  DT  A C5    1
+ATOM   115 C C6    . DT  A 3 6  . -4.853  23.539 9.050  1.00 27.35 6  DT  A C6    1
+ATOM   116 N N1    . DT  A 3 6  . -4.747  22.452 9.879  1.00 35.08 6  DT  A N1    1
+ATOM   117 C C2    . DT  A 3 6  . -4.460  22.621 11.228 1.00 36.69 6  DT  A C2    1
+ATOM   118 N N3    . DT  A 3 6  . -4.310  23.911 11.684 1.00 26.93 6  DT  A N3    1
+ATOM   119 C C4    . DT  A 3 6  . -4.416  25.048 10.912 1.00 30.32 6  DT  A C4    1
+ATOM   120 O O2    . DT  A 3 6  . -4.386  21.698 12.041 1.00 45.95 6  DT  A O2    1
+ATOM   121 O O4    . DT  A 3 6  . -4.268  26.148 11.464 1.00 31.81 6  DT  A O4    1
+ATOM   122 C C7    . DT  A 3 6  . -4.711  25.960 8.488  1.00 15.51 6  DT  A C7    1
+ATOM   123 P P     . DT  A 3 7  . -7.903  17.820 9.251  1.00 59.01 7  DT  A P     1
+ATOM   124 O OP1   . DT  A 3 7  . -7.707  16.346 9.321  1.00 56.03 7  DT  A OP1   1
+ATOM   125 O OP2   . DT  A 3 7  . -9.136  18.325 8.600  1.00 56.17 7  DT  A OP2   1
+ATOM   126 O 'O5'' . DT  A 3 7  . -7.946  18.366 10.743 1.00 46.90 7  DT  A 'O5'' 1
+ATOM   127 C 'C5'' . DT  A 3 7  . -6.989  17.828 11.640 1.00 40.51 7  DT  A 'C5'' 1
+ATOM   128 C 'C4'' . DT  A 3 7  . -7.436  18.003 13.078 1.00 41.31 7  DT  A 'C4'' 1
+ATOM   129 O 'O4'' . DT  A 3 7  . -7.354  19.352 13.550 1.00 42.33 7  DT  A 'O4'' 1
+ATOM   130 C 'C3'' . DT  A 3 7  . -8.859  17.506 13.222 1.00 38.41 7  DT  A 'C3'' 1
+ATOM   131 O 'O3'' . DT  A 3 7  . -8.999  16.834 14.485 1.00 41.42 7  DT  A 'O3'' 1
+ATOM   132 C 'C2'' . DT  A 3 7  . -9.573  18.879 13.213 1.00 38.89 7  DT  A 'C2'' 1
+ATOM   133 C 'C1'' . DT  A 3 7  . -8.636  19.836 13.942 1.00 30.99 7  DT  A 'C1'' 1
+ATOM   134 C C5    . DT  A 3 7  . -8.443  22.952 11.846 1.00 10.20 7  DT  A C5    1
+ATOM   135 C C6    . DT  A 3 7  . -8.595  21.658 12.212 1.00 14.32 7  DT  A C6    1
+ATOM   136 N N1    . DT  A 3 7  . -8.584  21.270 13.537 1.00 20.24 7  DT  A N1    1
+ATOM   137 C C2    . DT  A 3 7  . -8.384  22.197 14.541 1.00 14.11 7  DT  A C2    1
+ATOM   138 N N3    . DT  A 3 7  . -8.133  23.446 14.138 1.00 10.56 7  DT  A N3    1
+ATOM   139 C C4    . DT  A 3 7  . -8.167  23.920 12.864 1.00 13.22 7  DT  A C4    1
+ATOM   140 O O2    . DT  A 3 7  . -8.575  22.039 15.739 1.00 13.77 7  DT  A O2    1
+ATOM   141 O O4    . DT  A 3 7  . -7.910  25.100 12.704 1.00 22.21 7  DT  A O4    1
+ATOM   142 C C7    . DT  A 3 7  . -8.576  23.408 10.376 1.00 6.01  7  DT  A C7    1
+ATOM   143 P P     . DC  A 3 8  . -10.208 15.799 14.657 1.00 36.69 8  DC  A P     1
+ATOM   144 O OP1   . DC  A 3 8  . -10.187 15.315 16.051 1.00 35.86 8  DC  A OP1   1
+ATOM   145 O OP2   . DC  A 3 8  . -10.144 14.811 13.559 1.00 39.27 8  DC  A OP2   1
+ATOM   146 O 'O5'' . DC  A 3 8  . -11.482 16.822 14.443 1.00 44.73 8  DC  A 'O5'' 1
+ATOM   147 C 'C5'' . DC  A 3 8  . -12.338 17.492 15.408 1.00 47.93 8  DC  A 'C5'' 1
+ATOM   148 C 'C4'' . DC  A 3 8  . -11.727 18.249 16.607 1.00 53.50 8  DC  A 'C4'' 1
+ATOM   149 O 'O4'' . DC  A 3 8  . -11.038 19.501 16.351 1.00 56.28 8  DC  A 'O4'' 1
+ATOM   150 C 'C3'' . DC  A 3 8  . -12.884 18.595 17.523 1.00 51.69 8  DC  A 'C3'' 1
+ATOM   151 O 'O3'' . DC  A 3 8  . -12.443 18.453 18.880 1.00 52.73 8  DC  A 'O3'' 1
+ATOM   152 C 'C2'' . DC  A 3 8  . -13.175 20.043 17.122 1.00 52.39 8  DC  A 'C2'' 1
+ATOM   153 C 'C1'' . DC  A 3 8  . -11.815 20.643 16.850 1.00 50.55 8  DC  A 'C1'' 1
+ATOM   154 C C5    . DC  A 3 8  . -11.825 22.516 13.631 1.00 42.45 8  DC  A C5    1
+ATOM   155 C C6    . DC  A 3 8  . -11.966 21.547 14.560 1.00 41.41 8  DC  A C6    1
+ATOM   156 N N1    . DC  A 3 8  . -11.782 21.799 15.893 1.00 45.70 8  DC  A N1    1
+ATOM   157 C C2    . DC  A 3 8  . -11.420 23.087 16.340 1.00 40.47 8  DC  A C2    1
+ATOM   158 N N3    . DC  A 3 8  . -11.225 24.055 15.396 1.00 39.77 8  DC  A N3    1
+ATOM   159 C C4    . DC  A 3 8  . -11.410 23.814 14.090 1.00 42.18 8  DC  A C4    1
+ATOM   160 O O2    . DC  A 3 8  . -11.241 23.382 17.531 1.00 40.68 8  DC  A O2    1
+ATOM   161 N N4    . DC  A 3 8  . -11.138 24.795 13.212 1.00 39.09 8  DC  A N4    1
+ATOM   162 O 'O5'' . DG  B 3 1  . -8.557  35.827 17.636 1.00 58.17 1  DG  B 'O5'' 1
+ATOM   163 C 'C5'' . DG  B 3 1  . -7.718  34.699 17.939 1.00 55.44 1  DG  B 'C5'' 1
+ATOM   164 C 'C4'' . DG  B 3 1  . -8.377  33.551 18.755 1.00 51.08 1  DG  B 'C4'' 1
+ATOM   165 O 'O4'' . DG  B 3 1  . -9.461  32.872 18.074 1.00 43.84 1  DG  B 'O4'' 1
+ATOM   166 C 'C3'' . DG  B 3 1  . -7.344  32.446 18.932 1.00 54.07 1  DG  B 'C3'' 1
+ATOM   167 O 'O3'' . DG  B 3 1  . -6.215  32.762 19.783 1.00 57.51 1  DG  B 'O3'' 1
+ATOM   168 C 'C2'' . DG  B 3 1  . -8.225  31.265 19.321 1.00 44.48 1  DG  B 'C2'' 1
+ATOM   169 C 'C1'' . DG  B 3 1  . -9.482  31.465 18.460 1.00 41.16 1  DG  B 'C1'' 1
+ATOM   170 N N9    . DG  B 3 1  . -9.563  30.616 17.237 1.00 31.65 1  DG  B N9    1
+ATOM   171 C C8    . DG  B 3 1  . -9.388  31.083 15.958 1.00 23.88 1  DG  B C8    1
+ATOM   172 N N7    . DG  B 3 1  . -9.427  30.140 15.065 1.00 29.85 1  DG  B N7    1
+ATOM   173 C C5    . DG  B 3 1  . -9.814  28.993 15.760 1.00 27.17 1  DG  B C5    1
+ATOM   174 C C6    . DG  B 3 1  . -10.140 27.693 15.264 1.00 28.52 1  DG  B C6    1
+ATOM   175 N N1    . DG  B 3 1  . -10.345 26.763 16.260 1.00 26.77 1  DG  B N1    1
+ATOM   176 C C2    . DG  B 3 1  . -10.315 27.054 17.603 1.00 26.71 1  DG  B C2    1
+ATOM   177 N N3    . DG  B 3 1  . -10.214 28.333 18.067 1.00 28.39 1  DG  B N3    1
+ATOM   178 C C4    . DG  B 3 1  . -9.879  29.246 17.104 1.00 26.84 1  DG  B C4    1
+ATOM   179 O O6    . DG  B 3 1  . -10.262 27.335 14.089 1.00 36.90 1  DG  B O6    1
+ATOM   180 N N2    . DG  B 3 1  . -10.501 25.999 18.426 1.00 21.95 1  DG  B N2    1
+ATOM   181 P P     . DA  B 3 2  . -6.212  33.007 21.371 1.00 66.70 2  DA  B P     1
+ATOM   182 O OP1   . DA  B 3 2  . -7.346  33.883 21.737 1.00 68.35 2  DA  B OP1   1
+ATOM   183 O OP2   . DA  B 3 2  . -4.841  33.415 21.753 1.00 67.39 2  DA  B OP2   1
+ATOM   184 O 'O5'' . DA  B 3 2  . -6.480  31.513 21.976 1.00 65.67 2  DA  B 'O5'' 1
+ATOM   185 C 'C5'' . DA  B 3 2  . -5.443  30.515 21.924 1.00 54.37 2  DA  B 'C5'' 1
+ATOM   186 C 'C4'' . DA  B 3 2  . -5.827  29.139 22.473 1.00 50.57 2  DA  B 'C4'' 1
+ATOM   187 O 'O4'' . DA  B 3 2  . -6.769  28.447 21.612 1.00 49.27 2  DA  B 'O4'' 1
+ATOM   188 C 'C3'' . DA  B 3 2  . -4.545  28.328 22.510 1.00 48.51 2  DA  B 'C3'' 1
+ATOM   189 O 'O3'' . DA  B 3 2  . -4.351  27.419 23.608 1.00 51.40 2  DA  B 'O3'' 1
+ATOM   190 C 'C2'' . DA  B 3 2  . -4.648  27.563 21.215 1.00 54.22 2  DA  B 'C2'' 1
+ATOM   191 C 'C1'' . DA  B 3 2  . -6.132  27.347 20.911 1.00 47.66 2  DA  B 'C1'' 1
+ATOM   192 N N9    . DA  B 3 2  . -6.297  27.362 19.416 1.00 44.22 2  DA  B N9    1
+ATOM   193 C C8    . DA  B 3 2  . -6.051  28.420 18.574 1.00 39.18 2  DA  B C8    1
+ATOM   194 N N7    . DA  B 3 2  . -6.201  28.144 17.316 1.00 36.01 2  DA  B N7    1
+ATOM   195 C C5    . DA  B 3 2  . -6.637  26.828 17.310 1.00 28.45 2  DA  B C5    1
+ATOM   196 C C6    . DA  B 3 2  . -6.999  25.987 16.260 1.00 19.89 2  DA  B C6    1
+ATOM   197 N N6    . DA  B 3 2  . -7.121  26.439 15.013 1.00 17.15 2  DA  B N6    1
+ATOM   198 N N1    . DA  B 3 2  . -7.329  24.747 16.551 1.00 15.21 2  DA  B N1    1
+ATOM   199 C C2    . DA  B 3 2  . -7.241  24.332 17.811 1.00 23.04 2  DA  B C2    1
+ATOM   200 N N3    . DA  B 3 2  . -6.955  25.026 18.901 1.00 27.18 2  DA  B N3    1
+ATOM   201 C C4    . DA  B 3 2  . -6.628  26.300 18.569 1.00 32.80 2  DA  B C4    1
+ATOM   202 P P     . DA  B 3 3  . -5.085  26.019 23.979 1.00 47.16 3  DA  B P     1
+ATOM   203 O OP1   . DA  B 3 3  . -6.539  26.171 23.736 1.00 44.70 3  DA  B OP1   1
+ATOM   204 O OP2   . DA  B 3 3  . -4.576  25.612 25.317 1.00 37.30 3  DA  B OP2   1
+ATOM   205 O 'O5'' . DA  B 3 3  . -4.473  25.042 22.885 1.00 42.47 3  DA  B 'O5'' 1
+ATOM   206 C 'C5'' . DA  B 3 3  . -4.668  23.626 22.815 1.00 40.94 3  DA  B 'C5'' 1
+ATOM   207 C 'C4'' . DA  B 3 3  . -3.763  23.095 21.712 1.00 41.84 3  DA  B 'C4'' 1
+ATOM   208 O 'O4'' . DA  B 3 3  . -4.130  23.598 20.404 1.00 45.53 3  DA  B 'O4'' 1
+ATOM   209 C 'C3'' . DA  B 3 3  . -2.367  23.627 22.045 1.00 42.32 3  DA  B 'C3'' 1
+ATOM   210 O 'O3'' . DA  B 3 3  . -1.588  22.568 22.612 1.00 43.11 3  DA  B 'O3'' 1
+ATOM   211 C 'C2'' . DA  B 3 3  . -1.912  24.192 20.701 1.00 44.59 3  DA  B 'C2'' 1
+ATOM   212 C 'C1'' . DA  B 3 3  . -2.919  23.695 19.633 1.00 39.89 3  DA  B 'C1'' 1
+ATOM   213 N N9    . DA  B 3 3  . -3.113  24.629 18.480 1.00 34.24 3  DA  B N9    1
+ATOM   214 C C8    . DA  B 3 3  . -3.084  26.010 18.465 1.00 33.21 3  DA  B C8    1
+ATOM   215 N N7    . DA  B 3 3  . -3.396  26.533 17.304 1.00 32.65 3  DA  B N7    1
+ATOM   216 C C5    . DA  B 3 3  . -3.409  25.427 16.443 1.00 28.54 3  DA  B C5    1
+ATOM   217 C C6    . DA  B 3 3  . -3.551  25.296 15.040 1.00 23.46 3  DA  B C6    1
+ATOM   218 N N6    . DA  B 3 3  . -3.682  26.327 14.209 1.00 29.72 3  DA  B N6    1
+ATOM   219 N N1    . DA  B 3 3  . -3.678  24.075 14.538 1.00 18.35 3  DA  B N1    1
+ATOM   220 C C2    . DA  B 3 3  . -3.526  23.051 15.354 1.00 16.75 3  DA  B C2    1
+ATOM   221 N N3    . DA  B 3 3  . -3.157  23.040 16.628 1.00 16.99 3  DA  B N3    1
+ATOM   222 C C4    . DA  B 3 3  . -3.223  24.273 17.151 1.00 26.12 3  DA  B C4    1
+ATOM   223 P P     . DG  B 3 4  . -0.326  22.860 23.571 1.00 39.86 4  DG  B P     1
+ATOM   224 O OP1   . DG  B 3 4  . 0.064   21.558 24.148 1.00 46.03 4  DG  B OP1   1
+ATOM   225 O OP2   . DG  B 3 4  . -0.710  23.950 24.489 1.00 38.44 4  DG  B OP2   1
+ATOM   226 O 'O5'' . DG  B 3 4  . 0.939   23.415 22.754 1.00 50.06 4  DG  B 'O5'' 1
+ATOM   227 C 'C5'' . DG  B 3 4  . 1.914   22.664 22.018 1.00 47.81 4  DG  B 'C5'' 1
+ATOM   228 C 'C4'' . DG  B 3 4  . 1.397   21.763 20.915 1.00 47.79 4  DG  B 'C4'' 1
+ATOM   229 O 'O4'' . DG  B 3 4  . 0.425   22.377 20.022 1.00 48.32 4  DG  B 'O4'' 1
+ATOM   230 C 'C3'' . DG  B 3 4  . 2.607   21.492 20.040 1.00 53.07 4  DG  B 'C3'' 1
+ATOM   231 O 'O3'' . DG  B 3 4  . 2.761   20.105 19.766 1.00 57.71 4  DG  B 'O3'' 1
+ATOM   232 C 'C2'' . DG  B 3 4  . 2.373   22.282 18.791 1.00 48.82 4  DG  B 'C2'' 1
+ATOM   233 C 'C1'' . DG  B 3 4  . 0.902   22.453 18.643 1.00 47.15 4  DG  B 'C1'' 1
+ATOM   234 N N9    . DG  B 3 4  . 0.601   23.711 17.874 1.00 44.56 4  DG  B N9    1
+ATOM   235 C C8    . DG  B 3 4  . 0.539   25.021 18.331 1.00 38.26 4  DG  B C8    1
+ATOM   236 N N7    . DG  B 3 4  . 0.218   25.903 17.420 1.00 29.53 4  DG  B N7    1
+ATOM   237 C C5    . DG  B 3 4  . 0.097   25.141 16.239 1.00 38.62 4  DG  B C5    1
+ATOM   238 C C6    . DG  B 3 4  . -0.229  25.545 14.883 1.00 34.00 4  DG  B C6    1
+ATOM   239 N N1    . DG  B 3 4  . -0.265  24.474 13.993 1.00 28.39 4  DG  B N1    1
+ATOM   240 C C2    . DG  B 3 4  . -0.053  23.161 14.352 1.00 33.31 4  DG  B C2    1
+ATOM   241 N N3    . DG  B 3 4  . 0.235   22.772 15.619 1.00 40.89 4  DG  B N3    1
+ATOM   242 C C4    . DG  B 3 4  . 0.297   23.803 16.515 1.00 41.82 4  DG  B C4    1
+ATOM   243 O O6    . DG  B 3 4  . -0.461  26.681 14.459 1.00 30.01 4  DG  B O6    1
+ATOM   244 N N2    . DG  B 3 4  . -0.195  22.243 13.396 1.00 20.48 4  DG  B N2    1
+ATOM   245 P P     . DC  B 3 5  . 3.592   19.104 20.674 1.00 50.58 5  DC  B P     1
+ATOM   246 O OP1   . DC  B 3 5  . 3.101   17.735 20.390 1.00 52.89 5  DC  B OP1   1
+ATOM   247 O OP2   . DC  B 3 5  . 3.570   19.628 22.055 1.00 53.54 5  DC  B OP2   1
+ATOM   248 O 'O5'' . DC  B 3 5  . 5.076   19.215 20.074 1.00 50.43 5  DC  B 'O5'' 1
+ATOM   249 C 'C5'' . DC  B 3 5  . 6.112   20.204 20.172 1.00 46.78 5  DC  B 'C5'' 1
+ATOM   250 C 'C4'' . DC  B 3 5  . 7.267   19.727 19.256 1.00 44.05 5  DC  B 'C4'' 1
+ATOM   251 O 'O4'' . DC  B 3 5  . 7.116   20.441 18.015 1.00 37.21 5  DC  B 'O4'' 1
+ATOM   252 C 'C3'' . DC  B 3 5  . 8.722   19.935 19.731 1.00 44.36 5  DC  B 'C3'' 1
+ATOM   253 O 'O3'' . DC  B 3 5  . 9.666   19.170 18.927 1.00 56.56 5  DC  B 'O3'' 1
+ATOM   254 C 'C2'' . DC  B 3 5  . 8.869   21.345 19.296 1.00 40.28 5  DC  B 'C2'' 1
+ATOM   255 C 'C1'' . DC  B 3 5  . 8.266   21.282 17.916 1.00 36.45 5  DC  B 'C1'' 1
+ATOM   256 C C5    . DC  B 3 5  . 7.506   24.909 17.657 1.00 39.41 5  DC  B C5    1
+ATOM   257 C C6    . DC  B 3 5  . 7.848   23.712 18.178 1.00 41.48 5  DC  B C6    1
+ATOM   258 N N1    . DC  B 3 5  . 7.878   22.581 17.392 1.00 38.14 5  DC  B N1    1
+ATOM   259 C C2    . DC  B 3 5  . 7.555   22.620 16.060 1.00 32.34 5  DC  B C2    1
+ATOM   260 N N3    . DC  B 3 5  . 7.248   23.805 15.523 1.00 33.38 5  DC  B N3    1
+ATOM   261 C C4    . DC  B 3 5  . 7.212   24.923 16.251 1.00 38.77 5  DC  B C4    1
+ATOM   262 O O2    . DC  B 3 5  . 7.580   21.624 15.364 1.00 29.72 5  DC  B O2    1
+ATOM   263 N N4    . DC  B 3 5  . 6.894   26.067 15.637 1.00 41.50 5  DC  B N4    1
+ATOM   264 P P     . DT  B 3 6  . 11.275  19.064 19.205 1.00 58.44 6  DT  B P     1
+ATOM   265 O OP1   . DT  B 3 6  . 11.477  18.314 20.469 1.00 51.99 6  DT  B OP1   1
+ATOM   266 O OP2   . DT  B 3 6  . 11.872  20.426 19.067 1.00 54.05 6  DT  B OP2   1
+ATOM   267 O 'O5'' . DT  B 3 6  . 11.921  18.106 18.071 1.00 42.61 6  DT  B 'O5'' 1
+ATOM   268 C 'C5'' . DT  B 3 6  . 12.419  18.558 16.827 1.00 30.75 6  DT  B 'C5'' 1
+ATOM   269 C 'C4'' . DT  B 3 6  . 11.442  19.214 15.907 1.00 32.68 6  DT  B 'C4'' 1
+ATOM   270 O 'O4'' . DT  B 3 6  . 11.062  20.551 16.242 1.00 38.83 6  DT  B 'O4'' 1
+ATOM   271 C 'C3'' . DT  B 3 6  . 12.116  19.340 14.547 1.00 37.70 6  DT  B 'C3'' 1
+ATOM   272 O 'O3'' . DT  B 3 6  . 12.286  18.011 14.109 1.00 38.71 6  DT  B 'O3'' 1
+ATOM   273 C 'C2'' . DT  B 3 6  . 11.190  20.250 13.791 1.00 37.98 6  DT  B 'C2'' 1
+ATOM   274 C 'C1'' . DT  B 3 6  . 10.634  21.134 14.942 1.00 40.71 6  DT  B 'C1'' 1
+ATOM   275 C C5    . DT  B 3 6  . 10.542  24.670 16.039 1.00 24.87 6  DT  B C5    1
+ATOM   276 C C6    . DT  B 3 6  . 10.678  23.346 16.006 1.00 12.57 6  DT  B C6    1
+ATOM   277 N N1    . DT  B 3 6  . 10.646  22.658 14.831 1.00 25.51 6  DT  B N1    1
+ATOM   278 C C2    . DT  B 3 6  . 10.494  23.336 13.593 1.00 18.62 6  DT  B C2    1
+ATOM   279 N N3    . DT  B 3 6  . 10.283  24.682 13.667 1.00 20.22 6  DT  B N3    1
+ATOM   280 C C4    . DT  B 3 6  . 10.247  25.430 14.838 1.00 30.05 6  DT  B C4    1
+ATOM   281 O O2    . DT  B 3 6  . 10.576  22.862 12.460 1.00 9.02  6  DT  B O2    1
+ATOM   282 O O4    . DT  B 3 6  . 10.023  26.649 14.807 1.00 29.86 6  DT  B O4    1
+ATOM   283 C C7    . DT  B 3 6  . 10.899  25.426 17.327 1.00 25.09 6  DT  B C7    1
+ATOM   284 P P     . DT  B 3 7  . 12.754  17.466 12.719 1.00 34.95 7  DT  B P     1
+ATOM   285 O OP1   . DT  B 3 7  . 11.819  17.945 11.685 1.00 45.65 7  DT  B OP1   1
+ATOM   286 O OP2   . DT  B 3 7  . 12.936  16.013 12.916 1.00 38.56 7  DT  B OP2   1
+ATOM   287 O 'O5'' . DT  B 3 7  . 14.194  18.141 12.559 1.00 39.05 7  DT  B 'O5'' 1
+ATOM   288 C 'C5'' . DT  B 3 7  . 15.127  17.876 11.488 1.00 35.63 7  DT  B 'C5'' 1
+ATOM   289 C 'C4'' . DT  B 3 7  . 14.711  18.295 10.084 1.00 35.33 7  DT  B 'C4'' 1
+ATOM   290 O 'O4'' . DT  B 3 7  . 13.893  19.499 10.120 1.00 35.29 7  DT  B 'O4'' 1
+ATOM   291 C 'C3'' . DT  B 3 7  . 16.030  18.697 9.397  1.00 41.44 7  DT  B 'C3'' 1
+ATOM   292 O 'O3'' . DT  B 3 7  . 16.089  18.488 7.945  1.00 48.17 7  DT  B 'O3'' 1
+ATOM   293 C 'C2'' . DT  B 3 7  . 16.110  20.182 9.815  1.00 38.74 7  DT  B 'C2'' 1
+ATOM   294 C 'C1'' . DT  B 3 7  . 14.677  20.717 9.981  1.00 35.71 7  DT  B 'C1'' 1
+ATOM   295 C C5    . DT  B 3 7  . 14.698  21.922 13.523 1.00 32.53 7  DT  B C5    1
+ATOM   296 C C6    . DT  B 3 7  . 14.759  21.156 12.429 1.00 37.72 7  DT  B C6    1
+ATOM   297 N N1    . DT  B 3 7  . 14.560  21.650 11.168 1.00 36.68 7  DT  B N1    1
+ATOM   298 C C2    . DT  B 3 7  . 14.255  23.016 11.004 1.00 34.03 7  DT  B C2    1
+ATOM   299 N N3    . DT  B 3 7  . 14.183  23.789 12.163 1.00 27.38 7  DT  B N3    1
+ATOM   300 C C4    . DT  B 3 7  . 14.414  23.337 13.439 1.00 28.75 7  DT  B C4    1
+ATOM   301 O O2    . DT  B 3 7  . 14.084  23.564 9.916  1.00 38.93 7  DT  B O2    1
+ATOM   302 O O4    . DT  B 3 7  . 14.364  24.118 14.385 1.00 22.67 7  DT  B O4    1
+ATOM   303 C C7    . DT  B 3 7  . 14.928  21.237 14.861 1.00 34.03 7  DT  B C7    1
+ATOM   304 P P     . DC  B 3 8  . 17.414  18.706 6.975  1.00 47.22 8  DC  B P     1
+ATOM   305 O OP1   . DC  B 3 8  . 16.998  18.286 5.608  1.00 37.69 8  DC  B OP1   1
+ATOM   306 O OP2   . DC  B 3 8  . 18.608  18.053 7.589  1.00 47.07 8  DC  B OP2   1
+ATOM   307 O 'O5'' . DC  B 3 8  . 17.671  20.344 7.014  1.00 43.51 8  DC  B 'O5'' 1
+ATOM   308 C 'C5'' . DC  B 3 8  . 16.786  21.179 6.244  1.00 41.32 8  DC  B 'C5'' 1
+ATOM   309 C 'C4'' . DC  B 3 8  . 16.960  22.673 6.356  1.00 32.67 8  DC  B 'C4'' 1
+ATOM   310 O 'O4'' . DC  B 3 8  . 16.732  23.061 7.690  1.00 30.72 8  DC  B 'O4'' 1
+ATOM   311 C 'C3'' . DC  B 3 8  . 18.303  23.241 5.900  1.00 31.47 8  DC  B 'C3'' 1
+ATOM   312 O 'O3'' . DC  B 3 8  . 18.100  24.057 4.730  1.00 29.26 8  DC  B 'O3'' 1
+ATOM   313 C 'C2'' . DC  B 3 8  . 18.745  24.097 7.078  1.00 24.83 8  DC  B 'C2'' 1
+ATOM   314 C 'C1'' . DC  B 3 8  . 17.491  24.283 7.909  1.00 29.88 8  DC  B 'C1'' 1
+ATOM   315 C C5    . DC  B 3 8  . 18.275  23.155 11.348 1.00 27.17 8  DC  B C5    1
+ATOM   316 C C6    . DC  B 3 8  . 18.170  23.214 10.008 1.00 29.26 8  DC  B C6    1
+ATOM   317 N N1    . DC  B 3 8  . 17.708  24.333 9.376  1.00 28.61 8  DC  B N1    1
+ATOM   318 C C2    . DC  B 3 8  . 17.321  25.452 10.101 1.00 20.05 8  DC  B C2    1
+ATOM   319 N N3    . DC  B 3 8  . 17.400  25.381 11.452 1.00 14.19 8  DC  B N3    1
+ATOM   320 C C4    . DC  B 3 8  . 17.837  24.297 12.077 1.00 22.77 8  DC  B C4    1
+ATOM   321 O O2    . DC  B 3 8  . 16.955  26.496 9.562  1.00 19.43 8  DC  B O2    1
+ATOM   322 N N4    . DC  B 3 8  . 17.875  24.272 13.405 1.00 22.65 8  DC  B N4    1
+ATOM   323 N N     . THR C 3 1  . 4.252   21.376 10.447 1.00 28.75 1  THR C N     1
+ATOM   324 C CA    . THR C 3 1  . 4.114   19.994 10.022 1.00 29.48 1  THR C CA    1
+ATOM   325 C C     . THR C 3 1  . 5.197   19.213 10.665 1.00 36.33 1  THR C C     1
+ATOM   326 C CB    . THR C 3 1  . 4.174   19.643 8.531  1.00 29.73 1  THR C CB    1
+ATOM   327 O O     . THR C 3 1  . 6.384   19.562 10.694 1.00 34.94 1  THR C O     1
+ATOM   328 C CG2   . THR C 3 1  . 3.088   20.389 7.760  1.00 37.51 1  THR C CG2   1
+ATOM   329 O OG1   . THR C 3 1  . 5.492   19.959 8.017  1.00 34.21 1  THR C OG1   1
+ATOM   330 N N     . DVA C 3 2  . 4.588   18.204 11.274 1.00 44.85 2  DVA C N     1
+ATOM   331 C CA    . DVA C 3 2  . 5.287   16.993 11.630 1.00 41.03 2  DVA C CA    1
+ATOM   332 C C     . DVA C 3 2  . 5.766   16.989 13.064 1.00 34.73 2  DVA C C     1
+ATOM   333 C CB    . DVA C 3 2  . 4.343   15.795 11.333 1.00 51.07 2  DVA C CB    1
+ATOM   334 O O     . DVA C 3 2  . 4.957   17.363 13.908 1.00 35.69 2  DVA C O     1
+ATOM   335 C CG1   . DVA C 3 2  . 4.345   14.623 12.319 1.00 53.60 2  DVA C CG1   1
+ATOM   336 C CG2   . DVA C 3 2  . 4.472   15.285 9.890  1.00 51.47 2  DVA C CG2   1
+ATOM   337 N N     . PRO C 3 3  . 6.994   16.595 13.409 1.00 34.65 3  PRO C N     1
+ATOM   338 C CA    . PRO C 3 3  . 8.109   16.343 12.480 1.00 37.94 3  PRO C CA    1
+ATOM   339 C C     . PRO C 3 3  . 7.826   15.274 11.409 1.00 38.45 3  PRO C C     1
+ATOM   340 C CB    . PRO C 3 3  . 9.265   15.879 13.388 1.00 29.99 3  PRO C CB    1
+ATOM   341 O O     . PRO C 3 3  . 7.318   14.211 11.787 1.00 42.61 3  PRO C O     1
+ATOM   342 C CG    . PRO C 3 3  . 8.821   16.195 14.793 1.00 34.51 3  PRO C CG    1
+ATOM   343 C CD    . PRO C 3 3  . 7.303   16.050 14.729 1.00 35.14 3  PRO C CD    1
+ATOM   344 N N     . SAR C 3 4  . 8.041   15.504 10.100 1.00 34.28 4  SAR C N     1
+ATOM   345 C CA    . SAR C 3 4  . 8.545   16.750 9.530  1.00 34.55 4  SAR C CA    1
+ATOM   346 C C     . SAR C 3 4  . 7.672   17.386 8.444  1.00 42.07 4  SAR C C     1
+ATOM   347 O O     . SAR C 3 4  . 6.566   16.908 8.189  1.00 49.04 4  SAR C O     1
+ATOM   348 N N     . MVA C 3 5  . 8.086   18.473 7.779  1.00 41.41 5  MVA C N     1
+ATOM   349 C CA    . MVA C 3 5  . 7.440   19.139 6.645  1.00 35.08 5  MVA C CA    1
+ATOM   350 C C     . MVA C 3 5  . 5.931   19.395 6.804  1.00 38.77 5  MVA C C     1
+ATOM   351 C CB    . MVA C 3 5  . 7.890   18.478 5.289  1.00 24.16 5  MVA C CB    1
+ATOM   352 O O     . MVA C 3 5  . 5.265   19.621 5.781  1.00 49.27 5  MVA C O     1
+ATOM   353 C CG1   . MVA C 3 5  . 7.168   17.203 4.968  1.00 26.44 5  MVA C CG1   1
+ATOM   354 C CG2   . MVA C 3 5  . 7.828   19.398 4.080  1.00 13.25 5  MVA C CG2   1
+HETATM 355 C C1    . PXA C 3 6  . 3.110   23.480 10.908 1.00 19.18 6  PXA C C1    1
+HETATM 356 C C0    . PXA C 3 6  . 3.145   22.068 10.722 1.00 29.27 6  PXA C C0    1
+HETATM 357 O O1    . PXA C 3 6  . 2.091   21.438 10.818 1.00 43.62 6  PXA C O1    1
+HETATM 358 C C2    . PXA C 3 6  . 2.872   24.319 9.798  1.00 20.52 6  PXA C C2    1
+HETATM 359 N N2    . PXA C 3 6  . 2.694   23.793 8.592  1.00 31.34 6  PXA C N2    1
+HETATM 360 C C3    . PXA C 3 6  . 2.812   25.733 9.935  1.00 18.26 6  PXA C C3    1
+HETATM 361 O O3    . PXA C 3 6  . 2.591   26.436 8.943  1.00 19.24 6  PXA C O3    1
+HETATM 362 C C4    . PXA C 3 6  . 2.996   26.334 11.199 1.00 16.69 6  PXA C C4    1
+HETATM 363 O O5    . PXA C 3 6  . 3.403   26.063 13.558 1.00 17.97 6  PXA C O5    1
+HETATM 364 C C6    . PXA C 3 6  . 3.768   25.785 15.972 1.00 24.16 6  PXA C C6    1
+HETATM 365 C C7    . PXA C 3 6  . 3.961   24.852 17.007 1.00 20.55 6  PXA C C7    1
+HETATM 366 N N8    . PXA C 3 6  . 3.984   23.551 16.753 1.00 23.49 6  PXA C N8    1
+HETATM 367 C C9    . PXA C 3 6  . 3.835   23.024 15.552 1.00 28.76 6  PXA C C9    1
+HETATM 368 C 'C0'' . PXA C 3 6  . 3.859   21.639 15.347 1.00 38.08 6  PXA C 'C0'' 1
+HETATM 369 O 'O1'' . PXA C 3 6  . 4.929   21.107 15.078 1.00 53.00 6  PXA C 'O1'' 1
+HETATM 370 N N10   . PXA C 3 6  . 3.490   23.340 13.240 1.00 11.63 6  PXA C N10   1
+HETATM 371 C C11   . PXA C 3 6  . 3.287   24.081 12.176 1.00 15.22 6  PXA C C11   1
+HETATM 372 C C12   . PXA C 3 6  . 3.236   25.512 12.325 1.00 17.45 6  PXA C C12   1
+HETATM 373 C C13   . PXA C 3 6  . 3.604   25.273 14.642 1.00 22.27 6  PXA C C13   1
+HETATM 374 C C14   . PXA C 3 6  . 3.644   23.859 14.441 1.00 21.19 6  PXA C C14   1
+HETATM 375 C C15   . PXA C 3 6  . 2.916   27.849 11.345 1.00 15.08 6  PXA C C15   1
+HETATM 376 C C16   . PXA C 3 6  . 3.738   27.275 16.325 1.00 18.65 6  PXA C C16   1
+ATOM   377 N N     . THR C 3 7  . 2.732   20.931 15.409 1.00 42.34 7  THR C N     1
+ATOM   378 C CA    . THR C 3 7  . 2.798   19.477 15.209 1.00 46.50 7  THR C CA    1
+ATOM   379 C C     . THR C 3 7  . 1.675   18.945 14.356 1.00 42.04 7  THR C C     1
+ATOM   380 C CB    . THR C 3 7  . 2.732   18.640 16.484 1.00 47.70 7  THR C CB    1
+ATOM   381 O O     . THR C 3 7  . 0.580   19.524 14.325 1.00 36.98 7  THR C O     1
+ATOM   382 C CG2   . THR C 3 7  . 4.017   18.668 17.283 1.00 42.77 7  THR C CG2   1
+ATOM   383 O OG1   . THR C 3 7  . 1.581   19.110 17.218 1.00 48.30 7  THR C OG1   1
+ATOM   384 N N     . DVA C 3 8  . 1.963   17.829 13.682 1.00 33.77 8  DVA C N     1
+ATOM   385 C CA    . DVA C 3 8  . 0.897   17.195 12.940 1.00 39.54 8  DVA C CA    1
+ATOM   386 C C     . DVA C 3 8  . 0.831   17.751 11.526 1.00 43.35 8  DVA C C     1
+ATOM   387 C CB    . DVA C 3 8  . 1.037   15.678 12.941 1.00 37.91 8  DVA C CB    1
+ATOM   388 O O     . DVA C 3 8  . 1.722   17.396 10.751 1.00 48.88 8  DVA C O     1
+ATOM   389 C CG1   . DVA C 3 8  . -0.106  14.986 12.217 1.00 34.46 8  DVA C CG1   1
+ATOM   390 C CG2   . DVA C 3 8  . 1.128   15.189 14.366 1.00 42.02 8  DVA C CG2   1
+ATOM   391 N N     . PRO C 3 9  . -0.105  18.631 11.119 1.00 44.11 9  PRO C N     1
+ATOM   392 C CA    . PRO C 3 9  . -1.182  19.199 11.948 1.00 37.28 9  PRO C CA    1
+ATOM   393 C C     . PRO C 3 9  . -2.215  18.190 12.418 1.00 27.92 9  PRO C C     1
+ATOM   394 C CB    . PRO C 3 9  . -1.784  20.209 11.004 1.00 34.81 9  PRO C CB    1
+ATOM   395 O O     . PRO C 3 9  . -2.478  17.275 11.633 1.00 32.50 9  PRO C O     1
+ATOM   396 C CG    . PRO C 3 9  . -1.567  19.658 9.625  1.00 30.90 9  PRO C CG    1
+ATOM   397 C CD    . PRO C 3 9  . -0.143  19.198 9.769  1.00 39.19 9  PRO C CD    1
+ATOM   398 N N     . SAR C 3 10 . -2.793  18.226 13.622 1.00 23.40 10 SAR C N     1
+ATOM   399 C CA    . SAR C 3 10 . -2.556  19.125 14.725 1.00 33.03 10 SAR C CA    1
+ATOM   400 C C     . SAR C 3 10 . -1.892  18.440 15.925 1.00 38.97 10 SAR C C     1
+ATOM   401 O O     . SAR C 3 10 . -1.748  17.216 15.927 1.00 45.95 10 SAR C O     1
+ATOM   402 N N     . MVA C 3 11 . -1.465  19.154 16.982 1.00 44.37 11 MVA C N     1
+ATOM   403 C CA    . MVA C 3 11 . -0.683  18.723 18.129 1.00 47.99 11 MVA C CA    1
+ATOM   404 C C     . MVA C 3 11 . 0.639   18.160 17.609 1.00 48.61 11 MVA C C     1
+ATOM   405 C CB    . MVA C 3 11 . -1.465  17.789 19.105 1.00 49.25 11 MVA C CB    1
+ATOM   406 O O     . MVA C 3 11 . 0.731   16.982 17.226 1.00 42.02 11 MVA C O     1
+ATOM   407 C CG1   . MVA C 3 11 . -0.606  17.480 20.321 1.00 50.89 11 MVA C CG1   1
+ATOM   408 C CG2   . MVA C 3 11 . -2.735  18.448 19.631 1.00 44.90 11 MVA C CG2   1
+#

--- a/data/test/721p-assembly1.cif
+++ b/data/test/721p-assembly1.cif
@@ -1,0 +1,3446 @@
+data_721P-ASSEMBLY1
+#
+loop_
+_audit_author.name
+_audit_author.pdbx_ordinal
+'Krengel, U.'      1
+'Scherer, A.'      2
+'Kabsch, W.'       3
+'Wittinghofer, A.' 4
+'Pai, E.F.'        5
+#
+_struct.entry_id                  XXXX
+_struct.title                     'THREE-DIMENSIONAL STRUCTURES OF H-RAS P21 MUTANTS: MOLECULAR BASIS FOR THEIR INABILITY TO FUNCTION AS SIGNAL SWITCH MOLECULES'
+_struct.pdbx_model_details        ?
+_struct.pdbx_CASP_flag            ?
+_struct.pdbx_model_type_details   ?
+#
+_struct_keywords.entry_id        XXXX
+_struct_keywords.pdbx_keywords   'ONCOGENE PROTEIN'
+_struct_keywords.text            'ONCOGENE PROTEIN'
+#
+_exptl.entry_id          XXXX
+_exptl.method            'X-RAY DIFFRACTION'
+_exptl.crystals_number   ?
+#
+loop_
+_citation.id
+_citation.title
+_citation.journal_abbrev
+_citation.journal_volume
+_citation.page_first
+_citation.page_last
+_citation.year
+_citation.journal_id_ASTM
+_citation.country
+_citation.journal_id_ISSN
+_citation.journal_id_CSD
+_citation.book_publisher
+_citation.pdbx_database_id_PubMed
+_citation.pdbx_database_id_DOI
+primary 'Three-dimensional structures of H-ras p21 mutants: molecular basis for their inability to function as signal switch molecules.'                         Cell(Cambridge,Mass.) 62 539  548 1990 CELLB5 US 0092-8674 0998 ? 2199064 10.1016/0092-8674(90)90018-A
+1       'Refined Crystal Structure of the Triphosphate Conformation of H-Ras P21 at 1.35 Angstroms Resolution: Implications for the Mechanism of GTP Hydrolysis' 'Embo J.'             9  2351 ?   1990 EMJODG UK 0261-4189 0897 ? ?       ?
+#
+loop_
+_citation_author.citation_id
+_citation_author.name
+_citation_author.ordinal
+primary 'Krengel, U.'      1
+primary 'Schlichting, I.'  2
+primary 'Scherer, A.'      3
+primary 'Schumann, R.'     4
+primary 'Frech, M.'        5
+primary 'John, J.'         6
+primary 'Kabsch, W.'       7
+primary 'Pai, E.F.'        8
+primary 'Wittinghofer, A.' 9
+1       'Pai, E.F.'        10
+1       'Krengel, U.'      11
+1       'Petsko, G.A.'     12
+1       'Goody, R.S.'      13
+1       'Kabsch, W.'       14
+1       'Wittinghofer, A.' 15
+#
+_struct_conf_type.id          HELX_P
+_struct_conf_type.criteria    ?
+_struct_conf_type.reference   ?
+#
+loop_
+_struct_conf.conf_type_id
+_struct_conf.id
+_struct_conf.pdbx_PDB_helix_id
+_struct_conf.beg_label_comp_id
+_struct_conf.beg_label_asym_id
+_struct_conf.beg_label_seq_id
+_struct_conf.pdbx_beg_PDB_ins_code
+_struct_conf.end_label_comp_id
+_struct_conf.end_label_asym_id
+_struct_conf.end_label_seq_id
+_struct_conf.pdbx_end_PDB_ins_code
+_struct_conf.beg_auth_comp_id
+_struct_conf.beg_auth_asym_id
+_struct_conf.beg_auth_seq_id
+_struct_conf.end_auth_comp_id
+_struct_conf.end_auth_asym_id
+_struct_conf.end_auth_seq_id
+_struct_conf.pdbx_PDB_helix_class
+_struct_conf.details
+_struct_conf.pdbx_PDB_helix_length
+HELX_P HELX_P1  AA1 LYS A   16  ? GLN A   25  ? LYS A   16  GLN A   25  1 ?                 10
+HELX_P HELX_P2  AA2 ALA A   66  ? THR A   74  ? ALA A   66  THR A   74  1 ?                 9
+HELX_P HELX_P3  AA3 THR A   87  ? VAL A   103 ? THR A   87  VAL A   103 1 'BREAK AT ASP 92' 17
+HELX_P HELX_P4  AA4 SER A   127 ? SER A   136 ? SER A   127 SER A   136 1 ?                 10
+HELX_P HELX_P5  AA5 VAL A   152 ? GLN A   165 ? VAL A   152 GLN A   165 1 ?                 14
+HELX_P HELX_P6  AA6 LYS A-2 16  ? GLN A-2 25  ? LYS A-2 16  GLN A-2 25  1 ?                 10
+HELX_P HELX_P7  AA7 ALA A-2 66  ? THR A-2 74  ? ALA A-2 66  THR A-2 74  1 ?                 9
+HELX_P HELX_P8  AA8 THR A-2 87  ? VAL A-2 103 ? THR A-2 87  VAL A-2 103 1 'BREAK AT ASP 92' 17
+HELX_P HELX_P9  AA9 SER A-2 127 ? SER A-2 136 ? SER A-2 127 SER A-2 136 1 ?                 10
+HELX_P HELX_P10 AB1 VAL A-2 152 ? GLN A-2 165 ? VAL A-2 152 GLN A-2 165 1 ?                 14
+#
+loop_
+_struct_sheet.id
+_struct_sheet.type
+_struct_sheet.number_strands
+_struct_sheet.details
+AA1 ? 6 ?
+AA2 ? 6 ?
+#
+loop_
+_struct_sheet_order.sheet_id
+_struct_sheet_order.range_id_1
+_struct_sheet_order.range_id_2
+_struct_sheet_order.offset
+_struct_sheet_order.sense
+AA1 1 2 ? anti-parallel
+AA1 2 3 ? parallel
+AA1 3 4 ? parallel
+AA1 4 5 ? parallel
+AA1 5 6 ? parallel
+AA2 1 2 ? anti-parallel
+AA2 2 3 ? parallel
+AA2 3 4 ? parallel
+AA2 4 5 ? parallel
+AA2 5 6 ? parallel
+#
+loop_
+_struct_sheet_range.sheet_id
+_struct_sheet_range.id
+_struct_sheet_range.beg_label_comp_id
+_struct_sheet_range.beg_label_asym_id
+_struct_sheet_range.beg_label_seq_id
+_struct_sheet_range.pdbx_beg_PDB_ins_code
+_struct_sheet_range.end_label_comp_id
+_struct_sheet_range.end_label_asym_id
+_struct_sheet_range.end_label_seq_id
+_struct_sheet_range.pdbx_end_PDB_ins_code
+_struct_sheet_range.beg_auth_comp_id
+_struct_sheet_range.beg_auth_asym_id
+_struct_sheet_range.beg_auth_seq_id
+_struct_sheet_range.end_auth_comp_id
+_struct_sheet_range.end_auth_asym_id
+_struct_sheet_range.end_auth_seq_id
+AA1 1 GLU A   37  ? ILE A   46  ? GLU A   37  ILE A   46
+AA1 2 GLU A   49  ? THR A   58  ? GLU A   49  THR A   58
+AA1 3 THR A   2   ? GLY A   10  ? THR A   2   GLY A   10
+AA1 4 GLY A   77  ? ALA A   83  ? GLY A   77  ALA A   83
+AA1 5 MET A   111 ? ASN A   116 ? MET A   111 ASN A   116
+AA1 6 TYR A   141 ? GLU A   143 ? TYR A   141 GLU A   143
+AA2 1 GLU A-2 37  ? ILE A-2 46  ? GLU A-2 37  ILE A-2 46
+AA2 2 GLU A-2 49  ? THR A-2 58  ? GLU A-2 49  THR A-2 58
+AA2 3 THR A-2 2   ? GLY A-2 10  ? THR A-2 2   GLY A-2 10
+AA2 4 GLY A-2 77  ? ALA A-2 83  ? GLY A-2 77  ALA A-2 83
+AA2 5 MET A-2 111 ? ASN A-2 116 ? MET A-2 111 ASN A-2 116
+AA2 6 TYR A-2 141 ? GLU A-2 143 ? TYR A-2 141 GLU A-2 143
+#
+loop_
+_pdbx_struct_oper_list.id
+_pdbx_struct_oper_list.type
+_pdbx_struct_oper_list.name
+_pdbx_struct_oper_list.symmetry_operation
+_pdbx_struct_oper_list.matrix[1][1]
+_pdbx_struct_oper_list.matrix[1][2]
+_pdbx_struct_oper_list.matrix[1][3]
+_pdbx_struct_oper_list.vector[1]
+_pdbx_struct_oper_list.matrix[2][1]
+_pdbx_struct_oper_list.matrix[2][2]
+_pdbx_struct_oper_list.matrix[2][3]
+_pdbx_struct_oper_list.vector[2]
+_pdbx_struct_oper_list.matrix[3][1]
+_pdbx_struct_oper_list.matrix[3][2]
+_pdbx_struct_oper_list.matrix[3][3]
+_pdbx_struct_oper_list.vector[3]
+1 'identity operation'         1_555 x,y,z  1.0000000000  0.0000000000 0.0000000000 0.0000000000 0.0000000000 1.0000000000 0.0000000000 0.0000000000 0.0000000000 0.0000000000 1.0000000000  0.0000000000
+2 'crystal symmetry operation' 4_555 y,x,-z -0.5000000000 0.8660254038 0.0000000000 0.0000000000 0.8660254038 0.5000000000 0.0000000000 0.0000000000 0.0000000000 0.0000000000 -1.0000000000 0.0000000000
+#
+_atom_sites.entry_id                    XXXX
+_atom_sites.fract_transf_matrix[1][1]   0.024814
+_atom_sites.fract_transf_matrix[1][2]   0.014326
+_atom_sites.fract_transf_matrix[1][3]   0.000000
+_atom_sites.fract_transf_matrix[2][1]   0.000000
+_atom_sites.fract_transf_matrix[2][2]   0.028653
+_atom_sites.fract_transf_matrix[2][3]   0.000000
+_atom_sites.fract_transf_matrix[3][1]   0.000000
+_atom_sites.fract_transf_matrix[3][2]   0.000000
+_atom_sites.fract_transf_matrix[3][3]   0.006223
+_atom_sites.fract_transf_vector[1]      0.00000
+_atom_sites.fract_transf_vector[2]      0.00000
+_atom_sites.fract_transf_vector[3]      0.00000
+#
+_entry.id   721P-ASSEMBLY1
+#
+loop_
+_pdbx_chain_remapping.entity_id
+_pdbx_chain_remapping.label_asym_id
+_pdbx_chain_remapping.auth_asym_id
+_pdbx_chain_remapping.orig_label_asym_id
+_pdbx_chain_remapping.orig_auth_asym_id
+_pdbx_chain_remapping.applied_operations
+1 A   A   A A 1
+1 A-2 A-2 A A 2
+2 B   A   B A 1
+3 C   A   C A 1
+2 B-2 A-2 B A 2
+3 C-2 A-2 C A 2
+4 D   A   D A 1
+4 D-2 A-2 D A 2
+#
+loop_
+_pdbx_entity_nonpoly.entity_id
+_pdbx_entity_nonpoly.name
+_pdbx_entity_nonpoly.comp_id
+2 'MAGNESIUM ION'                               MG
+3 'PHOSPHOAMINOPHOSPHONIC ACID-GUANYLATE ESTER' GNP
+4 water                                         HOH
+#
+loop_
+_pdbx_entity_remapping.entity_id
+_pdbx_entity_remapping.orig_entity_id
+1 1
+2 2
+3 3
+4 4
+#
+loop_
+_pdbx_struct_sheet_hbond.sheet_id
+_pdbx_struct_sheet_hbond.range_id_1
+_pdbx_struct_sheet_hbond.range_id_2
+_pdbx_struct_sheet_hbond.range_1_label_atom_id
+_pdbx_struct_sheet_hbond.range_1_label_comp_id
+_pdbx_struct_sheet_hbond.range_1_label_asym_id
+_pdbx_struct_sheet_hbond.range_1_label_seq_id
+_pdbx_struct_sheet_hbond.range_1_PDB_ins_code
+_pdbx_struct_sheet_hbond.range_1_auth_atom_id
+_pdbx_struct_sheet_hbond.range_1_auth_comp_id
+_pdbx_struct_sheet_hbond.range_1_auth_asym_id
+_pdbx_struct_sheet_hbond.range_1_auth_seq_id
+_pdbx_struct_sheet_hbond.range_2_label_atom_id
+_pdbx_struct_sheet_hbond.range_2_label_comp_id
+_pdbx_struct_sheet_hbond.range_2_label_asym_id
+_pdbx_struct_sheet_hbond.range_2_label_seq_id
+_pdbx_struct_sheet_hbond.range_2_PDB_ins_code
+_pdbx_struct_sheet_hbond.range_2_auth_atom_id
+_pdbx_struct_sheet_hbond.range_2_auth_comp_id
+_pdbx_struct_sheet_hbond.range_2_auth_asym_id
+_pdbx_struct_sheet_hbond.range_2_auth_seq_id
+AA1 1 2 N LYS A   42  ? N LYS A   42  O LEU A   53  ? O LEU A   53
+AA1 2 3 O ASP A   54  ? O ASP A   54  N LEU A   6   ? N LEU A   6
+AA1 3 4 O VAL A   7   ? O VAL A   7   N LEU A   79  ? N LEU A   79
+AA1 4 5 O CYS A   80  ? O CYS A   80  N VAL A   114 ? N VAL A   114
+AA1 5 6 O LEU A   113 ? O LEU A   113 N ILE A   142 ? N ILE A   142
+AA2 1 2 N LYS A-2 42  ? N LYS A-2 42  O LEU A-2 53  ? O LEU A-2 53
+AA2 2 3 O ASP A-2 54  ? O ASP A-2 54  N LEU A-2 6   ? N LEU A-2 6
+AA2 3 4 O VAL A-2 7   ? O VAL A-2 7   N LEU A-2 79  ? N LEU A-2 79
+AA2 4 5 O CYS A-2 80  ? O CYS A-2 80  N VAL A-2 114 ? N VAL A-2 114
+AA2 5 6 O LEU A-2 113 ? O LEU A-2 113 N ILE A-2 142 ? N ILE A-2 142
+#
+loop_
+_pdbx_audit_revision_history.revision_date
+1994-01-31
+2008-03-03
+2011-07-13
+2012-03-07
+2017-11-29
+#
+_refine.ls_d_res_high   2.0
+#
+loop_
+_ma_target_entity_instance.asym_id
+_ma_target_entity_instance.entity_id
+_ma_target_entity_instance.details
+A 1 .
+B 1 .
+A 2 .
+B 2 .
+A 3 .
+B 3 .
+A 4 .
+B 4 .
+#
+loop_
+_ma_target_entity.entity_id
+_ma_target_entity.data_id
+_ma_target_entity.origin
+1 1 .
+1 1 .
+2 1 .
+2 1 .
+3 1 .
+3 1 .
+4 1 .
+4 1 .
+#
+loop_
+_atom_type.symbol
+C
+M
+N
+O
+P
+S
+#
+loop_
+_struct_asym.id
+_struct_asym.entity_id
+A 1
+B 1
+A 2
+B 2
+A 3
+B 3
+A 4
+B 4
+#
+loop_
+_entity.id
+_entity.type
+1 polymer
+2 polymer
+3 polymer
+4 polymer
+#
+loop_
+_entity_poly.entity_id
+_entity_poly.type
+_entity_poly.pdbx_strand_id
+1 polypeptide(L) A,B
+2 polypeptide(L) A,B
+3 polypeptide(L) A,B
+4 polypeptide(L) A,B
+#
+loop_
+_pdbx_struct_assembly_gen.assembly_id
+#
+loop_
+_chem_comp.id
+_chem_comp.formula
+_chem_comp.formula_weight
+_chem_comp.mon_nstd_flag
+_chem_comp.name
+_chem_comp.type
+ASN 'C4 H8 N2 O3'       132.118 y ASPARAGINE                                    'L-peptide linking'
+THR 'C4 H9 N O3'        119.119 y THREONINE                                     'L-peptide linking'
+GLU 'C5 H9 N O4'        147.129 y 'GLUTAMIC ACID'                               'L-peptide linking'
+ILE 'C6 H13 N O2'       131.173 y ISOLEUCINE                                    'L-peptide linking'
+PHE 'C9 H11 N O2'       165.189 y PHENYLALANINE                                 'L-peptide linking'
+GLY 'C2 H5 N O2'        75.067  y GLYCINE                                       'peptide linking'
+SER 'C3 H7 N O3'        105.093 y SERINE                                        'L-peptide linking'
+VAL 'C5 H11 N O2'       117.146 y VALINE                                        'L-peptide linking'
+MET 'C5 H11 N O2 S'     149.211 y METHIONINE                                    'L-peptide linking'
+GNP 'C10 H17 N6 O13 P3' 522.196 . 'PHOSPHOAMINOPHOSPHONIC ACID-GUANYLATE ESTER' non-polymer
+ALA 'C3 H7 N O2'        89.093  y ALANINE                                       'L-peptide linking'
+LYS 'C6 H15 N2 O2 1'    147.195 y LYSINE                                        'L-peptide linking'
+ARG 'C6 H15 N4 O2 1'    175.209 y ARGININE                                      'L-peptide linking'
+LEU 'C6 H13 N O2'       131.173 y LEUCINE                                       'L-peptide linking'
+CYS 'C3 H7 N O2 S'      121.158 y CYSTEINE                                      'L-peptide linking'
+TYR 'C9 H11 N O3'       181.189 y TYROSINE                                      'L-peptide linking'
+PRO 'C5 H9 N O2'        115.130 y PROLINE                                       'L-peptide linking'
+GLN 'C5 H10 N2 O3'      146.144 y GLUTAMINE                                     'L-peptide linking'
+HIS 'C6 H10 N3 O2 1'    156.162 y HISTIDINE                                     'L-peptide linking'
+ASP 'C4 H7 N O4'        133.103 y 'ASPARTIC ACID'                               'L-peptide linking'
+MG  'Mg 2'              24.305  . 'MAGNESIUM ION'                               non-polymer
+#
+loop_
+_pdbx_poly_seq_scheme.asym_id
+_pdbx_poly_seq_scheme.entity_id
+_pdbx_poly_seq_scheme.seq_id
+_pdbx_poly_seq_scheme.auth_seq_num
+_pdbx_poly_seq_scheme.pdb_seq_num
+_pdbx_poly_seq_scheme.mon_id
+_pdbx_poly_seq_scheme.auth_mon_id
+_pdbx_poly_seq_scheme.pdb_mon_id
+_pdbx_poly_seq_scheme.hetero
+A 4 1   1   1   MET MET MET n
+A 4 2   2   2   THR THR THR n
+A 4 3   3   3   GLU GLU GLU n
+A 4 4   4   4   TYR TYR TYR n
+A 4 5   5   5   LYS LYS LYS n
+A 4 6   6   6   LEU LEU LEU n
+A 4 7   7   7   VAL VAL VAL n
+A 4 8   8   8   VAL VAL VAL n
+A 4 9   9   9   VAL VAL VAL n
+A 4 10  10  10  GLY GLY GLY n
+A 4 11  11  11  ALA ALA ALA n
+A 4 12  12  12  GLY GLY GLY n
+A 4 13  13  13  GLY GLY GLY n
+A 4 14  14  14  VAL VAL VAL n
+A 4 15  15  15  GLY GLY GLY n
+A 4 16  16  16  LYS LYS LYS n
+A 4 17  17  17  SER SER SER n
+A 4 18  18  18  ALA ALA ALA n
+A 4 19  19  19  LEU LEU LEU n
+A 4 20  20  20  THR THR THR n
+A 4 21  21  21  ILE ILE ILE n
+A 4 22  22  22  GLN GLN GLN n
+A 4 23  23  23  LEU LEU LEU n
+A 4 24  24  24  ILE ILE ILE n
+A 4 25  25  25  GLN GLN GLN n
+A 4 26  26  26  ASN ASN ASN n
+A 4 27  27  27  HIS HIS HIS n
+A 4 28  28  28  PHE PHE PHE n
+A 4 29  29  29  VAL VAL VAL n
+A 4 30  30  30  ASP ASP ASP n
+A 4 31  31  31  GLU GLU GLU n
+A 4 32  32  32  TYR TYR TYR n
+A 4 33  33  33  ASP ASP ASP n
+A 4 34  34  34  PRO PRO PRO n
+A 4 35  35  35  THR THR THR n
+A 4 36  36  36  ILE ILE ILE n
+A 4 37  37  37  GLU GLU GLU n
+A 4 38  38  38  ASP ASP ASP n
+A 4 39  39  39  SER SER SER n
+A 4 40  40  40  TYR TYR TYR n
+A 4 41  41  41  ARG ARG ARG n
+A 4 42  42  42  LYS LYS LYS n
+A 4 43  43  43  GLN GLN GLN n
+A 4 44  44  44  VAL VAL VAL n
+A 4 45  45  45  VAL VAL VAL n
+A 4 46  46  46  ILE ILE ILE n
+A 4 47  47  47  ASP ASP ASP n
+A 4 48  48  48  GLY GLY GLY n
+A 4 49  49  49  GLU GLU GLU n
+A 4 50  50  50  THR THR THR n
+A 4 51  51  51  CYS CYS CYS n
+A 4 52  52  52  LEU LEU LEU n
+A 4 53  53  53  LEU LEU LEU n
+A 4 54  54  54  ASP ASP ASP n
+A 4 55  55  55  ILE ILE ILE n
+A 4 56  56  56  LEU LEU LEU n
+A 4 57  57  57  ASP ASP ASP n
+A 4 58  58  58  THR THR THR n
+A 4 59  59  59  ALA ALA ALA n
+A 4 60  60  60  GLY GLY GLY n
+A 4 61  61  61  LEU LEU LEU n
+A 4 62  62  62  GLU GLU GLU n
+A 4 63  63  63  GLU GLU GLU n
+A 4 64  64  64  TYR TYR TYR n
+A 4 65  65  65  SER SER SER n
+A 4 66  66  66  ALA ALA ALA n
+A 4 67  67  67  MET MET MET n
+A 4 68  68  68  ARG ARG ARG n
+A 4 69  69  69  ASP ASP ASP n
+A 4 70  70  70  GLN GLN GLN n
+A 4 71  71  71  TYR TYR TYR n
+A 4 72  72  72  MET MET MET n
+A 4 73  73  73  ARG ARG ARG n
+A 4 74  74  74  THR THR THR n
+A 4 75  75  75  GLY GLY GLY n
+A 4 76  76  76  GLU GLU GLU n
+A 4 77  77  77  GLY GLY GLY n
+A 4 78  78  78  PHE PHE PHE n
+A 4 79  79  79  LEU LEU LEU n
+A 4 80  80  80  CYS CYS CYS n
+A 4 81  81  81  VAL VAL VAL n
+A 4 82  82  82  PHE PHE PHE n
+A 4 83  83  83  ALA ALA ALA n
+A 4 84  84  84  ILE ILE ILE n
+A 4 85  85  85  ASN ASN ASN n
+A 4 86  86  86  ASN ASN ASN n
+A 4 87  87  87  THR THR THR n
+A 4 88  88  88  LYS LYS LYS n
+A 4 89  89  89  SER SER SER n
+A 4 90  90  90  PHE PHE PHE n
+A 4 91  91  91  GLU GLU GLU n
+A 4 92  92  92  ASP ASP ASP n
+A 4 93  93  93  ILE ILE ILE n
+A 4 94  94  94  HIS HIS HIS n
+A 4 95  95  95  GLN GLN GLN n
+A 4 96  96  96  TYR TYR TYR n
+A 4 97  97  97  ARG ARG ARG n
+A 4 98  98  98  GLU GLU GLU n
+A 4 99  99  99  GLN GLN GLN n
+A 4 100 100 100 ILE ILE ILE n
+A 4 101 101 101 LYS LYS LYS n
+A 4 102 102 102 ARG ARG ARG n
+A 4 103 103 103 VAL VAL VAL n
+A 4 104 104 104 LYS LYS LYS n
+A 4 105 105 105 ASP ASP ASP n
+A 4 106 106 106 SER SER SER n
+A 4 107 107 107 ASP ASP ASP n
+A 4 108 108 108 ASP ASP ASP n
+A 4 109 109 109 VAL VAL VAL n
+A 4 110 110 110 PRO PRO PRO n
+A 4 111 111 111 MET MET MET n
+A 4 112 112 112 VAL VAL VAL n
+A 4 113 113 113 LEU LEU LEU n
+A 4 114 114 114 VAL VAL VAL n
+A 4 115 115 115 GLY GLY GLY n
+A 4 116 116 116 ASN ASN ASN n
+A 4 117 117 117 LYS LYS LYS n
+A 4 118 118 118 CYS CYS CYS n
+A 4 119 119 119 ASP ASP ASP n
+A 4 120 120 120 LEU LEU LEU n
+A 4 121 121 121 ALA ALA ALA n
+A 4 122 122 122 ALA ALA ALA n
+A 4 123 123 123 ARG ARG ARG n
+A 4 124 124 124 THR THR THR n
+A 4 125 125 125 VAL VAL VAL n
+A 4 126 126 126 GLU GLU GLU n
+A 4 127 127 127 SER SER SER n
+A 4 128 128 128 ARG ARG ARG n
+A 4 129 129 129 GLN GLN GLN n
+A 4 130 130 130 ALA ALA ALA n
+A 4 131 131 131 GLN GLN GLN n
+A 4 132 132 132 ASP ASP ASP n
+A 4 133 133 133 LEU LEU LEU n
+A 4 134 134 134 ALA ALA ALA n
+A 4 135 135 135 ARG ARG ARG n
+A 4 136 136 136 SER SER SER n
+A 4 137 137 137 TYR TYR TYR n
+A 4 138 138 138 GLY GLY GLY n
+A 4 139 139 139 ILE ILE ILE n
+A 4 140 140 140 PRO PRO PRO n
+A 4 141 141 141 TYR TYR TYR n
+A 4 142 142 142 ILE ILE ILE n
+A 4 143 143 143 GLU GLU GLU n
+A 4 144 144 144 THR THR THR n
+A 4 145 145 145 SER SER SER n
+A 4 146 146 146 ALA ALA ALA n
+A 4 147 147 147 LYS LYS LYS n
+A 4 148 148 148 THR THR THR n
+A 4 149 149 149 ARG ARG ARG n
+A 4 150 150 150 GLN GLN GLN n
+A 4 151 151 151 GLY GLY GLY n
+A 4 152 152 152 VAL VAL VAL n
+A 4 153 153 153 GLU GLU GLU n
+A 4 154 154 154 ASP ASP ASP n
+A 4 155 155 155 ALA ALA ALA n
+A 4 156 156 156 PHE PHE PHE n
+A 4 157 157 157 TYR TYR TYR n
+A 4 158 158 158 THR THR THR n
+A 4 159 159 159 LEU LEU LEU n
+A 4 160 160 160 VAL VAL VAL n
+A 4 161 161 161 ARG ARG ARG n
+A 4 162 162 162 GLU GLU GLU n
+A 4 163 163 163 ILE ILE ILE n
+A 4 164 164 164 ARG ARG ARG n
+A 4 165 165 165 GLN GLN GLN n
+A 4 166 166 166 HIS HIS HIS n
+B 4 1   1   1   MET MET MET n
+B 4 2   2   2   THR THR THR n
+B 4 3   3   3   GLU GLU GLU n
+B 4 4   4   4   TYR TYR TYR n
+B 4 5   5   5   LYS LYS LYS n
+B 4 6   6   6   LEU LEU LEU n
+B 4 7   7   7   VAL VAL VAL n
+B 4 8   8   8   VAL VAL VAL n
+B 4 9   9   9   VAL VAL VAL n
+B 4 10  10  10  GLY GLY GLY n
+B 4 11  11  11  ALA ALA ALA n
+B 4 12  12  12  GLY GLY GLY n
+B 4 13  13  13  GLY GLY GLY n
+B 4 14  14  14  VAL VAL VAL n
+B 4 15  15  15  GLY GLY GLY n
+B 4 16  16  16  LYS LYS LYS n
+B 4 17  17  17  SER SER SER n
+B 4 18  18  18  ALA ALA ALA n
+B 4 19  19  19  LEU LEU LEU n
+B 4 20  20  20  THR THR THR n
+B 4 21  21  21  ILE ILE ILE n
+B 4 22  22  22  GLN GLN GLN n
+B 4 23  23  23  LEU LEU LEU n
+B 4 24  24  24  ILE ILE ILE n
+B 4 25  25  25  GLN GLN GLN n
+B 4 26  26  26  ASN ASN ASN n
+B 4 27  27  27  HIS HIS HIS n
+B 4 28  28  28  PHE PHE PHE n
+B 4 29  29  29  VAL VAL VAL n
+B 4 30  30  30  ASP ASP ASP n
+B 4 31  31  31  GLU GLU GLU n
+B 4 32  32  32  TYR TYR TYR n
+B 4 33  33  33  ASP ASP ASP n
+B 4 34  34  34  PRO PRO PRO n
+B 4 35  35  35  THR THR THR n
+B 4 36  36  36  ILE ILE ILE n
+B 4 37  37  37  GLU GLU GLU n
+B 4 38  38  38  ASP ASP ASP n
+B 4 39  39  39  SER SER SER n
+B 4 40  40  40  TYR TYR TYR n
+B 4 41  41  41  ARG ARG ARG n
+B 4 42  42  42  LYS LYS LYS n
+B 4 43  43  43  GLN GLN GLN n
+B 4 44  44  44  VAL VAL VAL n
+B 4 45  45  45  VAL VAL VAL n
+B 4 46  46  46  ILE ILE ILE n
+B 4 47  47  47  ASP ASP ASP n
+B 4 48  48  48  GLY GLY GLY n
+B 4 49  49  49  GLU GLU GLU n
+B 4 50  50  50  THR THR THR n
+B 4 51  51  51  CYS CYS CYS n
+B 4 52  52  52  LEU LEU LEU n
+B 4 53  53  53  LEU LEU LEU n
+B 4 54  54  54  ASP ASP ASP n
+B 4 55  55  55  ILE ILE ILE n
+B 4 56  56  56  LEU LEU LEU n
+B 4 57  57  57  ASP ASP ASP n
+B 4 58  58  58  THR THR THR n
+B 4 59  59  59  ALA ALA ALA n
+B 4 60  60  60  GLY GLY GLY n
+B 4 61  61  61  LEU LEU LEU n
+B 4 62  62  62  GLU GLU GLU n
+B 4 63  63  63  GLU GLU GLU n
+B 4 64  64  64  TYR TYR TYR n
+B 4 65  65  65  SER SER SER n
+B 4 66  66  66  ALA ALA ALA n
+B 4 67  67  67  MET MET MET n
+B 4 68  68  68  ARG ARG ARG n
+B 4 69  69  69  ASP ASP ASP n
+B 4 70  70  70  GLN GLN GLN n
+B 4 71  71  71  TYR TYR TYR n
+B 4 72  72  72  MET MET MET n
+B 4 73  73  73  ARG ARG ARG n
+B 4 74  74  74  THR THR THR n
+B 4 75  75  75  GLY GLY GLY n
+B 4 76  76  76  GLU GLU GLU n
+B 4 77  77  77  GLY GLY GLY n
+B 4 78  78  78  PHE PHE PHE n
+B 4 79  79  79  LEU LEU LEU n
+B 4 80  80  80  CYS CYS CYS n
+B 4 81  81  81  VAL VAL VAL n
+B 4 82  82  82  PHE PHE PHE n
+B 4 83  83  83  ALA ALA ALA n
+B 4 84  84  84  ILE ILE ILE n
+B 4 85  85  85  ASN ASN ASN n
+B 4 86  86  86  ASN ASN ASN n
+B 4 87  87  87  THR THR THR n
+B 4 88  88  88  LYS LYS LYS n
+B 4 89  89  89  SER SER SER n
+B 4 90  90  90  PHE PHE PHE n
+B 4 91  91  91  GLU GLU GLU n
+B 4 92  92  92  ASP ASP ASP n
+B 4 93  93  93  ILE ILE ILE n
+B 4 94  94  94  HIS HIS HIS n
+B 4 95  95  95  GLN GLN GLN n
+B 4 96  96  96  TYR TYR TYR n
+B 4 97  97  97  ARG ARG ARG n
+B 4 98  98  98  GLU GLU GLU n
+B 4 99  99  99  GLN GLN GLN n
+B 4 100 100 100 ILE ILE ILE n
+B 4 101 101 101 LYS LYS LYS n
+B 4 102 102 102 ARG ARG ARG n
+B 4 103 103 103 VAL VAL VAL n
+B 4 104 104 104 LYS LYS LYS n
+B 4 105 105 105 ASP ASP ASP n
+B 4 106 106 106 SER SER SER n
+B 4 107 107 107 ASP ASP ASP n
+B 4 108 108 108 ASP ASP ASP n
+B 4 109 109 109 VAL VAL VAL n
+B 4 110 110 110 PRO PRO PRO n
+B 4 111 111 111 MET MET MET n
+B 4 112 112 112 VAL VAL VAL n
+B 4 113 113 113 LEU LEU LEU n
+B 4 114 114 114 VAL VAL VAL n
+B 4 115 115 115 GLY GLY GLY n
+B 4 116 116 116 ASN ASN ASN n
+B 4 117 117 117 LYS LYS LYS n
+B 4 118 118 118 CYS CYS CYS n
+B 4 119 119 119 ASP ASP ASP n
+B 4 120 120 120 LEU LEU LEU n
+B 4 121 121 121 ALA ALA ALA n
+B 4 122 122 122 ALA ALA ALA n
+B 4 123 123 123 ARG ARG ARG n
+B 4 124 124 124 THR THR THR n
+B 4 125 125 125 VAL VAL VAL n
+B 4 126 126 126 GLU GLU GLU n
+B 4 127 127 127 SER SER SER n
+B 4 128 128 128 ARG ARG ARG n
+B 4 129 129 129 GLN GLN GLN n
+B 4 130 130 130 ALA ALA ALA n
+B 4 131 131 131 GLN GLN GLN n
+B 4 132 132 132 ASP ASP ASP n
+B 4 133 133 133 LEU LEU LEU n
+B 4 134 134 134 ALA ALA ALA n
+B 4 135 135 135 ARG ARG ARG n
+B 4 136 136 136 SER SER SER n
+B 4 137 137 137 TYR TYR TYR n
+B 4 138 138 138 GLY GLY GLY n
+B 4 139 139 139 ILE ILE ILE n
+B 4 140 140 140 PRO PRO PRO n
+B 4 141 141 141 TYR TYR TYR n
+B 4 142 142 142 ILE ILE ILE n
+B 4 143 143 143 GLU GLU GLU n
+B 4 144 144 144 THR THR THR n
+B 4 145 145 145 SER SER SER n
+B 4 146 146 146 ALA ALA ALA n
+B 4 147 147 147 LYS LYS LYS n
+B 4 148 148 148 THR THR THR n
+B 4 149 149 149 ARG ARG ARG n
+B 4 150 150 150 GLN GLN GLN n
+B 4 151 151 151 GLY GLY GLY n
+B 4 152 152 152 VAL VAL VAL n
+B 4 153 153 153 GLU GLU GLU n
+B 4 154 154 154 ASP ASP ASP n
+B 4 155 155 155 ALA ALA ALA n
+B 4 156 156 156 PHE PHE PHE n
+B 4 157 157 157 TYR TYR TYR n
+B 4 158 158 158 THR THR THR n
+B 4 159 159 159 LEU LEU LEU n
+B 4 160 160 160 VAL VAL VAL n
+B 4 161 161 161 ARG ARG ARG n
+B 4 162 162 162 GLU GLU GLU n
+B 4 163 163 163 ILE ILE ILE n
+B 4 164 164 164 ARG ARG ARG n
+B 4 165 165 165 GLN GLN GLN n
+B 4 166 166 166 HIS HIS HIS n
+#
+loop_
+_pdbx_nonpoly_scheme.asym_id
+_pdbx_nonpoly_scheme.entity_id
+_pdbx_nonpoly_scheme.auth_seq_num
+_pdbx_nonpoly_scheme.pdb_seq_num
+_pdbx_nonpoly_scheme.auth_mon_id
+_pdbx_nonpoly_scheme.pdb_mon_id
+A 4 167 167 MG  MG
+A 4 168 168 GNP GNP
+B 4 167 167 MG  MG
+B 4 168 168 GNP GNP
+#
+loop_
+_atom_site.group_PDB
+_atom_site.id
+_atom_site.type_symbol
+_atom_site.label_atom_id
+_atom_site.label_alt_id
+_atom_site.label_comp_id
+_atom_site.label_asym_id
+_atom_site.label_entity_id
+_atom_site.label_seq_id
+_atom_site.pdbx_PDB_ins_code
+_atom_site.Cartn_x
+_atom_site.Cartn_y
+_atom_site.Cartn_z
+_atom_site.occupancy
+_atom_site.B_iso_or_equiv
+_atom_site.auth_seq_id
+_atom_site.auth_comp_id
+_atom_site.auth_asym_id
+_atom_site.auth_atom_id
+_atom_site.pdbx_PDB_model_num
+ATOM   1    N N     . MET A 4 1   . -7.158  32.575 -6.570  1.00 17.39 1   MET A N     1
+ATOM   2    C CA    . MET A 4 1   . -5.824  32.016 -6.717  1.00 21.56 1   MET A CA    1
+ATOM   3    C C     . MET A 4 1   . -5.787  30.991 -5.657  1.00 19.87 1   MET A C     1
+ATOM   4    C CB    . MET A 4 1   . -4.681  33.014 -6.463  1.00 21.63 1   MET A CB    1
+ATOM   5    O O     . MET A 4 1   . -6.653  30.981 -4.772  1.00 22.03 1   MET A O     1
+ATOM   6    C CG    . MET A 4 1   . -4.445  33.505 -5.061  1.00 22.93 1   MET A CG    1
+ATOM   7    S SD    . MET A 4 1   . -3.231  34.843 -5.049  1.00 28.30 1   MET A SD    1
+ATOM   8    C CE    . MET A 4 1   . -4.503  36.070 -4.890  1.00 26.84 1   MET A CE    1
+ATOM   9    N N     . THR A 4 2   . -4.799  30.126 -5.806  1.00 23.06 2   THR A N     1
+ATOM   10   C CA    . THR A 4 2   . -4.676  29.026 -4.877  1.00 21.79 2   THR A CA    1
+ATOM   11   C C     . THR A 4 2   . -4.322  29.594 -3.519  1.00 19.63 2   THR A C     1
+ATOM   12   C CB    . THR A 4 2   . -3.599  28.088 -5.367  1.00 20.84 2   THR A CB    1
+ATOM   13   O O     . THR A 4 2   . -3.470  30.472 -3.448  1.00 15.86 2   THR A O     1
+ATOM   14   C CG2   . THR A 4 2   . -3.489  26.830 -4.537  1.00 21.59 2   THR A CG2   1
+ATOM   15   O OG1   . THR A 4 2   . -3.974  27.725 -6.678  1.00 25.79 2   THR A OG1   1
+ATOM   16   N N     . GLU A 4 3   . -5.018  29.177 -2.458  1.00 20.28 3   GLU A N     1
+ATOM   17   C CA    . GLU A 4 3   . -4.600  29.579 -1.118  1.00 22.28 3   GLU A CA    1
+ATOM   18   C C     . GLU A 4 3   . -4.183  28.335 -0.346  1.00 17.63 3   GLU A C     1
+ATOM   19   C CB    . GLU A 4 3   . -5.719  30.269 -0.381  1.00 24.90 3   GLU A CB    1
+ATOM   20   O O     . GLU A 4 3   . -4.708  27.248 -0.570  1.00 17.65 3   GLU A O     1
+ATOM   21   C CG    . GLU A 4 3   . -6.209  31.429 -1.224  1.00 27.80 3   GLU A CG    1
+ATOM   22   C CD    . GLU A 4 3   . -7.120  32.458 -0.570  1.00 29.48 3   GLU A CD    1
+ATOM   23   O OE1   . GLU A 4 3   . -7.350  32.391 0.636   1.00 27.39 3   GLU A OE1   1
+ATOM   24   O OE2   . GLU A 4 3   . -7.575  33.357 -1.288  1.00 33.53 3   GLU A OE2   1
+ATOM   25   N N     . TYR A 4 4   . -3.174  28.467 0.494   1.00 13.72 4   TYR A N     1
+ATOM   26   C CA    . TYR A 4 4   . -2.687  27.356 1.286   1.00 12.99 4   TYR A CA    1
+ATOM   27   C C     . TYR A 4 4   . -2.779  27.811 2.726   1.00 12.18 4   TYR A C     1
+ATOM   28   C CB    . TYR A 4 4   . -1.264  27.060 0.940   1.00 12.70 4   TYR A CB    1
+ATOM   29   O O     . TYR A 4 4   . -2.199  28.831 3.098   1.00 11.40 4   TYR A O     1
+ATOM   30   C CG    . TYR A 4 4   . -1.033  26.561 -0.470  1.00 13.42 4   TYR A CG    1
+ATOM   31   C CD1   . TYR A 4 4   . -1.211  25.202 -0.730  1.00 13.88 4   TYR A CD1   1
+ATOM   32   C CD2   . TYR A 4 4   . -0.649  27.480 -1.455  1.00 15.41 4   TYR A CD2   1
+ATOM   33   C CE1   . TYR A 4 4   . -1.002  24.750 -2.011  1.00 12.73 4   TYR A CE1   1
+ATOM   34   C CE2   . TYR A 4 4   . -0.427  27.043 -2.743  1.00 12.65 4   TYR A CE2   1
+ATOM   35   O OH    . TYR A 4 4   . -0.528  25.235 -4.294  1.00 12.99 4   TYR A OH    1
+ATOM   36   C CZ    . TYR A 4 4   . -0.626  25.676 -2.992  1.00 14.61 4   TYR A CZ    1
+ATOM   37   N N     . LYS A 4 5   . -3.541  27.071 3.532   1.00 16.13 5   LYS A N     1
+ATOM   38   C CA    . LYS A 4 5   . -3.818  27.410 4.923   1.00 14.98 5   LYS A CA    1
+ATOM   39   C C     . LYS A 4 5   . -2.827  26.651 5.781   1.00 11.27 5   LYS A C     1
+ATOM   40   C CB    . LYS A 4 5   . -5.280  27.034 5.212   1.00 18.95 5   LYS A CB    1
+ATOM   41   O O     . LYS A 4 5   . -2.927  25.454 6.020   1.00 13.26 5   LYS A O     1
+ATOM   42   C CG    . LYS A 4 5   . -5.747  27.009 6.683   1.00 24.97 5   LYS A CG    1
+ATOM   43   C CD    . LYS A 4 5   . -6.156  28.321 7.368   1.00 28.72 5   LYS A CD    1
+ATOM   44   C CE    . LYS A 4 5   . -5.317  28.636 8.625   1.00 29.78 5   LYS A CE    1
+ATOM   45   N NZ    . LYS A 4 5   . -4.122  29.380 8.267   1.00 31.62 5   LYS A NZ    1
+ATOM   46   N N     . LEU A 4 6   . -1.814  27.416 6.168   1.00 10.35 6   LEU A N     1
+ATOM   47   C CA    . LEU A 4 6   . -0.664  26.936 6.939   1.00 10.82 6   LEU A CA    1
+ATOM   48   C C     . LEU A 4 6   . -0.797  27.279 8.418   1.00 9.50  6   LEU A C     1
+ATOM   49   C CB    . LEU A 4 6   . 0.635   27.570 6.394   1.00 9.36  6   LEU A CB    1
+ATOM   50   O O     . LEU A 4 6   . -1.258  28.399 8.709   1.00 11.11 6   LEU A O     1
+ATOM   51   C CG    . LEU A 4 6   . 1.470   27.077 5.203   1.00 11.39 6   LEU A CG    1
+ATOM   52   C CD1   . LEU A 4 6   . 0.651   26.481 4.112   1.00 13.78 6   LEU A CD1   1
+ATOM   53   C CD2   . LEU A 4 6   . 2.228   28.239 4.681   1.00 10.60 6   LEU A CD2   1
+ATOM   54   N N     . VAL A 4 7   . -0.493  26.352 9.364   1.00 11.49 7   VAL A N     1
+ATOM   55   C CA    . VAL A 4 7   . -0.382  26.793 10.758  1.00 11.06 7   VAL A CA    1
+ATOM   56   C C     . VAL A 4 7   . 0.943   26.387 11.448  1.00 7.54  7   VAL A C     1
+ATOM   57   C CB    . VAL A 4 7   . -1.753  26.350 11.582  1.00 14.01 7   VAL A CB    1
+ATOM   58   O O     . VAL A 4 7   . 1.501   25.307 11.268  1.00 4.81  7   VAL A O     1
+ATOM   59   C CG1   . VAL A 4 7   . -2.884  25.902 10.629  1.00 10.28 7   VAL A CG1   1
+ATOM   60   C CG2   . VAL A 4 7   . -1.442  25.340 12.604  1.00 15.93 7   VAL A CG2   1
+ATOM   61   N N     . VAL A 4 8   . 1.558   27.348 12.144  1.00 6.61  8   VAL A N     1
+ATOM   62   C CA    . VAL A 4 8   . 2.849   27.165 12.869  1.00 6.42  8   VAL A CA    1
+ATOM   63   C C     . VAL A 4 8   . 2.526   26.749 14.318  1.00 10.01 8   VAL A C     1
+ATOM   64   C CB    . VAL A 4 8   . 3.624   28.484 12.842  1.00 7.58  8   VAL A CB    1
+ATOM   65   O O     . VAL A 4 8   . 1.850   27.445 15.068  1.00 9.77  8   VAL A O     1
+ATOM   66   C CG1   . VAL A 4 8   . 5.026   28.288 13.386  1.00 4.13  8   VAL A CG1   1
+ATOM   67   C CG2   . VAL A 4 8   . 3.767   28.973 11.405  1.00 7.72  8   VAL A CG2   1
+ATOM   68   N N     . VAL A 4 9   . 2.984   25.577 14.750  1.00 12.37 9   VAL A N     1
+ATOM   69   C CA    . VAL A 4 9   . 2.606   24.933 16.012  1.00 11.60 9   VAL A CA    1
+ATOM   70   C C     . VAL A 4 9   . 3.872   24.629 16.805  1.00 9.03  9   VAL A C     1
+ATOM   71   C CB    . VAL A 4 9   . 1.773   23.736 15.480  1.00 9.76  9   VAL A CB    1
+ATOM   72   O O     . VAL A 4 9   . 4.944   24.537 16.223  1.00 6.96  9   VAL A O     1
+ATOM   73   C CG1   . VAL A 4 9   . 2.128   22.446 16.073  1.00 8.97  9   VAL A CG1   1
+ATOM   74   C CG2   . VAL A 4 9   . 0.347   24.112 15.685  1.00 8.44  9   VAL A CG2   1
+ATOM   75   N N     . GLY A 4 10  . 3.816   24.531 18.122  1.00 5.40  10  GLY A N     1
+ATOM   76   C CA    . GLY A 4 10  . 4.995   24.285 18.951  1.00 9.50  10  GLY A CA    1
+ATOM   77   C C     . GLY A 4 10  . 4.966   25.012 20.317  1.00 10.97 10  GLY A C     1
+ATOM   78   O O     . GLY A 4 10  . 4.159   25.917 20.568  1.00 8.91  10  GLY A O     1
+ATOM   79   N N     . ALA A 4 11  . 5.916   24.608 21.185  1.00 11.74 11  ALA A N     1
+ATOM   80   C CA    . ALA A 4 11  . 6.077   25.074 22.550  1.00 10.30 11  ALA A CA    1
+ATOM   81   C C     . ALA A 4 11  . 6.432   26.546 22.627  1.00 7.59  11  ALA A C     1
+ATOM   82   C CB    . ALA A 4 11  . 7.173   24.254 23.251  1.00 5.26  11  ALA A CB    1
+ATOM   83   O O     . ALA A 4 11  . 6.984   27.130 21.704  1.00 9.59  11  ALA A O     1
+ATOM   84   N N     . GLY A 4 12  . 6.110   27.160 23.767  1.00 13.13 12  GLY A N     1
+ATOM   85   C CA    . GLY A 4 12  . 6.387   28.568 24.046  1.00 10.37 12  GLY A CA    1
+ATOM   86   C C     . GLY A 4 12  . 7.871   28.852 23.961  1.00 8.39  12  GLY A C     1
+ATOM   87   O O     . GLY A 4 12  . 8.675   28.047 24.442  1.00 12.77 12  GLY A O     1
+ATOM   88   N N     . GLY A 4 13  . 8.164   29.944 23.242  1.00 3.43  13  GLY A N     1
+ATOM   89   C CA    . GLY A 4 13  . 9.489   30.521 23.111  1.00 2.72  13  GLY A CA    1
+ATOM   90   C C     . GLY A 4 13  . 10.359  29.886 22.053  1.00 2.00  13  GLY A C     1
+ATOM   91   O O     . GLY A 4 13  . 11.500  30.301 21.928  1.00 5.95  13  GLY A O     1
+ATOM   92   N N     . VAL A 4 14  . 9.896   28.902 21.280  1.00 5.87  14  VAL A N     1
+ATOM   93   C CA    . VAL A 4 14  . 10.715  28.233 20.241  1.00 8.14  14  VAL A CA    1
+ATOM   94   C C     . VAL A 4 14  . 11.055  29.051 18.956  1.00 9.48  14  VAL A C     1
+ATOM   95   C CB    . VAL A 4 14  . 10.049  26.852 19.793  1.00 8.30  14  VAL A CB    1
+ATOM   96   O O     . VAL A 4 14  . 11.976  28.693 18.220  1.00 11.28 14  VAL A O     1
+ATOM   97   C CG1   . VAL A 4 14  . 9.993   25.918 20.995  1.00 2.18  14  VAL A CG1   1
+ATOM   98   C CG2   . VAL A 4 14  . 8.653   27.053 19.166  1.00 9.19  14  VAL A CG2   1
+ATOM   99   N N     . GLY A 4 15  . 10.417  30.186 18.668  1.00 7.97  15  GLY A N     1
+ATOM   100  C CA    . GLY A 4 15  . 10.699  31.000 17.494  1.00 10.23 15  GLY A CA    1
+ATOM   101  C C     . GLY A 4 15  . 9.584   30.926 16.460  1.00 10.49 15  GLY A C     1
+ATOM   102  O O     . GLY A 4 15  . 9.833   31.334 15.331  1.00 11.65 15  GLY A O     1
+ATOM   103  N N     . LYS A 4 16  . 8.369   30.414 16.781  1.00 11.05 16  LYS A N     1
+ATOM   104  C CA    . LYS A 4 16  . 7.241   30.340 15.834  1.00 8.71  16  LYS A CA    1
+ATOM   105  C C     . LYS A 4 16  . 7.029   31.653 15.134  1.00 11.00 16  LYS A C     1
+ATOM   106  C CB    . LYS A 4 16  . 5.936   29.960 16.563  1.00 5.15  16  LYS A CB    1
+ATOM   107  O O     . LYS A 4 16  . 7.072   31.720 13.912  1.00 15.58 16  LYS A O     1
+ATOM   108  C CG    . LYS A 4 16  . 5.917   28.538 17.099  1.00 5.63  16  LYS A CG    1
+ATOM   109  C CD    . LYS A 4 16  . 4.548   28.101 17.597  1.00 3.46  16  LYS A CD    1
+ATOM   110  C CE    . LYS A 4 16  . 4.023   28.845 18.844  1.00 8.41  16  LYS A CE    1
+ATOM   111  N NZ    . LYS A 4 16  . 4.791   28.629 20.042  1.00 7.94  16  LYS A NZ    1
+ATOM   112  N N     . SER A 4 17  . 6.819   32.728 15.915  1.00 13.06 17  SER A N     1
+ATOM   113  C CA    . SER A 4 17  . 6.587   34.087 15.460  1.00 8.74  17  SER A CA    1
+ATOM   114  C C     . SER A 4 17  . 7.765   34.749 14.792  1.00 11.65 17  SER A C     1
+ATOM   115  C CB    . SER A 4 17  . 6.172   34.986 16.622  1.00 11.04 17  SER A CB    1
+ATOM   116  O O     . SER A 4 17  . 7.581   35.419 13.794  1.00 10.52 17  SER A O     1
+ATOM   117  O OG    . SER A 4 17  . 4.867   34.796 17.190  1.00 9.37  17  SER A OG    1
+ATOM   118  N N     . ALA A 4 18  . 8.981   34.659 15.318  1.00 10.95 18  ALA A N     1
+ATOM   119  C CA    . ALA A 4 18  . 10.140  35.198 14.620  1.00 10.40 18  ALA A CA    1
+ATOM   120  C C     . ALA A 4 18  . 10.323  34.486 13.283  1.00 9.76  18  ALA A C     1
+ATOM   121  C CB    . ALA A 4 18  . 11.394  34.995 15.471  1.00 7.61  18  ALA A CB    1
+ATOM   122  O O     . ALA A 4 18  . 10.868  35.031 12.338  1.00 14.62 18  ALA A O     1
+ATOM   123  N N     . LEU A 4 19  . 9.952   33.220 13.153  1.00 10.29 19  LEU A N     1
+ATOM   124  C CA    . LEU A 4 19  . 10.066  32.529 11.870  1.00 11.49 19  LEU A CA    1
+ATOM   125  C C     . LEU A 4 19  . 9.104   33.152 10.870  1.00 8.80  19  LEU A C     1
+ATOM   126  C CB    . LEU A 4 19  . 9.723   31.051 12.034  1.00 7.54  19  LEU A CB    1
+ATOM   127  O O     . LEU A 4 19  . 9.464   33.481 9.741   1.00 8.29  19  LEU A O     1
+ATOM   128  C CG    . LEU A 4 19  . 10.669  29.941 11.795  1.00 10.78 19  LEU A CG    1
+ATOM   129  C CD1   . LEU A 4 19  . 12.118  30.395 11.638  1.00 15.81 19  LEU A CD1   1
+ATOM   130  C CD2   . LEU A 4 19  . 10.422  28.976 12.932  1.00 12.47 19  LEU A CD2   1
+ATOM   131  N N     . THR A 4 20  . 7.866   33.281 11.329  1.00 11.27 20  THR A N     1
+ATOM   132  C CA    . THR A 4 20  . 6.785   33.852 10.558  1.00 12.01 20  THR A CA    1
+ATOM   133  C C     . THR A 4 20  . 7.039   35.278 10.045  1.00 13.59 20  THR A C     1
+ATOM   134  C CB    . THR A 4 20  . 5.537   33.791 11.446  1.00 10.38 20  THR A CB    1
+ATOM   135  O O     . THR A 4 20  . 6.742   35.610 8.892   1.00 15.31 20  THR A O     1
+ATOM   136  C CG2   . THR A 4 20  . 4.284   34.338 10.777  1.00 14.18 20  THR A CG2   1
+ATOM   137  O OG1   . THR A 4 20  . 5.323   32.425 11.713  1.00 11.24 20  THR A OG1   1
+ATOM   138  N N     . ILE A 4 21  . 7.565   36.133 10.920  1.00 9.59  21  ILE A N     1
+ATOM   139  C CA    . ILE A 4 21  . 7.862   37.512 10.642  1.00 12.82 21  ILE A CA    1
+ATOM   140  C C     . ILE A 4 21  . 9.114   37.729 9.770   1.00 12.40 21  ILE A C     1
+ATOM   141  C CB    . ILE A 4 21  . 7.932   38.157 12.026  1.00 13.85 21  ILE A CB    1
+ATOM   142  O O     . ILE A 4 21  . 9.205   38.692 9.004   1.00 14.79 21  ILE A O     1
+ATOM   143  C CG1   . ILE A 4 21  . 6.495   38.294 12.532  1.00 12.86 21  ILE A CG1   1
+ATOM   144  C CG2   . ILE A 4 21  . 8.766   39.419 11.972  1.00 10.82 21  ILE A CG2   1
+ATOM   145  C CD1   . ILE A 4 21  . 6.291   39.079 13.822  1.00 17.21 21  ILE A CD1   1
+ATOM   146  N N     . GLN A 4 22  . 10.106  36.858 9.871   1.00 11.76 22  GLN A N     1
+ATOM   147  C CA    . GLN A 4 22  . 11.238  36.897 8.954   1.00 13.98 22  GLN A CA    1
+ATOM   148  C C     . GLN A 4 22  . 10.660  36.628 7.533   1.00 16.15 22  GLN A C     1
+ATOM   149  C CB    . GLN A 4 22  . 12.204  35.858 9.518   1.00 7.23  22  GLN A CB    1
+ATOM   150  O O     . GLN A 4 22  . 10.890  37.441 6.614   1.00 20.32 22  GLN A O     1
+ATOM   151  C CG    . GLN A 4 22  . 13.559  35.747 8.938   1.00 13.24 22  GLN A CG    1
+ATOM   152  C CD    . GLN A 4 22  . 14.359  37.026 8.890   1.00 12.26 22  GLN A CD    1
+ATOM   153  N NE2   . GLN A 4 22  . 15.228  37.282 9.860   1.00 10.61 22  GLN A NE2   1
+ATOM   154  O OE1   . GLN A 4 22  . 14.247  37.791 7.935   1.00 14.29 22  GLN A OE1   1
+ATOM   155  N N     . LEU A 4 23  . 9.805   35.598 7.304   1.00 15.21 23  LEU A N     1
+ATOM   156  C CA    . LEU A 4 23  . 9.143   35.353 5.990   1.00 17.11 23  LEU A CA    1
+ATOM   157  C C     . LEU A 4 23  . 8.333   36.525 5.404   1.00 17.19 23  LEU A C     1
+ATOM   158  C CB    . LEU A 4 23  . 8.182   34.156 6.107   1.00 10.86 23  LEU A CB    1
+ATOM   159  O O     . LEU A 4 23  . 8.492   36.834 4.236   1.00 21.87 23  LEU A O     1
+ATOM   160  C CG    . LEU A 4 23  . 7.927   33.055 5.100   1.00 15.35 23  LEU A CG    1
+ATOM   161  C CD1   . LEU A 4 23  . 6.474   33.070 4.835   1.00 15.34 23  LEU A CD1   1
+ATOM   162  C CD2   . LEU A 4 23  . 8.693   33.202 3.811   1.00 16.54 23  LEU A CD2   1
+ATOM   163  N N     . ILE A 4 24  . 7.428   37.137 6.186   1.00 18.20 24  ILE A N     1
+ATOM   164  C CA    . ILE A 4 24  . 6.470   38.154 5.779   1.00 19.80 24  ILE A CA    1
+ATOM   165  C C     . ILE A 4 24  . 7.033   39.579 5.890   1.00 23.98 24  ILE A C     1
+ATOM   166  C CB    . ILE A 4 24  . 5.184   38.056 6.666   1.00 15.64 24  ILE A CB    1
+ATOM   167  O O     . ILE A 4 24  . 6.640   40.467 5.115   1.00 23.17 24  ILE A O     1
+ATOM   168  C CG1   . ILE A 4 24  . 4.542   36.689 6.607   1.00 18.21 24  ILE A CG1   1
+ATOM   169  C CG2   . ILE A 4 24  . 4.150   39.038 6.190   1.00 17.62 24  ILE A CG2   1
+ATOM   170  C CD1   . ILE A 4 24  . 3.990   36.130 5.252   1.00 19.50 24  ILE A CD1   1
+ATOM   171  N N     . GLN A 4 25  . 7.889   39.855 6.882   1.00 22.23 25  GLN A N     1
+ATOM   172  C CA    . GLN A 4 25  . 8.366   41.206 7.083   1.00 22.85 25  GLN A CA    1
+ATOM   173  C C     . GLN A 4 25  . 9.864   41.349 7.039   1.00 21.11 25  GLN A C     1
+ATOM   174  C CB    . GLN A 4 25  . 7.862   41.751 8.411   1.00 26.50 25  GLN A CB    1
+ATOM   175  O O     . GLN A 4 25  . 10.420  42.428 7.254   1.00 21.65 25  GLN A O     1
+ATOM   176  C CG    . GLN A 4 25  . 6.359   42.015 8.508   1.00 30.11 25  GLN A CG    1
+ATOM   177  C CD    . GLN A 4 25  . 5.935   42.487 9.909   1.00 32.62 25  GLN A CD    1
+ATOM   178  N NE2   . GLN A 4 25  . 4.773   42.046 10.399  1.00 30.07 25  GLN A NE2   1
+ATOM   179  O OE1   . GLN A 4 25  . 6.635   43.252 10.581  1.00 33.70 25  GLN A OE1   1
+ATOM   180  N N     . ASN A 4 26  . 10.584  40.275 6.765   1.00 26.31 26  ASN A N     1
+ATOM   181  C CA    . ASN A 4 26  . 12.008  40.396 6.549   1.00 28.48 26  ASN A CA    1
+ATOM   182  C C     . ASN A 4 26  . 12.793  41.091 7.662   1.00 27.56 26  ASN A C     1
+ATOM   183  C CB    . ASN A 4 26  . 12.201  41.114 5.209   1.00 31.88 26  ASN A CB    1
+ATOM   184  O O     . ASN A 4 26  . 13.479  42.096 7.459   1.00 30.03 26  ASN A O     1
+ATOM   185  C CG    . ASN A 4 26  . 13.633  40.996 4.742   1.00 38.18 26  ASN A CG    1
+ATOM   186  N ND2   . ASN A 4 26  . 14.339  42.127 4.621   1.00 41.94 26  ASN A ND2   1
+ATOM   187  O OD1   . ASN A 4 26  . 14.114  39.883 4.491   1.00 41.14 26  ASN A OD1   1
+ATOM   188  N N     . HIS A 4 27  . 12.647  40.596 8.882   1.00 24.40 27  HIS A N     1
+ATOM   189  C CA    . HIS A 4 27  . 13.474  41.070 9.988   1.00 24.23 27  HIS A CA    1
+ATOM   190  C C     . HIS A 4 27  . 13.294  40.178 11.195  1.00 21.87 27  HIS A C     1
+ATOM   191  C CB    . HIS A 4 27  . 13.147  42.531 10.429  1.00 23.04 27  HIS A CB    1
+ATOM   192  O O     . HIS A 4 27  . 12.268  39.509 11.350  1.00 19.42 27  HIS A O     1
+ATOM   193  C CG    . HIS A 4 27  . 11.903  42.767 11.264  1.00 27.03 27  HIS A CG    1
+ATOM   194  C CD2   . HIS A 4 27  . 10.609  42.487 10.908  1.00 28.81 27  HIS A CD2   1
+ATOM   195  N ND1   . HIS A 4 27  . 12.001  43.369 12.431  1.00 28.94 27  HIS A ND1   1
+ATOM   196  C CE1   . HIS A 4 27  . 10.749  43.474 12.821  1.00 28.40 27  HIS A CE1   1
+ATOM   197  N NE2   . HIS A 4 27  . 9.932   42.954 11.922  1.00 29.56 27  HIS A NE2   1
+ATOM   198  N N     . PHE A 4 28  . 14.318  40.205 12.048  1.00 22.54 28  PHE A N     1
+ATOM   199  C CA    . PHE A 4 28  . 14.356  39.449 13.277  1.00 19.44 28  PHE A CA    1
+ATOM   200  C C     . PHE A 4 28  . 13.857  40.282 14.451  1.00 18.80 28  PHE A C     1
+ATOM   201  C CB    . PHE A 4 28  . 15.775  38.992 13.495  1.00 17.76 28  PHE A CB    1
+ATOM   202  O O     . PHE A 4 28  . 14.243  41.426 14.702  1.00 17.58 28  PHE A O     1
+ATOM   203  C CG    . PHE A 4 28  . 15.983  38.142 14.730  1.00 18.01 28  PHE A CG    1
+ATOM   204  C CD1   . PHE A 4 28  . 15.366  36.895 14.829  1.00 18.34 28  PHE A CD1   1
+ATOM   205  C CD2   . PHE A 4 28  . 16.810  38.614 15.731  1.00 18.40 28  PHE A CD2   1
+ATOM   206  C CE1   . PHE A 4 28  . 15.591  36.129 15.937  1.00 17.77 28  PHE A CE1   1
+ATOM   207  C CE2   . PHE A 4 28  . 17.024  37.821 16.847  1.00 19.53 28  PHE A CE2   1
+ATOM   208  C CZ    . PHE A 4 28  . 16.420  36.588 16.946  1.00 16.35 28  PHE A CZ    1
+ATOM   209  N N     . VAL A 4 29  . 12.903  39.642 15.118  1.00 19.19 29  VAL A N     1
+ATOM   210  C CA    . VAL A 4 29  . 12.299  40.184 16.319  1.00 23.68 29  VAL A CA    1
+ATOM   211  C C     . VAL A 4 29  . 13.119  39.545 17.452  1.00 27.40 29  VAL A C     1
+ATOM   212  C CB    . VAL A 4 29  . 10.804  39.770 16.417  1.00 21.40 29  VAL A CB    1
+ATOM   213  O O     . VAL A 4 29  . 13.074  38.327 17.682  1.00 25.78 29  VAL A O     1
+ATOM   214  C CG1   . VAL A 4 29  . 10.215  40.360 17.677  1.00 22.94 29  VAL A CG1   1
+ATOM   215  C CG2   . VAL A 4 29  . 9.991   40.305 15.237  1.00 23.24 29  VAL A CG2   1
+ATOM   216  N N     . ASP A 4 30  . 13.891  40.397 18.136  1.00 28.85 30  ASP A N     1
+ATOM   217  C CA    . ASP A 4 30  . 14.783  39.988 19.224  1.00 30.28 30  ASP A CA    1
+ATOM   218  C C     . ASP A 4 30  . 14.088  39.995 20.615  1.00 31.13 30  ASP A C     1
+ATOM   219  C CB    . ASP A 4 30  . 16.004  40.954 19.117  1.00 33.44 30  ASP A CB    1
+ATOM   220  O O     . ASP A 4 30  . 14.701  39.602 21.618  1.00 34.55 30  ASP A O     1
+ATOM   221  C CG    . ASP A 4 30  . 17.394  40.556 19.645  1.00 37.21 30  ASP A CG    1
+ATOM   222  O OD1   . ASP A 4 30  . 17.698  39.369 19.786  1.00 40.34 30  ASP A OD1   1
+ATOM   223  O OD2   . ASP A 4 30  . 18.205  41.452 19.903  1.00 39.26 30  ASP A OD2   1
+ATOM   224  N N     . GLU A 4 31  . 12.787  40.353 20.742  1.00 28.81 31  GLU A N     1
+ATOM   225  C CA    . GLU A 4 31  . 12.130  40.481 22.043  1.00 27.43 31  GLU A CA    1
+ATOM   226  C C     . GLU A 4 31  . 11.009  39.550 22.426  1.00 23.95 31  GLU A C     1
+ATOM   227  C CB    . GLU A 4 31  . 11.563  41.874 22.248  1.00 26.52 31  GLU A CB    1
+ATOM   228  O O     . GLU A 4 31  . 10.469  38.756 21.653  1.00 22.11 31  GLU A O     1
+ATOM   229  C CG    . GLU A 4 31  . 10.405  42.231 21.379  1.00 31.16 31  GLU A CG    1
+ATOM   230  C CD    . GLU A 4 31  . 10.803  43.442 20.593  1.00 35.47 31  GLU A CD    1
+ATOM   231  O OE1   . GLU A 4 31  . 11.665  43.327 19.708  1.00 36.58 31  GLU A OE1   1
+ATOM   232  O OE2   . GLU A 4 31  . 10.255  44.502 20.898  1.00 39.46 31  GLU A OE2   1
+ATOM   233  N N     . TYR A 4 32  . 10.731  39.780 23.715  1.00 21.32 32  TYR A N     1
+ATOM   234  C CA    . TYR A 4 32  . 9.702   39.090 24.452  1.00 20.70 32  TYR A CA    1
+ATOM   235  C C     . TYR A 4 32  . 8.336   39.597 23.981  1.00 19.76 32  TYR A C     1
+ATOM   236  C CB    . TYR A 4 32  . 9.944   39.341 25.984  1.00 17.09 32  TYR A CB    1
+ATOM   237  O O     . TYR A 4 32  . 7.936   40.737 24.255  1.00 18.76 32  TYR A O     1
+ATOM   238  C CG    . TYR A 4 32  . 9.105   38.435 26.903  1.00 15.38 32  TYR A CG    1
+ATOM   239  C CD1   . TYR A 4 32  . 7.808   38.783 27.251  1.00 16.04 32  TYR A CD1   1
+ATOM   240  C CD2   . TYR A 4 32  . 9.638   37.249 27.345  1.00 14.05 32  TYR A CD2   1
+ATOM   241  C CE1   . TYR A 4 32  . 7.056   37.936 28.034  1.00 13.20 32  TYR A CE1   1
+ATOM   242  C CE2   . TYR A 4 32  . 8.893   36.400 28.124  1.00 13.66 32  TYR A CE2   1
+ATOM   243  O OH    . TYR A 4 32  . 6.868   35.873 29.178  1.00 13.02 32  TYR A OH    1
+ATOM   244  C CZ    . TYR A 4 32  . 7.616   36.754 28.451  1.00 12.22 32  TYR A CZ    1
+ATOM   245  N N     . ASP A 4 33  . 7.626   38.741 23.227  1.00 17.30 33  ASP A N     1
+ATOM   246  C CA    . ASP A 4 33  . 6.308   39.109 22.772  1.00 17.06 33  ASP A CA    1
+ATOM   247  C C     . ASP A 4 33  . 5.343   37.939 22.532  1.00 18.74 33  ASP A C     1
+ATOM   248  C CB    . ASP A 4 33  . 6.533   39.929 21.521  1.00 15.86 33  ASP A CB    1
+ATOM   249  O O     . ASP A 4 33  . 5.044   37.609 21.367  1.00 16.60 33  ASP A O     1
+ATOM   250  C CG    . ASP A 4 33  . 5.313   40.666 21.014  1.00 16.58 33  ASP A CG    1
+ATOM   251  O OD1   . ASP A 4 33  . 4.265   40.704 21.661  1.00 20.14 33  ASP A OD1   1
+ATOM   252  O OD2   . ASP A 4 33  . 5.438   41.256 19.954  1.00 17.28 33  ASP A OD2   1
+ATOM   253  N N     . PRO A 4 34  . 4.831   37.247 23.583  1.00 14.85 34  PRO A N     1
+ATOM   254  C CA    . PRO A 4 34  . 4.075   35.996 23.471  1.00 12.63 34  PRO A CA    1
+ATOM   255  C C     . PRO A 4 34  . 2.851   36.226 22.627  1.00 9.18  34  PRO A C     1
+ATOM   256  C CB    . PRO A 4 34  . 3.703   35.598 24.846  1.00 10.39 34  PRO A CB    1
+ATOM   257  O O     . PRO A 4 34  . 2.317   37.319 22.610  1.00 13.30 34  PRO A O     1
+ATOM   258  C CG    . PRO A 4 34  . 4.761   36.299 25.627  1.00 13.12 34  PRO A CG    1
+ATOM   259  C CD    . PRO A 4 34  . 4.873   37.649 24.960  1.00 15.14 34  PRO A CD    1
+ATOM   260  N N     . THR A 4 35  . 2.412   35.205 21.916  1.00 11.37 35  THR A N     1
+ATOM   261  C CA    . THR A 4 35  . 1.288   35.261 20.993  1.00 10.07 35  THR A CA    1
+ATOM   262  C C     . THR A 4 35  . 0.099   34.643 21.634  1.00 11.03 35  THR A C     1
+ATOM   263  C CB    . THR A 4 35  . 1.620   34.475 19.732  1.00 5.59  35  THR A CB    1
+ATOM   264  O O     . THR A 4 35  . 0.233   33.697 22.404  1.00 11.01 35  THR A O     1
+ATOM   265  C CG2   . THR A 4 35  . 0.564   34.441 18.639  1.00 6.30  35  THR A CG2   1
+ATOM   266  O OG1   . THR A 4 35  . 2.763   35.139 19.268  1.00 6.36  35  THR A OG1   1
+ATOM   267  N N     . ILE A 4 36  . -1.045  35.205 21.235  1.00 14.57 36  ILE A N     1
+ATOM   268  C CA    . ILE A 4 36  . -2.354  34.632 21.556  1.00 18.28 36  ILE A CA    1
+ATOM   269  C C     . ILE A 4 36  . -2.729  33.973 20.222  1.00 16.18 36  ILE A C     1
+ATOM   270  C CB    . ILE A 4 36  . -3.427  35.771 21.993  1.00 18.48 36  ILE A CB    1
+ATOM   271  O O     . ILE A 4 36  . -2.710  32.759 20.054  1.00 17.75 36  ILE A O     1
+ATOM   272  C CG1   . ILE A 4 36  . -3.102  36.363 23.394  1.00 18.87 36  ILE A CG1   1
+ATOM   273  C CG2   . ILE A 4 36  . -4.816  35.157 22.044  1.00 16.25 36  ILE A CG2   1
+ATOM   274  C CD1   . ILE A 4 36  . -3.911  37.596 23.918  1.00 22.85 36  ILE A CD1   1
+ATOM   275  N N     . GLU A 4 37  . -2.951  34.809 19.227  1.00 18.33 37  GLU A N     1
+ATOM   276  C CA    . GLU A 4 37  . -3.258  34.334 17.905  1.00 22.50 37  GLU A CA    1
+ATOM   277  C C     . GLU A 4 37  . -3.072  35.502 16.955  1.00 22.10 37  GLU A C     1
+ATOM   278  C CB    . GLU A 4 37  . -4.690  33.814 17.853  1.00 23.67 37  GLU A CB    1
+ATOM   279  O O     . GLU A 4 37  . -3.541  36.620 17.198  1.00 24.14 37  GLU A O     1
+ATOM   280  C CG    . GLU A 4 37  . -4.714  32.498 17.081  1.00 30.80 37  GLU A CG    1
+ATOM   281  C CD    . GLU A 4 37  . -6.088  31.860 16.874  1.00 34.92 37  GLU A CD    1
+ATOM   282  O OE1   . GLU A 4 37  . -7.076  32.568 16.666  1.00 35.36 37  GLU A OE1   1
+ATOM   283  O OE2   . GLU A 4 37  . -6.170  30.629 16.896  1.00 38.35 37  GLU A OE2   1
+ATOM   284  N N     . ASP A 4 38  . -2.323  35.184 15.895  1.00 19.49 38  ASP A N     1
+ATOM   285  C CA    . ASP A 4 38  . -2.000  36.105 14.825  1.00 18.38 38  ASP A CA    1
+ATOM   286  C C     . ASP A 4 38  . -2.078  35.464 13.446  1.00 16.39 38  ASP A C     1
+ATOM   287  C CB    . ASP A 4 38  . -0.598  36.666 15.043  1.00 20.45 38  ASP A CB    1
+ATOM   288  O O     . ASP A 4 38  . -1.636  34.346 13.243  1.00 12.96 38  ASP A O     1
+ATOM   289  C CG    . ASP A 4 38  . -0.433  37.521 16.306  1.00 23.48 38  ASP A CG    1
+ATOM   290  O OD1   . ASP A 4 38  . -1.400  38.126 16.775  1.00 20.24 38  ASP A OD1   1
+ATOM   291  O OD2   . ASP A 4 38  . 0.688   37.600 16.810  1.00 26.72 38  ASP A OD2   1
+ATOM   292  N N     . SER A 4 39  . -2.584  36.237 12.482  1.00 16.24 39  SER A N     1
+ATOM   293  C CA    . SER A 4 39  . -2.867  35.762 11.140  1.00 18.13 39  SER A CA    1
+ATOM   294  C C     . SER A 4 39  . -2.123  36.561 10.083  1.00 17.69 39  SER A C     1
+ATOM   295  C CB    . SER A 4 39  . -4.341  35.875 10.909  1.00 19.11 39  SER A CB    1
+ATOM   296  O O     . SER A 4 39  . -2.135  37.793 10.105  1.00 18.74 39  SER A O     1
+ATOM   297  O OG    . SER A 4 39  . -4.683  35.248 9.686   1.00 27.01 39  SER A OG    1
+ATOM   298  N N     . TYR A 4 40  . -1.444  35.920 9.141   1.00 20.34 40  TYR A N     1
+ATOM   299  C CA    . TYR A 4 40  . -0.759  36.656 8.083   1.00 22.19 40  TYR A CA    1
+ATOM   300  C C     . TYR A 4 40  . -1.075  36.155 6.668   1.00 22.63 40  TYR A C     1
+ATOM   301  C CB    . TYR A 4 40  . 0.736   36.574 8.307   1.00 19.14 40  TYR A CB    1
+ATOM   302  O O     . TYR A 4 40  . -0.957  34.959 6.361   1.00 21.54 40  TYR A O     1
+ATOM   303  C CG    . TYR A 4 40  . 1.228   37.169 9.620   1.00 19.40 40  TYR A CG    1
+ATOM   304  C CD1   . TYR A 4 40  . 1.236   36.398 10.764  1.00 17.75 40  TYR A CD1   1
+ATOM   305  C CD2   . TYR A 4 40  . 1.705   38.468 9.646   1.00 20.82 40  TYR A CD2   1
+ATOM   306  C CE1   . TYR A 4 40  . 1.722   36.912 11.939  1.00 15.94 40  TYR A CE1   1
+ATOM   307  C CE2   . TYR A 4 40  . 2.194   38.977 10.830  1.00 20.24 40  TYR A CE2   1
+ATOM   308  O OH    . TYR A 4 40  . 2.666   38.700 13.125  1.00 19.99 40  TYR A OH    1
+ATOM   309  C CZ    . TYR A 4 40  . 2.193   38.190 11.956  1.00 16.49 40  TYR A CZ    1
+ATOM   310  N N     . ARG A 4 41  . -1.465  37.071 5.776   1.00 20.12 41  ARG A N     1
+ATOM   311  C CA    . ARG A 4 41  . -1.710  36.694 4.386   1.00 18.50 41  ARG A CA    1
+ATOM   312  C C     . ARG A 4 41  . -0.737  37.450 3.523   1.00 18.83 41  ARG A C     1
+ATOM   313  C CB    . ARG A 4 41  . -3.069  37.084 3.939   1.00 15.44 41  ARG A CB    1
+ATOM   314  O O     . ARG A 4 41  . -0.605  38.671 3.724   1.00 14.28 41  ARG A O     1
+ATOM   315  C CG    . ARG A 4 41  . -4.025  36.294 4.741   1.00 17.34 41  ARG A CG    1
+ATOM   316  C CD    . ARG A 4 41  . -5.319  37.027 4.739   1.00 18.47 41  ARG A CD    1
+ATOM   317  N NE    . ARG A 4 41  . -5.967  37.087 3.428   1.00 17.90 41  ARG A NE    1
+ATOM   318  N NH1   . ARG A 4 41  . -6.804  34.904 3.434   1.00 18.14 41  ARG A NH1   1
+ATOM   319  N NH2   . ARG A 4 41  . -7.357  36.335 1.744   1.00 21.06 41  ARG A NH2   1
+ATOM   320  C CZ    . ARG A 4 41  . -6.714  36.110 2.894   1.00 18.44 41  ARG A CZ    1
+ATOM   321  N N     . LYS A 4 42  . -0.118  36.711 2.575   1.00 16.63 42  LYS A N     1
+ATOM   322  C CA    . LYS A 4 42  . 0.853   37.272 1.642   1.00 16.51 42  LYS A CA    1
+ATOM   323  C C     . LYS A 4 42  . 0.753   36.604 0.288   1.00 15.80 42  LYS A C     1
+ATOM   324  C CB    . LYS A 4 42  . 2.296   37.096 2.115   1.00 17.12 42  LYS A CB    1
+ATOM   325  O O     . LYS A 4 42  . 0.675   35.391 0.173   1.00 13.96 42  LYS A O     1
+ATOM   326  C CG    . LYS A 4 42  . 3.238   38.000 1.313   1.00 19.06 42  LYS A CG    1
+ATOM   327  C CD    . LYS A 4 42  . 4.706   37.792 1.762   1.00 23.40 42  LYS A CD    1
+ATOM   328  C CE    . LYS A 4 42  . 5.759   38.637 1.023   1.00 21.30 42  LYS A CE    1
+ATOM   329  N NZ    . LYS A 4 42  . 5.343   40.030 0.998   1.00 24.34 42  LYS A NZ    1
+ATOM   330  N N     . GLN A 4 43  . 0.700   37.409 -0.761  1.00 16.94 43  GLN A N     1
+ATOM   331  C CA    . GLN A 4 43  . 0.667   36.880 -2.108  1.00 18.11 43  GLN A CA    1
+ATOM   332  C C     . GLN A 4 43  . 2.112   36.658 -2.492  1.00 15.74 43  GLN A C     1
+ATOM   333  C CB    . GLN A 4 43  . 0.058   37.844 -3.087  1.00 17.51 43  GLN A CB    1
+ATOM   334  O O     . GLN A 4 43  . 2.971   37.528 -2.420  1.00 18.16 43  GLN A O     1
+ATOM   335  C CG    . GLN A 4 43  . -1.378  38.230 -2.825  1.00 19.98 43  GLN A CG    1
+ATOM   336  C CD    . GLN A 4 43  . -1.844  39.354 -3.761  1.00 24.44 43  GLN A CD    1
+ATOM   337  N NE2   . GLN A 4 43  . -1.510  40.641 -3.602  1.00 25.98 43  GLN A NE2   1
+ATOM   338  O OE1   . GLN A 4 43  . -2.558  39.075 -4.711  1.00 28.07 43  GLN A OE1   1
+ATOM   339  N N     . VAL A 4 44  . 2.368   35.474 -3.006  1.00 16.35 44  VAL A N     1
+ATOM   340  C CA    . VAL A 4 44  . 3.727   35.030 -3.181  1.00 13.51 44  VAL A CA    1
+ATOM   341  C C     . VAL A 4 44  . 3.714   34.203 -4.485  1.00 13.48 44  VAL A C     1
+ATOM   342  C CB    . VAL A 4 44  . 3.892   34.367 -1.753  1.00 14.41 44  VAL A CB    1
+ATOM   343  O O     . VAL A 4 44  . 2.642   33.898 -5.028  1.00 12.84 44  VAL A O     1
+ATOM   344  C CG1   . VAL A 4 44  . 3.982   32.862 -1.839  1.00 15.20 44  VAL A CG1   1
+ATOM   345  C CG2   . VAL A 4 44  . 5.053   34.998 -1.055  1.00 13.27 44  VAL A CG2   1
+ATOM   346  N N     . VAL A 4 45  . 4.871   33.957 -5.105  1.00 11.40 45  VAL A N     1
+ATOM   347  C CA    . VAL A 4 45  . 4.952   33.105 -6.281  1.00 9.50  45  VAL A CA    1
+ATOM   348  C C     . VAL A 4 45  . 5.873   31.958 -5.928  1.00 7.87  45  VAL A C     1
+ATOM   349  C CB    . VAL A 4 45  . 5.510   33.881 -7.525  1.00 13.43 45  VAL A CB    1
+ATOM   350  O O     . VAL A 4 45  . 7.061   32.168 -5.682  1.00 9.48  45  VAL A O     1
+ATOM   351  C CG1   . VAL A 4 45  . 5.565   32.931 -8.745  1.00 12.51 45  VAL A CG1   1
+ATOM   352  C CG2   . VAL A 4 45  . 4.610   35.065 -7.869  1.00 11.76 45  VAL A CG2   1
+ATOM   353  N N     . ILE A 4 46  . 5.358   30.726 -5.910  1.00 8.46  46  ILE A N     1
+ATOM   354  C CA    . ILE A 4 46  . 6.190   29.576 -5.612  1.00 9.16  46  ILE A CA    1
+ATOM   355  C C     . ILE A 4 46  . 6.173   28.668 -6.814  1.00 11.00 46  ILE A C     1
+ATOM   356  C CB    . ILE A 4 46  . 5.646   28.854 -4.388  1.00 8.48  46  ILE A CB    1
+ATOM   357  O O     . ILE A 4 46  . 5.110   28.204 -7.252  1.00 14.11 46  ILE A O     1
+ATOM   358  C CG1   . ILE A 4 46  . 5.641   29.784 -3.175  1.00 11.76 46  ILE A CG1   1
+ATOM   359  C CG2   . ILE A 4 46  . 6.541   27.665 -4.070  1.00 10.64 46  ILE A CG2   1
+ATOM   360  C CD1   . ILE A 4 46  . 4.890   29.152 -1.974  1.00 11.38 46  ILE A CD1   1
+ATOM   361  N N     . ASP A 4 47  . 7.372   28.376 -7.328  1.00 13.00 47  ASP A N     1
+ATOM   362  C CA    . ASP A 4 47  . 7.548   27.471 -8.472  1.00 10.36 47  ASP A CA    1
+ATOM   363  C C     . ASP A 4 47  . 6.646   27.778 -9.663  1.00 10.06 47  ASP A C     1
+ATOM   364  C CB    . ASP A 4 47  . 7.296   26.039 -8.049  1.00 9.72  47  ASP A CB    1
+ATOM   365  O O     . ASP A 4 47  . 6.022   26.914 -10.294 1.00 9.28  47  ASP A O     1
+ATOM   366  C CG    . ASP A 4 47  . 8.174   25.566 -6.929  1.00 11.98 47  ASP A CG    1
+ATOM   367  O OD1   . ASP A 4 47  . 9.352   25.897 -6.957  1.00 10.72 47  ASP A OD1   1
+ATOM   368  O OD2   . ASP A 4 47  . 7.683   24.885 -6.019  1.00 12.80 47  ASP A OD2   1
+ATOM   369  N N     . GLY A 4 48  . 6.613   29.100 -9.873  1.00 13.83 48  GLY A N     1
+ATOM   370  C CA    . GLY A 4 48  . 5.844   29.732 -10.929 1.00 14.95 48  GLY A CA    1
+ATOM   371  C C     . GLY A 4 48  . 4.366   29.887 -10.656 1.00 13.63 48  GLY A C     1
+ATOM   372  O O     . GLY A 4 48  . 3.704   30.607 -11.384 1.00 11.73 48  GLY A O     1
+ATOM   373  N N     . GLU A 4 49  . 3.780   29.266 -9.638  1.00 16.59 49  GLU A N     1
+ATOM   374  C CA    . GLU A 4 49  . 2.351   29.424 -9.389  1.00 17.06 49  GLU A CA    1
+ATOM   375  C C     . GLU A 4 49  . 2.084   30.613 -8.470  1.00 17.60 49  GLU A C     1
+ATOM   376  C CB    . GLU A 4 49  . 1.842   28.130 -8.777  1.00 20.35 49  GLU A CB    1
+ATOM   377  O O     . GLU A 4 49  . 2.779   30.832 -7.477  1.00 14.55 49  GLU A O     1
+ATOM   378  C CG    . GLU A 4 49  . 0.430   28.195 -8.184  1.00 22.55 49  GLU A CG    1
+ATOM   379  C CD    . GLU A 4 49  . 0.031   26.948 -7.416  1.00 23.72 49  GLU A CD    1
+ATOM   380  O OE1   . GLU A 4 49  . 0.614   26.695 -6.359  1.00 21.94 49  GLU A OE1   1
+ATOM   381  O OE2   . GLU A 4 49  . -0.866  26.244 -7.881  1.00 23.99 49  GLU A OE2   1
+ATOM   382  N N     . THR A 4 50  . 1.069   31.415 -8.810  1.00 21.09 50  THR A N     1
+ATOM   383  C CA    . THR A 4 50  . 0.622   32.532 -7.979  1.00 19.56 50  THR A CA    1
+ATOM   384  C C     . THR A 4 50  . -0.213  31.936 -6.860  1.00 16.68 50  THR A C     1
+ATOM   385  C CB    . THR A 4 50  . -0.240  33.529 -8.812  1.00 22.00 50  THR A CB    1
+ATOM   386  O O     . THR A 4 50  . -1.191  31.222 -7.086  1.00 18.30 50  THR A O     1
+ATOM   387  C CG2   . THR A 4 50  . -0.684  34.730 -7.978  1.00 26.15 50  THR A CG2   1
+ATOM   388  O OG1   . THR A 4 50  . 0.551   34.005 -9.893  1.00 24.20 50  THR A OG1   1
+ATOM   389  N N     . CYS A 4 51  . 0.177   32.186 -5.626  1.00 15.83 51  CYS A N     1
+ATOM   390  C CA    . CYS A 4 51  . -0.652  31.739 -4.546  1.00 13.80 51  CYS A CA    1
+ATOM   391  C C     . CYS A 4 51  . -0.651  32.731 -3.390  1.00 14.96 51  CYS A C     1
+ATOM   392  C CB    . CYS A 4 51  . -0.155  30.350 -4.110  1.00 11.02 51  CYS A CB    1
+ATOM   393  O O     . CYS A 4 51  . 0.139   33.698 -3.325  1.00 14.55 51  CYS A O     1
+ATOM   394  S SG    . CYS A 4 51  . 1.603   30.270 -3.743  1.00 14.49 51  CYS A SG    1
+ATOM   395  N N     . LEU A 4 52  . -1.599  32.482 -2.486  1.00 12.48 52  LEU A N     1
+ATOM   396  C CA    . LEU A 4 52  . -1.634  33.267 -1.261  1.00 16.72 52  LEU A CA    1
+ATOM   397  C C     . LEU A 4 52  . -1.489  32.299 -0.092  1.00 13.08 52  LEU A C     1
+ATOM   398  C CB    . LEU A 4 52  . -2.964  34.095 -1.134  1.00 15.77 52  LEU A CB    1
+ATOM   399  O O     . LEU A 4 52  . -2.094  31.227 0.054   1.00 13.87 52  LEU A O     1
+ATOM   400  C CG    . LEU A 4 52  . -3.132  35.059 0.064   1.00 20.03 52  LEU A CG    1
+ATOM   401  C CD1   . LEU A 4 52  . -3.691  36.402 -0.353  1.00 17.85 52  LEU A CD1   1
+ATOM   402  C CD2   . LEU A 4 52  . -4.115  34.431 1.042   1.00 17.90 52  LEU A CD2   1
+ATOM   403  N N     . LEU A 4 53  . -0.568  32.749 0.735   1.00 12.42 53  LEU A N     1
+ATOM   404  C CA    . LEU A 4 53  . -0.198  32.065 1.954   1.00 9.77  53  LEU A CA    1
+ATOM   405  C C     . LEU A 4 53  . -0.971  32.722 3.086   1.00 9.97  53  LEU A C     1
+ATOM   406  C CB    . LEU A 4 53  . 1.287   32.231 2.112   1.00 10.85 53  LEU A CB    1
+ATOM   407  O O     . LEU A 4 53  . -0.888  33.929 3.304   1.00 7.99  53  LEU A O     1
+ATOM   408  C CG    . LEU A 4 53  . 2.264   31.107 1.776   1.00 13.67 53  LEU A CG    1
+ATOM   409  C CD1   . LEU A 4 53  . 1.988   30.368 0.476   1.00 14.55 53  LEU A CD1   1
+ATOM   410  C CD2   . LEU A 4 53  . 3.618   31.797 1.876   1.00 13.42 53  LEU A CD2   1
+ATOM   411  N N     . ASP A 4 54  . -1.744  31.909 3.771   1.00 11.68 54  ASP A N     1
+ATOM   412  C CA    . ASP A 4 54  . -2.571  32.377 4.850   1.00 14.27 54  ASP A CA    1
+ATOM   413  C C     . ASP A 4 54  . -2.056  31.702 6.107   1.00 11.16 54  ASP A C     1
+ATOM   414  C CB    . ASP A 4 54  . -3.993  31.983 4.510   1.00 17.91 54  ASP A CB    1
+ATOM   415  O O     . ASP A 4 54  . -2.479  30.597 6.414   1.00 16.62 54  ASP A O     1
+ATOM   416  C CG    . ASP A 4 54  . -4.988  32.399 5.571   1.00 22.60 54  ASP A CG    1
+ATOM   417  O OD1   . ASP A 4 54  . -4.658  33.196 6.438   1.00 26.09 54  ASP A OD1   1
+ATOM   418  O OD2   . ASP A 4 54  . -6.109  31.916 5.529   1.00 27.61 54  ASP A OD2   1
+ATOM   419  N N     . ILE A 4 55  . -1.149  32.319 6.859   1.00 10.59 55  ILE A N     1
+ATOM   420  C CA    . ILE A 4 55  . -0.467  31.686 7.985   1.00 8.47  55  ILE A CA    1
+ATOM   421  C C     . ILE A 4 55  . -1.101  32.019 9.314   1.00 11.81 55  ILE A C     1
+ATOM   422  C CB    . ILE A 4 55  . 0.996   32.131 8.072   1.00 9.56  55  ILE A CB    1
+ATOM   423  O O     . ILE A 4 55  . -1.292  33.186 9.623   1.00 12.50 55  ILE A O     1
+ATOM   424  C CG1   . ILE A 4 55  . 1.664   31.929 6.743   1.00 9.53  55  ILE A CG1   1
+ATOM   425  C CG2   . ILE A 4 55  . 1.722   31.330 9.179   1.00 9.71  55  ILE A CG2   1
+ATOM   426  C CD1   . ILE A 4 55  . 3.093   32.510 6.748   1.00 13.99 55  ILE A CD1   1
+ATOM   427  N N     . LEU A 4 56  . -1.344  31.002 10.149  1.00 14.24 56  LEU A N     1
+ATOM   428  C CA    . LEU A 4 56  . -1.894  31.225 11.478  1.00 14.72 56  LEU A CA    1
+ATOM   429  C C     . LEU A 4 56  . -0.775  30.934 12.459  1.00 12.67 56  LEU A C     1
+ATOM   430  C CB    . LEU A 4 56  . -3.105  30.279 11.701  1.00 18.10 56  LEU A CB    1
+ATOM   431  O O     . LEU A 4 56  . -0.281  29.816 12.540  1.00 14.14 56  LEU A O     1
+ATOM   432  C CG    . LEU A 4 56  . -4.265  30.577 12.701  1.00 19.81 56  LEU A CG    1
+ATOM   433  C CD1   . LEU A 4 56  . -3.815  30.398 14.120  1.00 19.35 56  LEU A CD1   1
+ATOM   434  C CD2   . LEU A 4 56  . -4.733  31.996 12.555  1.00 15.55 56  LEU A CD2   1
+ATOM   435  N N     . ASP A 4 57  . -0.320  31.984 13.140  1.00 13.40 57  ASP A N     1
+ATOM   436  C CA    . ASP A 4 57  . 0.702   31.935 14.172  1.00 12.96 57  ASP A CA    1
+ATOM   437  C C     . ASP A 4 57  . 0.049   31.733 15.534  1.00 12.78 57  ASP A C     1
+ATOM   438  C CB    . ASP A 4 57  . 1.420   33.216 14.159  1.00 12.74 57  ASP A CB    1
+ATOM   439  O O     . ASP A 4 57  . -0.663  32.610 16.027  1.00 14.40 57  ASP A O     1
+ATOM   440  C CG    . ASP A 4 57  . 2.649   33.263 15.013  1.00 13.49 57  ASP A CG    1
+ATOM   441  O OD1   . ASP A 4 57  . 3.195   32.222 15.395  1.00 13.16 57  ASP A OD1   1
+ATOM   442  O OD2   . ASP A 4 57  . 3.057   34.386 15.282  1.00 14.48 57  ASP A OD2   1
+ATOM   443  N N     . THR A 4 58  . 0.321   30.601 16.184  1.00 11.86 58  THR A N     1
+ATOM   444  C CA    . THR A 4 58  . -0.418  30.219 17.372  1.00 11.91 58  THR A CA    1
+ATOM   445  C C     . THR A 4 58  . 0.304   30.437 18.696  1.00 15.63 58  THR A C     1
+ATOM   446  C CB    . THR A 4 58  . -0.827  28.742 17.179  1.00 7.25  58  THR A CB    1
+ATOM   447  O O     . THR A 4 58  . 1.493   30.749 18.724  1.00 17.13 58  THR A O     1
+ATOM   448  C CG2   . THR A 4 58  . -1.492  28.532 15.811  1.00 7.19  58  THR A CG2   1
+ATOM   449  O OG1   . THR A 4 58  . 0.335   27.932 17.277  1.00 8.81  58  THR A OG1   1
+ATOM   450  N N     . ALA A 4 59  . -0.428  30.376 19.817  1.00 17.06 59  ALA A N     1
+ATOM   451  C CA    . ALA A 4 59  . 0.162   30.432 21.142  1.00 18.63 59  ALA A CA    1
+ATOM   452  C C     . ALA A 4 59  . 0.832   29.085 21.502  1.00 21.26 59  ALA A C     1
+ATOM   453  C CB    . ALA A 4 59  . -0.936  30.737 22.163  1.00 20.47 59  ALA A CB    1
+ATOM   454  O O     . ALA A 4 59  . 0.329   27.996 21.181  1.00 17.89 59  ALA A O     1
+ATOM   455  N N     . GLY A 4 60  . 1.981   29.107 22.194  1.00 27.85 60  GLY A N     1
+ATOM   456  C CA    . GLY A 4 60  . 2.697   27.890 22.603  1.00 34.76 60  GLY A CA    1
+ATOM   457  C C     . GLY A 4 60  . 2.109   27.115 23.779  1.00 40.18 60  GLY A C     1
+ATOM   458  O O     . GLY A 4 60  . 1.784   25.930 23.631  1.00 43.73 60  GLY A O     1
+ATOM   459  N N     . LEU A 4 61  . 1.939   27.814 24.917  1.00 43.53 61  LEU A N     1
+ATOM   460  C CA    . LEU A 4 61  . 1.457   27.282 26.204  1.00 48.01 61  LEU A CA    1
+ATOM   461  C C     . LEU A 4 61  . -0.068  27.260 26.421  1.00 48.19 61  LEU A C     1
+ATOM   462  C CB    . LEU A 4 61  . 2.163   28.119 27.313  1.00 50.49 61  LEU A CB    1
+ATOM   463  O O     . LEU A 4 61  . -0.710  26.210 26.450  1.00 45.51 61  LEU A O     1
+ATOM   464  C CG    . LEU A 4 61  . 1.951   27.983 28.835  1.00 50.47 61  LEU A CG    1
+ATOM   465  C CD1   . LEU A 4 61  . 3.091   27.153 29.423  1.00 51.00 61  LEU A CD1   1
+ATOM   466  C CD2   . LEU A 4 61  . 1.965   29.365 29.503  1.00 47.03 61  LEU A CD2   1
+ATOM   467  N N     . GLU A 4 62  . -0.616  28.475 26.581  1.00 51.26 62  GLU A N     1
+ATOM   468  C CA    . GLU A 4 62  . -2.026  28.801 26.852  1.00 54.13 62  GLU A CA    1
+ATOM   469  C C     . GLU A 4 62  . -3.033  27.821 27.546  1.00 56.12 62  GLU A C     1
+ATOM   470  C CB    . GLU A 4 62  . -2.666  29.318 25.469  1.00 51.97 62  GLU A CB    1
+ATOM   471  O O     . GLU A 4 62  . -2.787  26.710 28.064  1.00 51.72 62  GLU A O     1
+ATOM   472  C CG    . GLU A 4 62  . -3.302  30.761 25.460  1.00 46.75 62  GLU A CG    1
+ATOM   473  C CD    . GLU A 4 62  . -4.699  31.045 24.865  1.00 43.32 62  GLU A CD    1
+ATOM   474  O OE1   . GLU A 4 62  . -5.477  30.130 24.598  1.00 39.12 62  GLU A OE1   1
+ATOM   475  O OE2   . GLU A 4 62  . -5.028  32.223 24.698  1.00 40.41 62  GLU A OE2   1
+ATOM   476  N N     . GLU A 4 63  . -4.204  28.490 27.605  1.00 57.28 63  GLU A N     1
+ATOM   477  C CA    . GLU A 4 63  . -5.505  27.925 27.872  1.00 56.86 63  GLU A CA    1
+ATOM   478  C C     . GLU A 4 63  . -5.944  27.433 26.473  1.00 55.14 63  GLU A C     1
+ATOM   479  C CB    . GLU A 4 63  . -6.449  29.043 28.406  1.00 57.11 63  GLU A CB    1
+ATOM   480  O O     . GLU A 4 63  . -7.148  27.263 26.245  1.00 56.67 63  GLU A O     1
+ATOM   481  C CG    . GLU A 4 63  . -7.707  28.586 29.198  1.00 56.40 63  GLU A CG    1
+ATOM   482  C CD    . GLU A 4 63  . -8.847  29.599 29.348  1.00 55.00 63  GLU A CD    1
+ATOM   483  O OE1   . GLU A 4 63  . -8.617  30.700 29.859  1.00 54.92 63  GLU A OE1   1
+ATOM   484  O OE2   . GLU A 4 63  . -9.976  29.276 28.958  1.00 53.70 63  GLU A OE2   1
+ATOM   485  N N     . TYR A 4 64  . -5.020  27.187 25.506  1.00 52.50 64  TYR A N     1
+ATOM   486  C CA    . TYR A 4 64  . -5.368  26.678 24.183  1.00 50.78 64  TYR A CA    1
+ATOM   487  C C     . TYR A 4 64  . -5.450  25.166 24.279  1.00 49.98 64  TYR A C     1
+ATOM   488  C CB    . TYR A 4 64  . -4.318  27.048 23.110  1.00 51.61 64  TYR A CB    1
+ATOM   489  O O     . TYR A 4 64  . -4.472  24.479 24.600  1.00 47.14 64  TYR A O     1
+ATOM   490  C CG    . TYR A 4 64  . -4.795  28.100 22.119  1.00 52.79 64  TYR A CG    1
+ATOM   491  C CD1   . TYR A 4 64  . -6.137  28.419 22.062  1.00 53.84 64  TYR A CD1   1
+ATOM   492  C CD2   . TYR A 4 64  . -3.894  28.797 21.331  1.00 54.06 64  TYR A CD2   1
+ATOM   493  C CE1   . TYR A 4 64  . -6.600  29.432 21.253  1.00 55.75 64  TYR A CE1   1
+ATOM   494  C CE2   . TYR A 4 64  . -4.351  29.823 20.506  1.00 57.04 64  TYR A CE2   1
+ATOM   495  O OH    . TYR A 4 64  . -6.199  31.215 19.738  1.00 56.79 64  TYR A OH    1
+ATOM   496  C CZ    . TYR A 4 64  . -5.710  30.144 20.478  1.00 57.57 64  TYR A CZ    1
+ATOM   497  N N     . SER A 4 65  . -6.650  24.667 23.979  1.00 47.94 65  SER A N     1
+ATOM   498  C CA    . SER A 4 65  . -6.917  23.256 24.132  1.00 50.39 65  SER A CA    1
+ATOM   499  C C     . SER A 4 65  . -7.692  22.781 22.905  1.00 49.65 65  SER A C     1
+ATOM   500  C CB    . SER A 4 65  . -7.677  23.138 25.467  1.00 50.97 65  SER A CB    1
+ATOM   501  O O     . SER A 4 65  . -7.144  22.704 21.814  1.00 46.17 65  SER A O     1
+ATOM   502  O OG    . SER A 4 65  . -8.878  23.912 25.481  1.00 53.47 65  SER A OG    1
+ATOM   503  N N     . ALA A 4 66  . -8.960  22.390 23.017  1.00 52.05 66  ALA A N     1
+ATOM   504  C CA    . ALA A 4 66  . -9.791  22.226 21.843  1.00 50.41 66  ALA A CA    1
+ATOM   505  C C     . ALA A 4 66  . -10.063 23.636 21.238  1.00 48.94 66  ALA A C     1
+ATOM   506  C CB    . ALA A 4 66  . -11.087 21.531 22.267  1.00 52.68 66  ALA A CB    1
+ATOM   507  O O     . ALA A 4 66  . -10.822 23.822 20.280  1.00 49.74 66  ALA A O     1
+ATOM   508  N N     . MET A 4 67  . -9.496  24.701 21.830  1.00 43.56 67  MET A N     1
+ATOM   509  C CA    . MET A 4 67  . -9.442  25.993 21.175  1.00 39.49 67  MET A CA    1
+ATOM   510  C C     . MET A 4 67  . -8.309  25.873 20.113  1.00 36.36 67  MET A C     1
+ATOM   511  C CB    . MET A 4 67  . -9.172  27.031 22.276  1.00 44.51 67  MET A CB    1
+ATOM   512  O O     . MET A 4 67  . -8.190  26.668 19.159  1.00 33.14 67  MET A O     1
+ATOM   513  C CG    . MET A 4 67  . -9.951  28.360 22.176  1.00 48.48 67  MET A CG    1
+ATOM   514  S SD    . MET A 4 67  . -9.392  29.738 23.235  1.00 53.91 67  MET A SD    1
+ATOM   515  C CE    . MET A 4 67  . -9.910  29.236 24.857  1.00 50.97 67  MET A CE    1
+ATOM   516  N N     . ARG A 4 68  . -7.438  24.847 20.278  1.00 32.16 68  ARG A N     1
+ATOM   517  C CA    . ARG A 4 68  . -6.472  24.458 19.264  1.00 28.74 68  ARG A CA    1
+ATOM   518  C C     . ARG A 4 68  . -7.210  23.547 18.314  1.00 24.40 68  ARG A C     1
+ATOM   519  C CB    . ARG A 4 68  . -5.292  23.634 19.766  1.00 32.54 68  ARG A CB    1
+ATOM   520  O O     . ARG A 4 68  . -6.921  23.577 17.134  1.00 25.66 68  ARG A O     1
+ATOM   521  C CG    . ARG A 4 68  . -4.499  24.239 20.906  1.00 39.06 68  ARG A CG    1
+ATOM   522  C CD    . ARG A 4 68  . -3.389  23.308 21.400  1.00 41.85 68  ARG A CD    1
+ATOM   523  N NE    . ARG A 4 68  . -2.748  23.826 22.606  1.00 45.58 68  ARG A NE    1
+ATOM   524  N NH1   . ARG A 4 68  . -1.145  25.195 21.496  1.00 49.30 68  ARG A NH1   1
+ATOM   525  N NH2   . ARG A 4 68  . -1.230  25.040 23.811  1.00 50.26 68  ARG A NH2   1
+ATOM   526  C CZ    . ARG A 4 68  . -1.707  24.680 22.617  1.00 48.76 68  ARG A CZ    1
+ATOM   527  N N     . ASP A 4 69  . -8.131  22.684 18.741  1.00 25.77 69  ASP A N     1
+ATOM   528  C CA    . ASP A 4 69  . -8.882  21.818 17.837  1.00 22.56 69  ASP A CA    1
+ATOM   529  C C     . ASP A 4 69  . -9.423  22.548 16.637  1.00 20.79 69  ASP A C     1
+ATOM   530  C CB    . ASP A 4 69  . -10.054 21.185 18.559  1.00 21.73 69  ASP A CB    1
+ATOM   531  O O     . ASP A 4 69  . -9.303  22.082 15.521  1.00 21.01 69  ASP A O     1
+ATOM   532  C CG    . ASP A 4 69  . -9.737  19.892 19.283  1.00 22.44 69  ASP A CG    1
+ATOM   533  O OD1   . ASP A 4 69  . -8.633  19.704 19.809  1.00 26.68 69  ASP A OD1   1
+ATOM   534  O OD2   . ASP A 4 69  . -10.625 19.047 19.309  1.00 22.03 69  ASP A OD2   1
+ATOM   535  N N     . GLN A 4 70  . -9.993  23.720 16.879  1.00 22.60 70  GLN A N     1
+ATOM   536  C CA    . GLN A 4 70  . -10.529 24.571 15.845  1.00 27.15 70  GLN A CA    1
+ATOM   537  C C     . GLN A 4 70  . -9.469  24.925 14.801  1.00 27.63 70  GLN A C     1
+ATOM   538  C CB    . GLN A 4 70  . -11.122 25.852 16.485  1.00 27.58 70  GLN A CB    1
+ATOM   539  O O     . GLN A 4 70  . -9.690  24.492 13.664  1.00 31.79 70  GLN A O     1
+ATOM   540  C CG    . GLN A 4 70  . -11.833 26.765 15.477  1.00 31.03 70  GLN A CG    1
+ATOM   541  C CD    . GLN A 4 70  . -12.614 27.956 16.065  1.00 32.23 70  GLN A CD    1
+ATOM   542  N NE2   . GLN A 4 70  . -13.942 27.987 15.847  1.00 29.95 70  GLN A NE2   1
+ATOM   543  O OE1   . GLN A 4 70  . -12.053 28.855 16.708  1.00 31.84 70  GLN A OE1   1
+ATOM   544  N N     . TYR A 4 71  . -8.333  25.617 15.045  1.00 24.70 71  TYR A N     1
+ATOM   545  C CA    . TYR A 4 71  . -7.393  25.882 13.958  1.00 20.66 71  TYR A CA    1
+ATOM   546  C C     . TYR A 4 71  . -6.708  24.657 13.363  1.00 19.60 71  TYR A C     1
+ATOM   547  C CB    . TYR A 4 71  . -6.338  26.898 14.426  1.00 21.11 71  TYR A CB    1
+ATOM   548  O O     . TYR A 4 71  . -6.272  24.694 12.215  1.00 20.98 71  TYR A O     1
+ATOM   549  C CG    . TYR A 4 71  . -5.354  26.545 15.535  1.00 22.22 71  TYR A CG    1
+ATOM   550  C CD1   . TYR A 4 71  . -4.389  25.582 15.314  1.00 22.79 71  TYR A CD1   1
+ATOM   551  C CD2   . TYR A 4 71  . -5.406  27.194 16.755  1.00 22.98 71  TYR A CD2   1
+ATOM   552  C CE1   . TYR A 4 71  . -3.482  25.247 16.297  1.00 23.68 71  TYR A CE1   1
+ATOM   553  C CE2   . TYR A 4 71  . -4.495  26.871 17.747  1.00 25.34 71  TYR A CE2   1
+ATOM   554  O OH    . TYR A 4 71  . -2.628  25.509 18.504  1.00 27.19 71  TYR A OH    1
+ATOM   555  C CZ    . TYR A 4 71  . -3.534  25.890 17.516  1.00 26.28 71  TYR A CZ    1
+ATOM   556  N N     . MET A 4 72  . -6.614  23.541 14.077  1.00 16.15 72  MET A N     1
+ATOM   557  C CA    . MET A 4 72  . -6.005  22.341 13.547  1.00 17.98 72  MET A CA    1
+ATOM   558  C C     . MET A 4 72  . -6.928  21.691 12.541  1.00 19.84 72  MET A C     1
+ATOM   559  C CB    . MET A 4 72  . -5.722  21.331 14.619  1.00 14.17 72  MET A CB    1
+ATOM   560  O O     . MET A 4 72  . -6.413  21.071 11.614  1.00 19.37 72  MET A O     1
+ATOM   561  C CG    . MET A 4 72  . -4.653  21.809 15.553  1.00 15.59 72  MET A CG    1
+ATOM   562  S SD    . MET A 4 72  . -4.343  20.593 16.849  1.00 18.05 72  MET A SD    1
+ATOM   563  C CE    . MET A 4 72  . -3.110  21.543 17.691  1.00 16.01 72  MET A CE    1
+ATOM   564  N N     . ARG A 4 73  . -8.266  21.786 12.641  1.00 21.73 73  ARG A N     1
+ATOM   565  C CA    . ARG A 4 73  . -9.071  21.183 11.580  1.00 23.95 73  ARG A CA    1
+ATOM   566  C C     . ARG A 4 73  . -9.138  21.977 10.303  1.00 22.33 73  ARG A C     1
+ATOM   567  C CB    . ARG A 4 73  . -10.507 20.912 11.976  1.00 24.45 73  ARG A CB    1
+ATOM   568  O O     . ARG A 4 73  . -9.297  21.340 9.256   1.00 26.26 73  ARG A O     1
+ATOM   569  C CG    . ARG A 4 73  . -11.321 21.934 12.701  1.00 24.24 73  ARG A CG    1
+ATOM   570  C CD    . ARG A 4 73  . -12.652 21.245 12.933  1.00 30.28 73  ARG A CD    1
+ATOM   571  N NE    . ARG A 4 73  . -12.530 19.818 13.230  1.00 30.91 73  ARG A NE    1
+ATOM   572  N NH1   . ARG A 4 73  . -13.251 20.046 15.436  1.00 31.56 73  ARG A NH1   1
+ATOM   573  N NH2   . ARG A 4 73  . -12.535 17.995 14.581  1.00 32.38 73  ARG A NH2   1
+ATOM   574  C CZ    . ARG A 4 73  . -12.765 19.301 14.432  1.00 31.48 73  ARG A CZ    1
+ATOM   575  N N     . THR A 4 74  . -8.952  23.307 10.336  1.00 21.70 74  THR A N     1
+ATOM   576  C CA    . THR A 4 74  . -8.930  24.078 9.090   1.00 20.85 74  THR A CA    1
+ATOM   577  C C     . THR A 4 74  . -7.590  24.251 8.389   1.00 19.39 74  THR A C     1
+ATOM   578  C CB    . THR A 4 74  . -9.538  25.463 9.314   1.00 17.30 74  THR A CB    1
+ATOM   579  O O     . THR A 4 74  . -7.566  24.631 7.222   1.00 18.35 74  THR A O     1
+ATOM   580  C CG2   . THR A 4 74  . -11.013 25.300 9.621   1.00 21.31 74  THR A CG2   1
+ATOM   581  O OG1   . THR A 4 74  . -8.875  26.136 10.370  1.00 22.34 74  THR A OG1   1
+ATOM   582  N N     . GLY A 4 75  . -6.494  23.933 9.086   1.00 16.48 75  GLY A N     1
+ATOM   583  C CA    . GLY A 4 75  . -5.156  24.010 8.559   1.00 11.86 75  GLY A CA    1
+ATOM   584  C C     . GLY A 4 75  . -4.937  22.884 7.596   1.00 11.55 75  GLY A C     1
+ATOM   585  O O     . GLY A 4 75  . -5.322  21.744 7.818   1.00 11.88 75  GLY A O     1
+ATOM   586  N N     . GLU A 4 76  . -4.355  23.238 6.465   1.00 13.72 76  GLU A N     1
+ATOM   587  C CA    . GLU A 4 76  . -4.015  22.277 5.425   1.00 14.17 76  GLU A CA    1
+ATOM   588  C C     . GLU A 4 76  . -2.676  21.606 5.612   1.00 11.10 76  GLU A C     1
+ATOM   589  C CB    . GLU A 4 76  . -4.011  22.984 4.102   1.00 18.29 76  GLU A CB    1
+ATOM   590  O O     . GLU A 4 76  . -2.483  20.485 5.191   1.00 14.62 76  GLU A O     1
+ATOM   591  C CG    . GLU A 4 76  . -5.411  23.274 3.654   1.00 17.27 76  GLU A CG    1
+ATOM   592  C CD    . GLU A 4 76  . -5.441  23.953 2.302   1.00 19.90 76  GLU A CD    1
+ATOM   593  O OE1   . GLU A 4 76  . -5.452  23.278 1.279   1.00 24.68 76  GLU A OE1   1
+ATOM   594  O OE2   . GLU A 4 76  . -5.452  25.169 2.279   1.00 22.10 76  GLU A OE2   1
+ATOM   595  N N     . GLY A 4 77  . -1.745  22.315 6.223   1.00 12.03 77  GLY A N     1
+ATOM   596  C CA    . GLY A 4 77  . -0.412  21.838 6.519   1.00 9.01  77  GLY A CA    1
+ATOM   597  C C     . GLY A 4 77  . 0.121   22.573 7.728   1.00 7.34  77  GLY A C     1
+ATOM   598  O O     . GLY A 4 77  . -0.294  23.694 8.017   1.00 6.72  77  GLY A O     1
+ATOM   599  N N     . PHE A 4 78  . 1.033   21.892 8.431   1.00 8.71  78  PHE A N     1
+ATOM   600  C CA    . PHE A 4 78  . 1.605   22.316 9.699   1.00 11.73 78  PHE A CA    1
+ATOM   601  C C     . PHE A 4 78  . 3.133   22.325 9.785   1.00 11.17 78  PHE A C     1
+ATOM   602  C CB    . PHE A 4 78  . 1.046   21.411 10.865  1.00 9.22  78  PHE A CB    1
+ATOM   603  O O     . PHE A 4 78  . 3.831   21.395 9.366   1.00 9.11  78  PHE A O     1
+ATOM   604  C CG    . PHE A 4 78  . -0.479  21.330 10.922  1.00 11.02 78  PHE A CG    1
+ATOM   605  C CD1   . PHE A 4 78  . -1.175  20.444 10.108  1.00 9.86  78  PHE A CD1   1
+ATOM   606  C CD2   . PHE A 4 78  . -1.194  22.171 11.748  1.00 12.53 78  PHE A CD2   1
+ATOM   607  C CE1   . PHE A 4 78  . -2.552  20.404 10.101  1.00 6.80  78  PHE A CE1   1
+ATOM   608  C CE2   . PHE A 4 78  . -2.582  22.129 11.740  1.00 10.80 78  PHE A CE2   1
+ATOM   609  C CZ    . PHE A 4 78  . -3.259  21.257 10.920  1.00 9.77  78  PHE A CZ    1
+ATOM   610  N N     . LEU A 4 79  . 3.655   23.450 10.308  1.00 8.94  79  LEU A N     1
+ATOM   611  C CA    . LEU A 4 79  . 5.051   23.528 10.653  1.00 8.28  79  LEU A CA    1
+ATOM   612  C C     . LEU A 4 79  . 5.115   23.171 12.142  1.00 8.21  79  LEU A C     1
+ATOM   613  C CB    . LEU A 4 79  . 5.625   24.930 10.496  1.00 9.92  79  LEU A CB    1
+ATOM   614  O O     . LEU A 4 79  . 4.446   23.818 12.943  1.00 9.42  79  LEU A O     1
+ATOM   615  C CG    . LEU A 4 79  . 6.042   25.546 9.202   1.00 13.43 79  LEU A CG    1
+ATOM   616  C CD1   . LEU A 4 79  . 6.841   26.794 9.501   1.00 11.70 79  LEU A CD1   1
+ATOM   617  C CD2   . LEU A 4 79  . 6.929   24.604 8.451   1.00 11.71 79  LEU A CD2   1
+ATOM   618  N N     . CYS A 4 80  . 5.857   22.147 12.553  1.00 7.39  80  CYS A N     1
+ATOM   619  C CA    . CYS A 4 80  . 5.938   21.748 13.954  1.00 10.19 80  CYS A CA    1
+ATOM   620  C C     . CYS A 4 80  . 7.350   22.072 14.381  1.00 8.47  80  CYS A C     1
+ATOM   621  C CB    . CYS A 4 80  . 5.684   20.242 14.172  1.00 10.94 80  CYS A CB    1
+ATOM   622  O O     . CYS A 4 80  . 8.316   21.381 14.062  1.00 7.27  80  CYS A O     1
+ATOM   623  S SG    . CYS A 4 80  . 4.017   19.646 13.764  1.00 16.52 80  CYS A SG    1
+ATOM   624  N N     . VAL A 4 81  . 7.406   23.182 15.128  1.00 8.02  81  VAL A N     1
+ATOM   625  C CA    . VAL A 4 81  . 8.660   23.798 15.554  1.00 9.14  81  VAL A CA    1
+ATOM   626  C C     . VAL A 4 81  . 9.104   23.469 16.995  1.00 10.69 81  VAL A C     1
+ATOM   627  C CB    . VAL A 4 81  . 8.547   25.364 15.395  1.00 7.96  81  VAL A CB    1
+ATOM   628  O O     . VAL A 4 81  . 8.297   23.416 17.930  1.00 10.74 81  VAL A O     1
+ATOM   629  C CG1   . VAL A 4 81  . 9.943   25.957 15.585  1.00 3.47  81  VAL A CG1   1
+ATOM   630  C CG2   . VAL A 4 81  . 7.946   25.759 14.031  1.00 3.04  81  VAL A CG2   1
+ATOM   631  N N     . PHE A 4 82  . 10.416  23.262 17.158  1.00 8.32  82  PHE A N     1
+ATOM   632  C CA    . PHE A 4 82  . 11.036  23.127 18.467  1.00 8.45  82  PHE A CA    1
+ATOM   633  C C     . PHE A 4 82  . 12.339  23.869 18.298  1.00 4.38  82  PHE A C     1
+ATOM   634  C CB    . PHE A 4 82  . 11.311  21.650 18.865  1.00 4.90  82  PHE A CB    1
+ATOM   635  O O     . PHE A 4 82  . 12.724  24.302 17.197  1.00 10.21 82  PHE A O     1
+ATOM   636  C CG    . PHE A 4 82  . 12.273  20.877 18.000  1.00 3.93  82  PHE A CG    1
+ATOM   637  C CD1   . PHE A 4 82  . 13.611  20.903 18.298  1.00 4.56  82  PHE A CD1   1
+ATOM   638  C CD2   . PHE A 4 82  . 11.807  20.155 16.903  1.00 5.37  82  PHE A CD2   1
+ATOM   639  C CE1   . PHE A 4 82  . 14.478  20.208 17.483  1.00 6.51  82  PHE A CE1   1
+ATOM   640  C CE2   . PHE A 4 82  . 12.690  19.463 16.099  1.00 2.58  82  PHE A CE2   1
+ATOM   641  C CZ    . PHE A 4 82  . 14.028  19.485 16.387  1.00 5.78  82  PHE A CZ    1
+ATOM   642  N N     . ALA A 4 83  . 13.047  24.047 19.388  1.00 5.05  83  ALA A N     1
+ATOM   643  C CA    . ALA A 4 83  . 14.315  24.765 19.376  1.00 6.63  83  ALA A CA    1
+ATOM   644  C C     . ALA A 4 83  . 15.381  23.775 19.721  1.00 5.92  83  ALA A C     1
+ATOM   645  C CB    . ALA A 4 83  . 14.288  25.829 20.398  1.00 5.77  83  ALA A CB    1
+ATOM   646  O O     . ALA A 4 83  . 15.141  22.901 20.560  1.00 6.93  83  ALA A O     1
+ATOM   647  N N     . ILE A 4 84  . 16.538  23.888 19.058  1.00 9.03  84  ILE A N     1
+ATOM   648  C CA    . ILE A 4 84  . 17.584  22.880 19.190  1.00 11.81 84  ILE A CA    1
+ATOM   649  C C     . ILE A 4 84  . 18.340  22.973 20.493  1.00 14.85 84  ILE A C     1
+ATOM   650  C CB    . ILE A 4 84  . 18.653  22.932 17.993  1.00 12.75 84  ILE A CB    1
+ATOM   651  O O     . ILE A 4 84  . 19.141  22.088 20.780  1.00 11.68 84  ILE A O     1
+ATOM   652  C CG1   . ILE A 4 84  . 19.347  24.284 17.829  1.00 9.92  84  ILE A CG1   1
+ATOM   653  C CG2   . ILE A 4 84  . 17.920  22.538 16.703  1.00 13.31 84  ILE A CG2   1
+ATOM   654  C CD1   . ILE A 4 84  . 20.514  24.636 18.768  1.00 14.14 84  ILE A CD1   1
+ATOM   655  N N     . ASN A 4 85  . 18.151  24.066 21.252  1.00 15.97 85  ASN A N     1
+ATOM   656  C CA    . ASN A 4 85  . 18.795  24.221 22.553  1.00 16.19 85  ASN A CA    1
+ATOM   657  C C     . ASN A 4 85  . 17.809  23.995 23.702  1.00 15.70 85  ASN A C     1
+ATOM   658  C CB    . ASN A 4 85  . 19.393  25.627 22.645  1.00 20.22 85  ASN A CB    1
+ATOM   659  O O     . ASN A 4 85  . 18.104  24.307 24.858  1.00 15.79 85  ASN A O     1
+ATOM   660  C CG    . ASN A 4 85  . 18.364  26.743 22.874  1.00 22.66 85  ASN A CG    1
+ATOM   661  N ND2   . ASN A 4 85  . 18.603  27.568 23.894  1.00 19.66 85  ASN A ND2   1
+ATOM   662  O OD1   . ASN A 4 85  . 17.344  26.857 22.183  1.00 21.30 85  ASN A OD1   1
+ATOM   663  N N     . ASN A 4 86  . 16.624  23.450 23.397  1.00 14.92 86  ASN A N     1
+ATOM   664  C CA    . ASN A 4 86  . 15.590  23.147 24.376  1.00 12.76 86  ASN A CA    1
+ATOM   665  C C     . ASN A 4 86  . 15.049  21.710 24.280  1.00 11.01 86  ASN A C     1
+ATOM   666  C CB    . ASN A 4 86  . 14.538  24.177 24.143  1.00 12.26 86  ASN A CB    1
+ATOM   667  O O     . ASN A 4 86  . 14.069  21.474 23.573  1.00 11.08 86  ASN A O     1
+ATOM   668  C CG    . ASN A 4 86  . 13.443  24.223 25.174  1.00 17.16 86  ASN A CG    1
+ATOM   669  N ND2   . ASN A 4 86  . 13.290  23.282 26.087  1.00 19.06 86  ASN A ND2   1
+ATOM   670  O OD1   . ASN A 4 86  . 12.649  25.156 25.148  1.00 24.53 86  ASN A OD1   1
+ATOM   671  N N     . THR A 4 87  . 15.610  20.696 24.959  1.00 8.93  87  THR A N     1
+ATOM   672  C CA    . THR A 4 87  . 15.163  19.296 24.854  1.00 12.31 87  THR A CA    1
+ATOM   673  C C     . THR A 4 87  . 13.683  19.087 25.139  1.00 14.99 87  THR A C     1
+ATOM   674  C CB    . THR A 4 87  . 15.995  18.402 25.809  1.00 10.72 87  THR A CB    1
+ATOM   675  O O     . THR A 4 87  . 13.001  18.392 24.395  1.00 18.15 87  THR A O     1
+ATOM   676  C CG2   . THR A 4 87  . 15.842  16.924 25.557  1.00 12.92 87  THR A CG2   1
+ATOM   677  O OG1   . THR A 4 87  . 17.350  18.630 25.520  1.00 10.88 87  THR A OG1   1
+ATOM   678  N N     . LYS A 4 88  . 13.115  19.700 26.169  1.00 16.39 88  LYS A N     1
+ATOM   679  C CA    . LYS A 4 88  . 11.692  19.629 26.469  1.00 15.05 88  LYS A CA    1
+ATOM   680  C C     . LYS A 4 88  . 10.807  20.023 25.302  1.00 13.25 88  LYS A C     1
+ATOM   681  C CB    . LYS A 4 88  . 11.467  20.534 27.662  1.00 24.27 88  LYS A CB    1
+ATOM   682  O O     . LYS A 4 88  . 9.759   19.422 25.097  1.00 10.07 88  LYS A O     1
+ATOM   683  C CG    . LYS A 4 88  . 10.103  20.777 28.308  1.00 28.26 88  LYS A CG    1
+ATOM   684  C CD    . LYS A 4 88  . 10.454  21.250 29.749  1.00 35.40 88  LYS A CD    1
+ATOM   685  C CE    . LYS A 4 88  . 9.654   22.400 30.418  1.00 37.94 88  LYS A CE    1
+ATOM   686  N NZ    . LYS A 4 88  . 10.135  23.744 30.094  1.00 38.82 88  LYS A NZ    1
+ATOM   687  N N     . SER A 4 89  . 11.185  21.045 24.525  1.00 11.98 89  SER A N     1
+ATOM   688  C CA    . SER A 4 89  . 10.367  21.484 23.389  1.00 10.81 89  SER A CA    1
+ATOM   689  C C     . SER A 4 89  . 10.274  20.393 22.330  1.00 9.83  89  SER A C     1
+ATOM   690  C CB    . SER A 4 89  . 10.935  22.756 22.705  1.00 10.90 89  SER A CB    1
+ATOM   691  O O     . SER A 4 89  . 9.261   20.333 21.652  1.00 7.52  89  SER A O     1
+ATOM   692  O OG    . SER A 4 89  . 12.254  22.650 22.135  1.00 8.68  89  SER A OG    1
+ATOM   693  N N     . PHE A 4 90  . 11.329  19.582 22.183  1.00 11.15 90  PHE A N     1
+ATOM   694  C CA    . PHE A 4 90  . 11.457  18.483 21.235  1.00 11.53 90  PHE A CA    1
+ATOM   695  C C     . PHE A 4 90  . 10.589  17.319 21.650  1.00 14.97 90  PHE A C     1
+ATOM   696  C CB    . PHE A 4 90  . 12.953  18.051 21.143  1.00 11.64 90  PHE A CB    1
+ATOM   697  O O     . PHE A 4 90  . 9.932   16.688 20.800  1.00 17.06 90  PHE A O     1
+ATOM   698  C CG    . PHE A 4 90  . 13.252  16.828 20.266  1.00 14.40 90  PHE A CG    1
+ATOM   699  C CD1   . PHE A 4 90  . 12.872  16.792 18.934  1.00 15.62 90  PHE A CD1   1
+ATOM   700  C CD2   . PHE A 4 90  . 13.882  15.723 20.793  1.00 16.16 90  PHE A CD2   1
+ATOM   701  C CE1   . PHE A 4 90  . 13.112  15.675 18.152  1.00 18.83 90  PHE A CE1   1
+ATOM   702  C CE2   . PHE A 4 90  . 14.121  14.604 19.995  1.00 17.55 90  PHE A CE2   1
+ATOM   703  C CZ    . PHE A 4 90  . 13.739  14.567 18.671  1.00 15.90 90  PHE A CZ    1
+ATOM   704  N N     . GLU A 4 91  . 10.517  17.043 22.956  1.00 15.45 91  GLU A N     1
+ATOM   705  C CA    . GLU A 4 91  . 9.659   15.962 23.454  1.00 19.17 91  GLU A CA    1
+ATOM   706  C C     . GLU A 4 91  . 8.194   16.333 23.299  1.00 18.92 91  GLU A C     1
+ATOM   707  C CB    . GLU A 4 91  . 9.939   15.672 24.923  1.00 20.12 91  GLU A CB    1
+ATOM   708  O O     . GLU A 4 91  . 7.351   15.481 22.965  1.00 20.46 91  GLU A O     1
+ATOM   709  C CG    . GLU A 4 91  . 11.390  15.237 25.096  1.00 26.55 91  GLU A CG    1
+ATOM   710  C CD    . GLU A 4 91  . 11.934  15.075 26.513  1.00 29.19 91  GLU A CD    1
+ATOM   711  O OE1   . GLU A 4 91  . 11.246  15.360 27.499  1.00 31.44 91  GLU A OE1   1
+ATOM   712  O OE2   . GLU A 4 91  . 13.086  14.652 26.609  1.00 34.15 91  GLU A OE2   1
+ATOM   713  N N     . ASP A 4 92  . 7.867   17.617 23.545  1.00 17.92 92  ASP A N     1
+ATOM   714  C CA    . ASP A 4 92  . 6.503   18.058 23.302  1.00 16.73 92  ASP A CA    1
+ATOM   715  C C     . ASP A 4 92  . 6.077   17.953 21.842  1.00 15.45 92  ASP A C     1
+ATOM   716  C CB    . ASP A 4 92  . 6.334   19.501 23.747  1.00 19.30 92  ASP A CB    1
+ATOM   717  O O     . ASP A 4 92  . 4.882   17.999 21.577  1.00 10.57 92  ASP A O     1
+ATOM   718  C CG    . ASP A 4 92  . 6.467   19.750 25.247  1.00 19.92 92  ASP A CG    1
+ATOM   719  O OD1   . ASP A 4 92  . 6.599   18.814 26.036  1.00 18.28 92  ASP A OD1   1
+ATOM   720  O OD2   . ASP A 4 92  . 6.454   20.917 25.619  1.00 21.06 92  ASP A OD2   1
+ATOM   721  N N     . ILE A 4 93  . 6.976   17.814 20.853  1.00 15.69 93  ILE A N     1
+ATOM   722  C CA    . ILE A 4 93  . 6.547   17.713 19.461  1.00 16.80 93  ILE A CA    1
+ATOM   723  C C     . ILE A 4 93  . 5.551   16.584 19.324  1.00 17.42 93  ILE A C     1
+ATOM   724  C CB    . ILE A 4 93  . 7.759   17.482 18.465  1.00 11.84 93  ILE A CB    1
+ATOM   725  O O     . ILE A 4 93  . 4.507   16.807 18.708  1.00 14.18 93  ILE A O     1
+ATOM   726  C CG1   . ILE A 4 93  . 8.378   18.842 18.199  1.00 9.53  93  ILE A CG1   1
+ATOM   727  C CG2   . ILE A 4 93  . 7.345   16.782 17.172  1.00 8.81  93  ILE A CG2   1
+ATOM   728  C CD1   . ILE A 4 93  . 7.390   19.898 17.615  1.00 13.09 93  ILE A CD1   1
+ATOM   729  N N     . HIS A 4 94  . 5.826   15.418 19.919  1.00 18.61 94  HIS A N     1
+ATOM   730  C CA    . HIS A 4 94  . 4.868   14.320 19.824  1.00 21.55 94  HIS A CA    1
+ATOM   731  C C     . HIS A 4 94  . 3.408   14.700 20.131  1.00 18.71 94  HIS A C     1
+ATOM   732  C CB    . HIS A 4 94  . 5.315   13.197 20.753  1.00 23.57 94  HIS A CB    1
+ATOM   733  O O     . HIS A 4 94  . 2.496   14.356 19.386  1.00 17.88 94  HIS A O     1
+ATOM   734  C CG    . HIS A 4 94  . 4.709   11.909 20.208  1.00 26.77 94  HIS A CG    1
+ATOM   735  C CD2   . HIS A 4 94  . 3.621   11.262 20.710  1.00 26.64 94  HIS A CD2   1
+ATOM   736  N ND1   . HIS A 4 94  . 5.134   11.398 19.060  1.00 27.60 94  HIS A ND1   1
+ATOM   737  C CE1   . HIS A 4 94  . 4.308   10.409 18.803  1.00 28.74 94  HIS A CE1   1
+ATOM   738  N NE2   . HIS A 4 94  . 3.422   10.342 19.782  1.00 30.21 94  HIS A NE2   1
+ATOM   739  N N     . GLN A 4 95  . 3.203   15.496 21.196  1.00 19.99 95  GLN A N     1
+ATOM   740  C CA    . GLN A 4 95  . 1.918   16.025 21.648  1.00 19.06 95  GLN A CA    1
+ATOM   741  C C     . GLN A 4 95  . 1.082   16.681 20.577  1.00 17.93 95  GLN A C     1
+ATOM   742  C CB    . GLN A 4 95  . 2.091   17.096 22.755  1.00 20.35 95  GLN A CB    1
+ATOM   743  O O     . GLN A 4 95  . -0.140  16.514 20.522  1.00 12.78 95  GLN A O     1
+ATOM   744  C CG    . GLN A 4 95  . 1.821   16.602 24.166  1.00 27.68 95  GLN A CG    1
+ATOM   745  C CD    . GLN A 4 95  . 2.302   15.182 24.379  1.00 28.31 95  GLN A CD    1
+ATOM   746  N NE2   . GLN A 4 95  . 3.597   14.969 24.619  1.00 30.64 95  GLN A NE2   1
+ATOM   747  O OE1   . GLN A 4 95  . 1.511   14.240 24.273  1.00 31.88 95  GLN A OE1   1
+ATOM   748  N N     . TYR A 4 96  . 1.794   17.541 19.839  1.00 17.68 96  TYR A N     1
+ATOM   749  C CA    . TYR A 4 96  . 1.196   18.361 18.788  1.00 16.56 96  TYR A CA    1
+ATOM   750  C C     . TYR A 4 96  . 0.889   17.412 17.630  1.00 15.39 96  TYR A C     1
+ATOM   751  C CB    . TYR A 4 96  . 2.193   19.524 18.387  1.00 18.76 96  TYR A CB    1
+ATOM   752  O O     . TYR A 4 96  . -0.246  17.414 17.146  1.00 18.14 96  TYR A O     1
+ATOM   753  C CG    . TYR A 4 96  . 2.266   20.683 19.407  1.00 17.69 96  TYR A CG    1
+ATOM   754  C CD1   . TYR A 4 96  . 1.258   21.630 19.501  1.00 17.72 96  TYR A CD1   1
+ATOM   755  C CD2   . TYR A 4 96  . 3.307   20.743 20.316  1.00 18.24 96  TYR A CD2   1
+ATOM   756  C CE1   . TYR A 4 96  . 1.291   22.602 20.502  1.00 21.39 96  TYR A CE1   1
+ATOM   757  C CE2   . TYR A 4 96  . 3.344   21.719 21.318  1.00 18.64 96  TYR A CE2   1
+ATOM   758  O OH    . TYR A 4 96  . 2.369   23.583 22.443  1.00 23.11 96  TYR A OH    1
+ATOM   759  C CZ    . TYR A 4 96  . 2.334   22.644 21.413  1.00 16.86 96  TYR A CZ    1
+ATOM   760  N N     . ARG A 4 97  . 1.815   16.538 17.237  1.00 14.09 97  ARG A N     1
+ATOM   761  C CA    . ARG A 4 97  . 1.549   15.545 16.185  1.00 15.75 97  ARG A CA    1
+ATOM   762  C C     . ARG A 4 97  . 0.295   14.677 16.446  1.00 15.48 97  ARG A C     1
+ATOM   763  C CB    . ARG A 4 97  . 2.793   14.715 16.095  1.00 14.89 97  ARG A CB    1
+ATOM   764  O O     . ARG A 4 97  . -0.545  14.520 15.570  1.00 16.18 97  ARG A O     1
+ATOM   765  C CG    . ARG A 4 97  . 2.682   13.334 15.484  1.00 19.80 97  ARG A CG    1
+ATOM   766  C CD    . ARG A 4 97  . 2.981   13.419 14.034  1.00 18.95 97  ARG A CD    1
+ATOM   767  N NE    . ARG A 4 97  . 2.827   12.118 13.391  1.00 23.04 97  ARG A NE    1
+ATOM   768  N NH1   . ARG A 4 97  . 2.929   13.091 11.279  1.00 24.38 97  ARG A NH1   1
+ATOM   769  N NH2   . ARG A 4 97  . 2.545   10.829 11.492  1.00 21.32 97  ARG A NH2   1
+ATOM   770  C CZ    . ARG A 4 97  . 2.758   12.015 12.056  1.00 22.40 97  ARG A CZ    1
+ATOM   771  N N     . GLU A 4 98  . 0.075   14.115 17.633  1.00 14.98 98  GLU A N     1
+ATOM   772  C CA    . GLU A 4 98  . -1.084  13.259 17.857  1.00 16.28 98  GLU A CA    1
+ATOM   773  C C     . GLU A 4 98  . -2.393  14.023 17.881  1.00 16.55 98  GLU A C     1
+ATOM   774  C CB    . GLU A 4 98  . -0.894  12.507 19.171  1.00 19.65 98  GLU A CB    1
+ATOM   775  O O     . GLU A 4 98  . -3.439  13.636 17.334  1.00 14.44 98  GLU A O     1
+ATOM   776  C CG    . GLU A 4 98  . 0.295   11.557 19.197  1.00 23.49 98  GLU A CG    1
+ATOM   777  C CD    . GLU A 4 98  . 0.294   10.421 18.171  1.00 24.91 98  GLU A CD    1
+ATOM   778  O OE1   . GLU A 4 98  . -0.697  9.699  18.094  1.00 26.24 98  GLU A OE1   1
+ATOM   779  O OE2   . GLU A 4 98  . 1.286   10.237 17.451  1.00 25.77 98  GLU A OE2   1
+ATOM   780  N N     . GLN A 4 99  . -2.363  15.168 18.546  1.00 16.35 99  GLN A N     1
+ATOM   781  C CA    . GLN A 4 99  . -3.541  15.995 18.504  1.00 18.81 99  GLN A CA    1
+ATOM   782  C C     . GLN A 4 99  . -3.806  16.452 17.076  1.00 16.82 99  GLN A C     1
+ATOM   783  C CB    . GLN A 4 99  . -3.376  17.200 19.394  1.00 20.01 99  GLN A CB    1
+ATOM   784  O O     . GLN A 4 99  . -4.984  16.527 16.720  1.00 19.61 99  GLN A O     1
+ATOM   785  C CG    . GLN A 4 99  . -4.760  17.826 19.575  1.00 27.49 99  GLN A CG    1
+ATOM   786  C CD    . GLN A 4 99  . -4.838  19.021 20.531  1.00 29.05 99  GLN A CD    1
+ATOM   787  N NE2   . GLN A 4 99  . -5.995  19.629 20.245  1.00 26.83 99  GLN A NE2   1
+ATOM   788  O OE1   . GLN A 4 99  . -4.032  19.509 21.339  1.00 28.47 99  GLN A OE1   1
+ATOM   789  N N     . ILE A 4 100 . -2.836  16.791 16.211  1.00 13.90 100 ILE A N     1
+ATOM   790  C CA    . ILE A 4 100 . -3.195  17.076 14.811  1.00 10.37 100 ILE A CA    1
+ATOM   791  C C     . ILE A 4 100 . -3.860  15.826 14.174  1.00 12.44 100 ILE A C     1
+ATOM   792  C CB    . ILE A 4 100 . -1.889  17.499 14.075  1.00 10.73 100 ILE A CB    1
+ATOM   793  O O     . ILE A 4 100 . -4.902  15.886 13.493  1.00 12.92 100 ILE A O     1
+ATOM   794  C CG1   . ILE A 4 100 . -1.602  18.945 14.407  1.00 8.73  100 ILE A CG1   1
+ATOM   795  C CG2   . ILE A 4 100 . -2.006  17.320 12.586  1.00 13.65 100 ILE A CG2   1
+ATOM   796  C CD1   . ILE A 4 100 . -0.173  19.446 14.073  1.00 6.57  100 ILE A CD1   1
+ATOM   797  N N     . LYS A 4 101 . -3.331  14.641 14.409  1.00 11.29 101 LYS A N     1
+ATOM   798  C CA    . LYS A 4 101 . -3.860  13.421 13.782  1.00 16.26 101 LYS A CA    1
+ATOM   799  C C     . LYS A 4 101 . -5.293  13.053 14.116  1.00 17.56 101 LYS A C     1
+ATOM   800  C CB    . LYS A 4 101 . -2.984  12.265 14.141  1.00 20.40 101 LYS A CB    1
+ATOM   801  O O     . LYS A 4 101 . -6.063  12.668 13.236  1.00 17.75 101 LYS A O     1
+ATOM   802  C CG    . LYS A 4 101 . -1.673  12.270 13.359  1.00 25.96 101 LYS A CG    1
+ATOM   803  C CD    . LYS A 4 101 . -0.706  11.331 14.067  1.00 31.77 101 LYS A CD    1
+ATOM   804  C CE    . LYS A 4 101 . -1.288  9.948  14.322  1.00 33.22 101 LYS A CE    1
+ATOM   805  N NZ    . LYS A 4 101 . -0.405  9.174  15.176  1.00 37.16 101 LYS A NZ    1
+ATOM   806  N N     . ARG A 4 102 . -5.592  13.227 15.404  1.00 21.60 102 ARG A N     1
+ATOM   807  C CA    . ARG A 4 102 . -6.880  13.068 16.060  1.00 22.65 102 ARG A CA    1
+ATOM   808  C C     . ARG A 4 102 . -7.954  13.916 15.402  1.00 24.09 102 ARG A C     1
+ATOM   809  C CB    . ARG A 4 102 . -6.827  13.541 17.513  1.00 26.77 102 ARG A CB    1
+ATOM   810  O O     . ARG A 4 102 . -9.030  13.414 15.068  1.00 25.87 102 ARG A O     1
+ATOM   811  C CG    . ARG A 4 102 . -7.029  12.646 18.738  1.00 32.02 102 ARG A CG    1
+ATOM   812  C CD    . ARG A 4 102 . -7.509  13.533 19.900  1.00 32.09 102 ARG A CD    1
+ATOM   813  N NE    . ARG A 4 102 . -8.811  14.093 19.562  1.00 33.70 102 ARG A NE    1
+ATOM   814  N NH1   . ARG A 4 102 . -8.246  16.352 19.987  1.00 31.68 102 ARG A NH1   1
+ATOM   815  N NH2   . ARG A 4 102 . -10.304 15.732 19.182  1.00 37.72 102 ARG A NH2   1
+ATOM   816  C CZ    . ARG A 4 102 . -9.091  15.396 19.575  1.00 33.00 102 ARG A CZ    1
+ATOM   817  N N     . VAL A 4 103 . -7.712  15.227 15.295  1.00 21.82 103 VAL A N     1
+ATOM   818  C CA    . VAL A 4 103 . -8.740  16.098 14.771  1.00 21.59 103 VAL A CA    1
+ATOM   819  C C     . VAL A 4 103 . -8.837  16.010 13.263  1.00 20.64 103 VAL A C     1
+ATOM   820  C CB    . VAL A 4 103 . -8.522  17.590 15.160  1.00 22.45 103 VAL A CB    1
+ATOM   821  O O     . VAL A 4 103 . -9.914  16.269 12.736  1.00 24.79 103 VAL A O     1
+ATOM   822  C CG1   . VAL A 4 103 . -8.294  17.628 16.659  1.00 26.06 103 VAL A CG1   1
+ATOM   823  C CG2   . VAL A 4 103 . -7.363  18.233 14.447  1.00 23.64 103 VAL A CG2   1
+ATOM   824  N N     . LYS A 4 104 . -7.792  15.656 12.528  1.00 19.12 104 LYS A N     1
+ATOM   825  C CA    . LYS A 4 104 . -7.895  15.587 11.073  1.00 19.72 104 LYS A CA    1
+ATOM   826  C C     . LYS A 4 104 . -8.343  14.236 10.572  1.00 20.92 104 LYS A C     1
+ATOM   827  C CB    . LYS A 4 104 . -6.551  15.920 10.411  1.00 18.48 104 LYS A CB    1
+ATOM   828  O O     . LYS A 4 104 . -8.457  14.049 9.348   1.00 22.74 104 LYS A O     1
+ATOM   829  C CG    . LYS A 4 104 . -5.948  17.336 10.658  1.00 18.26 104 LYS A CG    1
+ATOM   830  C CD    . LYS A 4 104 . -6.687  18.528 10.029  1.00 16.72 104 LYS A CD    1
+ATOM   831  C CE    . LYS A 4 104 . -6.272  18.804 8.587   1.00 14.87 104 LYS A CE    1
+ATOM   832  N NZ    . LYS A 4 104 . -7.047  19.870 7.975   1.00 12.36 104 LYS A NZ    1
+ATOM   833  N N     . ASP A 4 105 . -8.564  13.281 11.507  1.00 21.60 105 ASP A N     1
+ATOM   834  C CA    . ASP A 4 105 . -8.941  11.905 11.164  1.00 21.23 105 ASP A CA    1
+ATOM   835  C C     . ASP A 4 105 . -7.893  11.304 10.249  1.00 22.05 105 ASP A C     1
+ATOM   836  C CB    . ASP A 4 105 . -10.255 11.777 10.362  1.00 24.78 105 ASP A CB    1
+ATOM   837  O O     . ASP A 4 105 . -8.211  10.461 9.412   1.00 21.37 105 ASP A O     1
+ATOM   838  C CG    . ASP A 4 105 . -11.578 12.006 11.041  1.00 29.15 105 ASP A CG    1
+ATOM   839  O OD1   . ASP A 4 105 . -11.596 11.975 12.279  1.00 28.61 105 ASP A OD1   1
+ATOM   840  O OD2   . ASP A 4 105 . -12.572 12.182 10.306  1.00 32.15 105 ASP A OD2   1
+ATOM   841  N N     . SER A 4 106 . -6.629  11.694 10.319  1.00 22.08 106 SER A N     1
+ATOM   842  C CA    . SER A 4 106 . -5.689  11.222 9.337   1.00 21.39 106 SER A CA    1
+ATOM   843  C C     . SER A 4 106 . -4.290  11.015 9.922   1.00 19.60 106 SER A C     1
+ATOM   844  C CB    . SER A 4 106 . -5.782  12.267 8.188   1.00 23.74 106 SER A CB    1
+ATOM   845  O O     . SER A 4 106 . -3.865  11.639 10.889  1.00 17.78 106 SER A O     1
+ATOM   846  O OG    . SER A 4 106 . -5.162  11.910 6.959   1.00 24.91 106 SER A OG    1
+ATOM   847  N N     . ASP A 4 107 . -3.621  10.017 9.359   1.00 21.92 107 ASP A N     1
+ATOM   848  C CA    . ASP A 4 107 . -2.256  9.696  9.702   1.00 23.92 107 ASP A CA    1
+ATOM   849  C C     . ASP A 4 107 . -1.260  10.329 8.741   1.00 21.88 107 ASP A C     1
+ATOM   850  C CB    . ASP A 4 107 . -2.144  8.154  9.743   1.00 23.04 107 ASP A CB    1
+ATOM   851  O O     . ASP A 4 107 . -0.071  10.425 9.029   1.00 21.60 107 ASP A O     1
+ATOM   852  C CG    . ASP A 4 107 . -2.912  7.521  10.911  1.00 24.05 107 ASP A CG    1
+ATOM   853  O OD1   . ASP A 4 107 . -2.955  8.073  12.012  1.00 28.33 107 ASP A OD1   1
+ATOM   854  O OD2   . ASP A 4 107 . -3.482  6.461  10.734  1.00 22.05 107 ASP A OD2   1
+ATOM   855  N N     . ASP A 4 108 . -1.765  10.826 7.613   1.00 26.95 108 ASP A N     1
+ATOM   856  C CA    . ASP A 4 108 . -0.983  11.445 6.555   1.00 29.01 108 ASP A CA    1
+ATOM   857  C C     . ASP A 4 108 . -1.387  12.912 6.384   1.00 29.23 108 ASP A C     1
+ATOM   858  C CB    . ASP A 4 108 . -1.164  10.646 5.198   1.00 34.99 108 ASP A CB    1
+ATOM   859  O O     . ASP A 4 108 . -1.989  13.316 5.385   1.00 31.16 108 ASP A O     1
+ATOM   860  C CG    . ASP A 4 108 . -2.388  10.686 4.237   1.00 40.51 108 ASP A CG    1
+ATOM   861  O OD1   . ASP A 4 108 . -3.556  10.727 4.652   1.00 45.23 108 ASP A OD1   1
+ATOM   862  O OD2   . ASP A 4 108 . -2.162  10.621 3.018   1.00 42.53 108 ASP A OD2   1
+ATOM   863  N N     . VAL A 4 109 . -1.106  13.761 7.372   1.00 24.05 109 VAL A N     1
+ATOM   864  C CA    . VAL A 4 109 . -1.451  15.161 7.171   1.00 23.13 109 VAL A CA    1
+ATOM   865  C C     . VAL A 4 109 . -0.166  15.946 6.832   1.00 19.24 109 VAL A C     1
+ATOM   866  C CB    . VAL A 4 109 . -2.288  15.673 8.471   1.00 25.42 109 VAL A CB    1
+ATOM   867  O O     . VAL A 4 109 . 0.890   15.625 7.385   1.00 18.43 109 VAL A O     1
+ATOM   868  C CG1   . VAL A 4 109 . -1.926  14.950 9.767   1.00 25.67 109 VAL A CG1   1
+ATOM   869  C CG2   . VAL A 4 109 . -2.093  17.190 8.579   1.00 19.99 109 VAL A CG2   1
+ATOM   870  N N     . PRO A 4 110 . -0.179  16.863 5.816   1.00 17.48 110 PRO A N     1
+ATOM   871  C CA    . PRO A 4 110 . 0.958   17.695 5.411   1.00 12.56 110 PRO A CA    1
+ATOM   872  C C     . PRO A 4 110 . 1.634   18.308 6.638   1.00 10.99 110 PRO A C     1
+ATOM   873  C CB    . PRO A 4 110 . 0.316   18.701 4.475   1.00 13.32 110 PRO A CB    1
+ATOM   874  O O     . PRO A 4 110 . 1.008   19.032 7.406   1.00 9.09  110 PRO A O     1
+ATOM   875  C CG    . PRO A 4 110 . -0.729  17.883 3.765   1.00 15.02 110 PRO A CG    1
+ATOM   876  C CD    . PRO A 4 110 . -1.343  17.163 4.952   1.00 13.08 110 PRO A CD    1
+ATOM   877  N N     . MET A 4 111 . 2.923   18.046 6.857   1.00 13.85 111 MET A N     1
+ATOM   878  C CA    . MET A 4 111 . 3.626   18.490 8.067   1.00 15.34 111 MET A CA    1
+ATOM   879  C C     . MET A 4 111 . 5.143   18.522 7.886   1.00 17.02 111 MET A C     1
+ATOM   880  C CB    . MET A 4 111 . 3.237   17.523 9.183   1.00 17.36 111 MET A CB    1
+ATOM   881  O O     . MET A 4 111 . 5.686   17.680 7.169   1.00 14.33 111 MET A O     1
+ATOM   882  C CG    . MET A 4 111 . 3.516   17.882 10.609  1.00 18.58 111 MET A CG    1
+ATOM   883  S SD    . MET A 4 111 . 2.760   16.625 11.665  1.00 21.20 111 MET A SD    1
+ATOM   884  C CE    . MET A 4 111 . 1.082   16.724 11.129  1.00 15.10 111 MET A CE    1
+ATOM   885  N N     . VAL A 4 112 . 5.864   19.489 8.472   1.00 15.99 112 VAL A N     1
+ATOM   886  C CA    . VAL A 4 112 . 7.320   19.452 8.466   1.00 13.92 112 VAL A CA    1
+ATOM   887  C C     . VAL A 4 112 . 7.810   19.880 9.827   1.00 10.66 112 VAL A C     1
+ATOM   888  C CB    . VAL A 4 112 . 7.946   20.354 7.277   1.00 16.36 112 VAL A CB    1
+ATOM   889  O O     . VAL A 4 112 . 7.287   20.802 10.438  1.00 10.35 112 VAL A O     1
+ATOM   890  C CG1   . VAL A 4 112 . 7.138   21.594 7.091   1.00 16.89 112 VAL A CG1   1
+ATOM   891  C CG2   . VAL A 4 112 . 9.399   20.779 7.573   1.00 13.20 112 VAL A CG2   1
+ATOM   892  N N     . LEU A 4 113 . 8.731   19.052 10.314  1.00 6.03  113 LEU A N     1
+ATOM   893  C CA    . LEU A 4 113 . 9.456   19.246 11.568  1.00 8.77  113 LEU A CA    1
+ATOM   894  C C     . LEU A 4 113 . 10.579  20.243 11.366  1.00 5.87  113 LEU A C     1
+ATOM   895  C CB    . LEU A 4 113 . 10.058  17.933 12.052  1.00 11.27 113 LEU A CB    1
+ATOM   896  O O     . LEU A 4 113 . 11.450  20.055 10.514  1.00 5.60  113 LEU A O     1
+ATOM   897  C CG    . LEU A 4 113 . 10.689  17.891 13.419  1.00 8.37  113 LEU A CG    1
+ATOM   898  C CD1   . LEU A 4 113 . 9.640   18.179 14.437  1.00 9.92  113 LEU A CD1   1
+ATOM   899  C CD2   . LEU A 4 113 . 11.290  16.519 13.667  1.00 9.68  113 LEU A CD2   1
+ATOM   900  N N     . VAL A 4 114 . 10.527  21.342 12.127  1.00 6.61  114 VAL A N     1
+ATOM   901  C CA    . VAL A 4 114 . 11.459  22.417 11.975  1.00 4.83  114 VAL A CA    1
+ATOM   902  C C     . VAL A 4 114 . 12.299  22.520 13.218  1.00 5.26  114 VAL A C     1
+ATOM   903  C CB    . VAL A 4 114 . 10.646  23.674 11.715  1.00 2.00  114 VAL A CB    1
+ATOM   904  O O     . VAL A 4 114 . 11.732  22.665 14.289  1.00 9.45  114 VAL A O     1
+ATOM   905  C CG1   . VAL A 4 114 . 11.577  24.844 11.655  1.00 3.92  114 VAL A CG1   1
+ATOM   906  C CG2   . VAL A 4 114 . 9.904   23.571 10.394  1.00 4.23  114 VAL A CG2   1
+ATOM   907  N N     . GLY A 4 115 . 13.617  22.430 13.160  1.00 4.75  115 GLY A N     1
+ATOM   908  C CA    . GLY A 4 115 . 14.417  22.595 14.345  1.00 5.03  115 GLY A CA    1
+ATOM   909  C C     . GLY A 4 115 . 14.998  24.002 14.295  1.00 4.53  115 GLY A C     1
+ATOM   910  O O     . GLY A 4 115 . 15.991  24.242 13.610  1.00 6.33  115 GLY A O     1
+ATOM   911  N N     . ASN A 4 116 . 14.454  24.953 15.036  1.00 6.13  116 ASN A N     1
+ATOM   912  C CA    . ASN A 4 116 . 14.901  26.337 14.946  1.00 8.71  116 ASN A CA    1
+ATOM   913  C C     . ASN A 4 116 . 16.027  26.650 15.964  1.00 11.32 116 ASN A C     1
+ATOM   914  C CB    . ASN A 4 116 . 13.644  27.194 15.144  1.00 6.49  116 ASN A CB    1
+ATOM   915  O O     . ASN A 4 116 . 16.344  25.860 16.856  1.00 9.77  116 ASN A O     1
+ATOM   916  C CG    . ASN A 4 116 . 13.776  28.693 14.946  1.00 9.62  116 ASN A CG    1
+ATOM   917  N ND2   . ASN A 4 116 . 13.377  29.509 15.944  1.00 5.40  116 ASN A ND2   1
+ATOM   918  O OD1   . ASN A 4 116 . 14.222  29.142 13.889  1.00 8.62  116 ASN A OD1   1
+ATOM   919  N N     . LYS A 4 117 . 16.622  27.830 15.784  1.00 11.65 117 LYS A N     1
+ATOM   920  C CA    . LYS A 4 117 . 17.727  28.444 16.526  1.00 13.46 117 LYS A CA    1
+ATOM   921  C C     . LYS A 4 117 . 19.092  27.797 16.273  1.00 14.84 117 LYS A C     1
+ATOM   922  C CB    . LYS A 4 117 . 17.370  28.445 18.040  1.00 14.11 117 LYS A CB    1
+ATOM   923  O O     . LYS A 4 117 . 20.001  27.779 17.120  1.00 14.23 117 LYS A O     1
+ATOM   924  C CG    . LYS A 4 117 . 15.939  28.966 18.308  1.00 10.72 117 LYS A CG    1
+ATOM   925  C CD    . LYS A 4 117 . 15.739  29.199 19.786  1.00 11.84 117 LYS A CD    1
+ATOM   926  C CE    . LYS A 4 117 . 14.407  29.837 20.032  1.00 11.09 117 LYS A CE    1
+ATOM   927  N NZ    . LYS A 4 117 . 14.388  30.309 21.394  1.00 13.07 117 LYS A NZ    1
+ATOM   928  N N     . CYS A 4 118 . 19.290  27.343 15.031  1.00 11.43 118 CYS A N     1
+ATOM   929  C CA    . CYS A 4 118 . 20.506  26.618 14.675  1.00 14.91 118 CYS A CA    1
+ATOM   930  C C     . CYS A 4 118 . 21.803  27.428 14.641  1.00 15.03 118 CYS A C     1
+ATOM   931  C CB    . CYS A 4 118 . 20.280  25.887 13.306  1.00 17.21 118 CYS A CB    1
+ATOM   932  O O     . CYS A 4 118 . 22.905  26.894 14.557  1.00 15.03 118 CYS A O     1
+ATOM   933  S SG    . CYS A 4 118 . 20.171  26.810 11.752  1.00 18.09 118 CYS A SG    1
+ATOM   934  N N     . ASP A 4 119 . 21.642  28.745 14.715  1.00 16.62 119 ASP A N     1
+ATOM   935  C CA    . ASP A 4 119 . 22.719  29.708 14.855  1.00 17.35 119 ASP A CA    1
+ATOM   936  C C     . ASP A 4 119 . 23.360  29.644 16.252  1.00 17.86 119 ASP A C     1
+ATOM   937  C CB    . ASP A 4 119 . 22.132  31.116 14.575  1.00 15.36 119 ASP A CB    1
+ATOM   938  O O     . ASP A 4 119 . 24.485  30.095 16.452  1.00 16.29 119 ASP A O     1
+ATOM   939  C CG    . ASP A 4 119 . 21.027  31.501 15.528  1.00 13.01 119 ASP A CG    1
+ATOM   940  O OD1   . ASP A 4 119 . 19.901  31.098 15.306  1.00 7.12  119 ASP A OD1   1
+ATOM   941  O OD2   . ASP A 4 119 . 21.287  32.176 16.513  1.00 13.71 119 ASP A OD2   1
+ATOM   942  N N     . LEU A 4 120 . 22.665  29.078 17.256  1.00 19.76 120 LEU A N     1
+ATOM   943  C CA    . LEU A 4 120 . 23.150  29.021 18.631  1.00 19.60 120 LEU A CA    1
+ATOM   944  C C     . LEU A 4 120 . 24.042  27.817 18.875  1.00 21.53 120 LEU A C     1
+ATOM   945  C CB    . LEU A 4 120 . 21.981  28.950 19.617  1.00 19.93 120 LEU A CB    1
+ATOM   946  O O     . LEU A 4 120 . 23.710  26.695 18.467  1.00 20.24 120 LEU A O     1
+ATOM   947  C CG    . LEU A 4 120 . 21.052  30.132 19.875  1.00 17.20 120 LEU A CG    1
+ATOM   948  C CD1   . LEU A 4 120 . 20.003  29.660 20.869  1.00 19.86 120 LEU A CD1   1
+ATOM   949  C CD2   . LEU A 4 120 . 21.816  31.358 20.372  1.00 16.37 120 LEU A CD2   1
+ATOM   950  N N     . ALA A 4 121 . 25.193  28.067 19.510  1.00 19.27 121 ALA A N     1
+ATOM   951  C CA    . ALA A 4 121 . 26.099  26.995 19.882  1.00 23.61 121 ALA A CA    1
+ATOM   952  C C     . ALA A 4 121 . 25.725  26.748 21.323  1.00 25.94 121 ALA A C     1
+ATOM   953  C CB    . ALA A 4 121 . 27.553  27.441 19.805  1.00 23.12 121 ALA A CB    1
+ATOM   954  O O     . ALA A 4 121 . 26.014  27.534 22.220  1.00 30.79 121 ALA A O     1
+ATOM   955  N N     . ALA A 4 122 . 24.959  25.692 21.517  1.00 26.89 122 ALA A N     1
+ATOM   956  C CA    . ALA A 4 122 . 24.414  25.349 22.813  1.00 25.13 122 ALA A CA    1
+ATOM   957  C C     . ALA A 4 122 . 23.279  24.373 22.586  1.00 24.10 122 ALA A C     1
+ATOM   958  O O     . ALA A 4 122 . 22.276  24.340 23.297  1.00 24.67 122 ALA A O     1
+ATOM   959  N N     . ARG A 4 123 . 23.511  23.562 21.564  1.00 23.10 123 ARG A N     1
+ATOM   960  C CA    . ARG A 4 123 . 22.619  22.530 21.104  1.00 20.91 123 ARG A CA    1
+ATOM   961  C C     . ARG A 4 123 . 22.502  21.388 22.106  1.00 21.93 123 ARG A C     1
+ATOM   962  C CB    . ARG A 4 123 . 23.161  22.038 19.781  1.00 19.67 123 ARG A CB    1
+ATOM   963  O O     . ARG A 4 123 . 23.503  20.889 22.628  1.00 18.99 123 ARG A O     1
+ATOM   964  C CG    . ARG A 4 123 . 22.481  20.812 19.215  1.00 22.60 123 ARG A CG    1
+ATOM   965  C CD    . ARG A 4 123 . 23.108  20.334 17.906  1.00 20.37 123 ARG A CD    1
+ATOM   966  N NE    . ARG A 4 123 . 23.029  21.360 16.886  1.00 21.63 123 ARG A NE    1
+ATOM   967  N NH1   . ARG A 4 123 . 21.181  20.393 15.769  1.00 16.45 123 ARG A NH1   1
+ATOM   968  N NH2   . ARG A 4 123 . 22.219  22.369 15.058  1.00 18.84 123 ARG A NH2   1
+ATOM   969  C CZ    . ARG A 4 123 . 22.133  21.348 15.901  1.00 19.02 123 ARG A CZ    1
+ATOM   970  N N     . THR A 4 124 . 21.264  20.973 22.396  1.00 21.48 124 THR A N     1
+ATOM   971  C CA    . THR A 4 124 . 21.037  19.846 23.271  1.00 18.90 124 THR A CA    1
+ATOM   972  C C     . THR A 4 124 . 20.245  18.795 22.521  1.00 19.00 124 THR A C     1
+ATOM   973  C CB    . THR A 4 124 . 20.289  20.291 24.524  1.00 20.99 124 THR A CB    1
+ATOM   974  O O     . THR A 4 124 . 20.163  17.671 22.990  1.00 18.55 124 THR A O     1
+ATOM   975  C CG2   . THR A 4 124 . 20.991  21.460 25.219  1.00 21.51 124 THR A CG2   1
+ATOM   976  O OG1   . THR A 4 124 . 18.968  20.617 24.134  1.00 18.03 124 THR A OG1   1
+ATOM   977  N N     . VAL A 4 125 . 19.665  19.120 21.352  1.00 19.39 125 VAL A N     1
+ATOM   978  C CA    . VAL A 4 125 . 18.975  18.143 20.522  1.00 17.84 125 VAL A CA    1
+ATOM   979  C C     . VAL A 4 125 . 19.885  17.872 19.318  1.00 20.64 125 VAL A C     1
+ATOM   980  C CB    . VAL A 4 125 . 17.593  18.701 20.043  1.00 15.08 125 VAL A CB    1
+ATOM   981  O O     . VAL A 4 125 . 20.033  18.742 18.456  1.00 23.00 125 VAL A O     1
+ATOM   982  C CG1   . VAL A 4 125 . 16.961  17.708 19.119  1.00 14.15 125 VAL A CG1   1
+ATOM   983  C CG2   . VAL A 4 125 . 16.637  18.938 21.207  1.00 15.51 125 VAL A CG2   1
+ATOM   984  N N     . GLU A 4 126 . 20.553  16.714 19.212  1.00 22.21 126 GLU A N     1
+ATOM   985  C CA    . GLU A 4 126 . 21.330  16.375 18.004  1.00 24.80 126 GLU A CA    1
+ATOM   986  C C     . GLU A 4 126 . 20.465  16.225 16.763  1.00 21.61 126 GLU A C     1
+ATOM   987  C CB    . GLU A 4 126 . 22.102  15.035 18.121  1.00 28.88 126 GLU A CB    1
+ATOM   988  O O     . GLU A 4 126 . 19.346  15.702 16.815  1.00 18.61 126 GLU A O     1
+ATOM   989  C CG    . GLU A 4 126 . 23.344  15.059 19.020  1.00 36.04 126 GLU A CG    1
+ATOM   990  C CD    . GLU A 4 126 . 24.432  16.086 18.669  1.00 38.33 126 GLU A CD    1
+ATOM   991  O OE1   . GLU A 4 126 . 24.327  17.254 19.038  1.00 38.50 126 GLU A OE1   1
+ATOM   992  O OE2   . GLU A 4 126 . 25.414  15.722 18.029  1.00 41.84 126 GLU A OE2   1
+ATOM   993  N N     . SER A 4 127 . 21.005  16.643 15.616  1.00 22.77 127 SER A N     1
+ATOM   994  C CA    . SER A 4 127 . 20.334  16.491 14.327  1.00 19.90 127 SER A CA    1
+ATOM   995  C C     . SER A 4 127 . 19.909  15.072 14.093  1.00 18.95 127 SER A C     1
+ATOM   996  C CB    . SER A 4 127 . 21.233  16.869 13.184  1.00 20.73 127 SER A CB    1
+ATOM   997  O O     . SER A 4 127 . 18.763  14.880 13.681  1.00 13.90 127 SER A O     1
+ATOM   998  O OG    . SER A 4 127 . 21.428  18.260 13.381  1.00 28.29 127 SER A OG    1
+ATOM   999  N N     . ARG A 4 128 . 20.779  14.090 14.427  1.00 21.70 128 ARG A N     1
+ATOM   1000 C CA    . ARG A 4 128 . 20.399  12.692 14.188  1.00 23.63 128 ARG A CA    1
+ATOM   1001 C C     . ARG A 4 128 . 19.160  12.300 14.959  1.00 22.65 128 ARG A C     1
+ATOM   1002 C CB    . ARG A 4 128 . 21.510  11.679 14.546  1.00 26.74 128 ARG A CB    1
+ATOM   1003 O O     . ARG A 4 128 . 18.346  11.572 14.399  1.00 26.46 128 ARG A O     1
+ATOM   1004 C CG    . ARG A 4 128 . 21.818  10.785 13.317  1.00 31.78 128 ARG A CG    1
+ATOM   1005 C CD    . ARG A 4 128 . 23.326  10.446 13.091  1.00 34.94 128 ARG A CD    1
+ATOM   1006 N NE    . ARG A 4 128 . 23.735  10.284 11.681  1.00 39.35 128 ARG A NE    1
+ATOM   1007 N NH1   . ARG A 4 128 . 24.748  12.417 11.538  1.00 42.73 128 ARG A NH1   1
+ATOM   1008 N NH2   . ARG A 4 128 . 24.790  11.042 9.698   1.00 40.83 128 ARG A NH2   1
+ATOM   1009 C CZ    . ARG A 4 128 . 24.416  11.238 10.981  1.00 41.93 128 ARG A CZ    1
+ATOM   1010 N N     . GLN A 4 129 . 18.906  12.813 16.170  1.00 22.80 129 GLN A N     1
+ATOM   1011 C CA    . GLN A 4 129 . 17.718  12.434 16.934  1.00 19.79 129 GLN A CA    1
+ATOM   1012 C C     . GLN A 4 129 . 16.441  12.810 16.193  1.00 16.84 129 GLN A C     1
+ATOM   1013 C CB    . GLN A 4 129 . 17.656  13.157 18.255  1.00 23.95 129 GLN A CB    1
+ATOM   1014 O O     . GLN A 4 129 . 15.448  12.097 16.160  1.00 15.03 129 GLN A O     1
+ATOM   1015 C CG    . GLN A 4 129 . 18.725  13.029 19.317  1.00 27.95 129 GLN A CG    1
+ATOM   1016 C CD    . GLN A 4 129 . 18.390  13.877 20.544  1.00 29.52 129 GLN A CD    1
+ATOM   1017 N NE2   . GLN A 4 129 . 17.148  13.871 21.017  1.00 31.02 129 GLN A NE2   1
+ATOM   1018 O OE1   . GLN A 4 129 . 19.238  14.559 21.109  1.00 31.31 129 GLN A OE1   1
+ATOM   1019 N N     . ALA A 4 130 . 16.470  14.065 15.756  1.00 14.26 130 ALA A N     1
+ATOM   1020 C CA    . ALA A 4 130 . 15.355  14.693 15.099  1.00 16.59 130 ALA A CA    1
+ATOM   1021 C C     . ALA A 4 130 . 15.128  14.161 13.690  1.00 17.00 130 ALA A C     1
+ATOM   1022 C CB    . ALA A 4 130 . 15.624  16.163 15.029  1.00 16.88 130 ALA A CB    1
+ATOM   1023 O O     . ALA A 4 130 . 13.993  14.169 13.220  1.00 16.14 130 ALA A O     1
+ATOM   1024 N N     . GLN A 4 131 . 16.221  13.761 13.002  1.00 16.98 131 GLN A N     1
+ATOM   1025 C CA    . GLN A 4 131 . 16.174  13.152 11.671  1.00 15.92 131 GLN A CA    1
+ATOM   1026 C C     . GLN A 4 131 . 15.459  11.812 11.636  1.00 15.07 131 GLN A C     1
+ATOM   1027 C CB    . GLN A 4 131 . 17.548  12.890 11.127  1.00 16.68 131 GLN A CB    1
+ATOM   1028 O O     . GLN A 4 131 . 14.685  11.482 10.717  1.00 15.86 131 GLN A O     1
+ATOM   1029 C CG    . GLN A 4 131 . 18.022  13.810 10.044  1.00 21.18 131 GLN A CG    1
+ATOM   1030 C CD    . GLN A 4 131 . 16.950  14.029 8.996   1.00 22.20 131 GLN A CD    1
+ATOM   1031 N NE2   . GLN A 4 131 . 15.971  13.170 8.643   1.00 21.00 131 GLN A NE2   1
+ATOM   1032 O OE1   . GLN A 4 131 . 16.977  15.118 8.458   1.00 26.46 131 GLN A OE1   1
+ATOM   1033 N N     . ASP A 4 132 . 15.769  11.045 12.684  1.00 15.18 132 ASP A N     1
+ATOM   1034 C CA    . ASP A 4 132 . 15.153  9.756  12.891  1.00 14.74 132 ASP A CA    1
+ATOM   1035 C C     . ASP A 4 132 . 13.721  9.945  13.303  1.00 16.46 132 ASP A C     1
+ATOM   1036 C CB    . ASP A 4 132 . 15.962  9.073  13.932  1.00 17.73 132 ASP A CB    1
+ATOM   1037 O O     . ASP A 4 132 . 12.847  9.262  12.783  1.00 20.62 132 ASP A O     1
+ATOM   1038 C CG    . ASP A 4 132 . 17.393  8.757  13.488  1.00 22.37 132 ASP A CG    1
+ATOM   1039 O OD1   . ASP A 4 132 . 17.901  9.250  12.459  1.00 24.08 132 ASP A OD1   1
+ATOM   1040 O OD2   . ASP A 4 132 . 18.014  7.979  14.212  1.00 25.11 132 ASP A OD2   1
+ATOM   1041 N N     . LEU A 4 133 . 13.391  10.885 14.203  1.00 16.15 133 LEU A N     1
+ATOM   1042 C CA    . LEU A 4 133 . 11.990  11.130 14.566  1.00 14.26 133 LEU A CA    1
+ATOM   1043 C C     . LEU A 4 133 . 11.156  11.429 13.335  1.00 12.39 133 LEU A C     1
+ATOM   1044 C CB    . LEU A 4 133 . 11.834  12.336 15.526  1.00 15.29 133 LEU A CB    1
+ATOM   1045 O O     . LEU A 4 133 . 10.136  10.790 13.063  1.00 13.12 133 LEU A O     1
+ATOM   1046 C CG    . LEU A 4 133 . 10.494  12.500 16.234  1.00 11.53 133 LEU A CG    1
+ATOM   1047 C CD1   . LEU A 4 133 . 10.432  11.494 17.356  1.00 14.77 133 LEU A CD1   1
+ATOM   1048 C CD2   . LEU A 4 133 . 10.360  13.859 16.891  1.00 10.29 133 LEU A CD2   1
+ATOM   1049 N N     . ALA A 4 134 . 11.615  12.453 12.618  1.00 12.99 134 ALA A N     1
+ATOM   1050 C CA    . ALA A 4 134 . 10.907  12.918 11.433  1.00 15.23 134 ALA A CA    1
+ATOM   1051 C C     . ALA A 4 134 . 10.725  11.812 10.414  1.00 18.90 134 ALA A C     1
+ATOM   1052 C CB    . ALA A 4 134 . 11.669  14.040 10.771  1.00 16.46 134 ALA A CB    1
+ATOM   1053 O O     . ALA A 4 134 . 9.712   11.825 9.740   1.00 18.15 134 ALA A O     1
+ATOM   1054 N N     . ARG A 4 135 . 11.692  10.886 10.270  1.00 23.36 135 ARG A N     1
+ATOM   1055 C CA    . ARG A 4 135 . 11.583  9.708  9.406   1.00 26.54 135 ARG A CA    1
+ATOM   1056 C C     . ARG A 4 135 . 10.519  8.719  9.925   1.00 25.49 135 ARG A C     1
+ATOM   1057 C CB    . ARG A 4 135 . 12.936  8.936  9.294   1.00 26.86 135 ARG A CB    1
+ATOM   1058 O O     . ARG A 4 135 . 9.857   8.086  9.080   1.00 22.41 135 ARG A O     1
+ATOM   1059 C CG    . ARG A 4 135 . 12.921  8.023  8.061   1.00 31.82 135 ARG A CG    1
+ATOM   1060 C CD    . ARG A 4 135 . 13.947  6.863  7.996   1.00 34.52 135 ARG A CD    1
+ATOM   1061 N NE    . ARG A 4 135 . 13.312  5.647  7.461   1.00 38.12 135 ARG A NE    1
+ATOM   1062 N NH1   . ARG A 4 135 . 13.557  6.225  5.198   1.00 37.11 135 ARG A NH1   1
+ATOM   1063 N NH2   . ARG A 4 135 . 12.373  4.351  5.796   1.00 34.93 135 ARG A NH2   1
+ATOM   1064 C CZ    . ARG A 4 135 . 13.067  5.430  6.154   1.00 37.37 135 ARG A CZ    1
+ATOM   1065 N N     . SER A 4 136 . 10.349  8.560  11.269  1.00 24.71 136 SER A N     1
+ATOM   1066 C CA    . SER A 4 136 . 9.330   7.651  11.835  1.00 24.23 136 SER A CA    1
+ATOM   1067 C C     . SER A 4 136 . 7.928   8.199  11.517  1.00 23.36 136 SER A C     1
+ATOM   1068 C CB    . SER A 4 136 . 9.526   7.492  13.376  1.00 20.59 136 SER A CB    1
+ATOM   1069 O O     . SER A 4 136 . 7.045   7.456  11.078  1.00 24.82 136 SER A O     1
+ATOM   1070 O OG    . SER A 4 136 . 9.102   8.557  14.208  1.00 17.68 136 SER A OG    1
+ATOM   1071 N N     . TYR A 4 137 . 7.662   9.494  11.770  1.00 23.44 137 TYR A N     1
+ATOM   1072 C CA    . TYR A 4 137 . 6.478   10.183 11.225  1.00 23.92 137 TYR A CA    1
+ATOM   1073 C C     . TYR A 4 137 . 6.760   10.175 9.714   1.00 23.25 137 TYR A C     1
+ATOM   1074 C CB    . TYR A 4 137 . 6.425   11.654 11.663  1.00 22.96 137 TYR A CB    1
+ATOM   1075 O O     . TYR A 4 137 . 7.953   10.225 9.453   1.00 31.14 137 TYR A O     1
+ATOM   1076 C CG    . TYR A 4 137 . 6.521   11.998 13.143  1.00 25.11 137 TYR A CG    1
+ATOM   1077 C CD1   . TYR A 4 137 . 6.187   11.040 14.099  1.00 26.64 137 TYR A CD1   1
+ATOM   1078 C CD2   . TYR A 4 137 . 6.920   13.292 13.541  1.00 25.18 137 TYR A CD2   1
+ATOM   1079 C CE1   . TYR A 4 137 . 6.236   11.361 15.453  1.00 24.00 137 TYR A CE1   1
+ATOM   1080 C CE2   . TYR A 4 137 . 6.968   13.615 14.896  1.00 21.24 137 TYR A CE2   1
+ATOM   1081 O OH    . TYR A 4 137 . 6.554   12.927 17.186  1.00 15.45 137 TYR A OH    1
+ATOM   1082 C CZ    . TYR A 4 137 . 6.616   12.638 15.838  1.00 21.08 137 TYR A CZ    1
+ATOM   1083 N N     . GLY A 4 138 . 6.042   10.131 8.588   1.00 23.96 138 GLY A N     1
+ATOM   1084 C CA    . GLY A 4 138 . 6.766   10.155 7.269   1.00 15.52 138 GLY A CA    1
+ATOM   1085 C C     . GLY A 4 138 . 7.062   11.597 6.828   1.00 17.99 138 GLY A C     1
+ATOM   1086 O O     . GLY A 4 138 . 6.533   12.021 5.792   1.00 15.65 138 GLY A O     1
+ATOM   1087 N N     . ILE A 4 139 . 7.876   12.372 7.584   1.00 11.66 139 ILE A N     1
+ATOM   1088 C CA    . ILE A 4 139 . 7.912   13.838 7.472   1.00 13.04 139 ILE A CA    1
+ATOM   1089 C C     . ILE A 4 139 . 9.301   14.416 7.180   1.00 11.83 139 ILE A C     1
+ATOM   1090 C CB    . ILE A 4 139 . 7.177   14.265 8.858   1.00 14.54 139 ILE A CB    1
+ATOM   1091 O O     . ILE A 4 139 . 10.313  13.869 7.633   1.00 18.03 139 ILE A O     1
+ATOM   1092 C CG1   . ILE A 4 139 . 5.818   14.653 8.399   1.00 9.95  139 ILE A CG1   1
+ATOM   1093 C CG2   . ILE A 4 139 . 7.745   15.380 9.744   1.00 12.54 139 ILE A CG2   1
+ATOM   1094 C CD1   . ILE A 4 139 . 4.843   13.478 8.370   1.00 12.91 139 ILE A CD1   1
+ATOM   1095 N N     . PRO A 4 140 . 9.457   15.488 6.390   1.00 10.94 140 PRO A N     1
+ATOM   1096 C CA    . PRO A 4 140 . 10.729  16.175 6.226   1.00 13.32 140 PRO A CA    1
+ATOM   1097 C C     . PRO A 4 140 . 11.259  16.857 7.518   1.00 11.57 140 PRO A C     1
+ATOM   1098 C CB    . PRO A 4 140 . 10.447  17.149 5.078   1.00 12.02 140 PRO A CB    1
+ATOM   1099 O O     . PRO A 4 140 . 10.472  17.321 8.346   1.00 11.32 140 PRO A O     1
+ATOM   1100 C CG    . PRO A 4 140 . 9.125   16.767 4.471   1.00 10.53 140 PRO A CG    1
+ATOM   1101 C CD    . PRO A 4 140 . 8.401   16.156 5.632   1.00 10.65 140 PRO A CD    1
+ATOM   1102 N N     . TYR A 4 141 . 12.583  16.895 7.755   1.00 13.16 141 TYR A N     1
+ATOM   1103 C CA    . TYR A 4 141 . 13.180  17.604 8.881   1.00 7.27  141 TYR A CA    1
+ATOM   1104 C C     . TYR A 4 141 . 14.076  18.703 8.321   1.00 8.80  141 TYR A C     1
+ATOM   1105 C CB    . TYR A 4 141 . 14.032  16.662 9.780   1.00 8.95  141 TYR A CB    1
+ATOM   1106 O O     . TYR A 4 141 . 15.044  18.422 7.597   1.00 10.68 141 TYR A O     1
+ATOM   1107 C CG    . TYR A 4 141 . 14.763  17.380 10.948  1.00 11.64 141 TYR A CG    1
+ATOM   1108 C CD1   . TYR A 4 141 . 14.063  18.158 11.854  1.00 9.84  141 TYR A CD1   1
+ATOM   1109 C CD2   . TYR A 4 141 . 16.142  17.317 11.053  1.00 8.77  141 TYR A CD2   1
+ATOM   1110 C CE1   . TYR A 4 141 . 14.716  18.864 12.836  1.00 7.53  141 TYR A CE1   1
+ATOM   1111 C CE2   . TYR A 4 141 . 16.802  18.037 12.038  1.00 11.20 141 TYR A CE2   1
+ATOM   1112 O OH    . TYR A 4 141 . 16.729  19.518 13.900  1.00 10.62 141 TYR A OH    1
+ATOM   1113 C CZ    . TYR A 4 141 . 16.081  18.802 12.919  1.00 8.27  141 TYR A CZ    1
+ATOM   1114 N N     . ILE A 4 142 . 13.694  19.961 8.594   1.00 3.78  142 ILE A N     1
+ATOM   1115 C CA    . ILE A 4 142 . 14.578  21.034 8.240   1.00 10.52 142 ILE A CA    1
+ATOM   1116 C C     . ILE A 4 142 . 14.973  21.980 9.406   1.00 11.97 142 ILE A C     1
+ATOM   1117 C CB    . ILE A 4 142 . 13.960  21.813 6.916   1.00 11.09 142 ILE A CB    1
+ATOM   1118 O O     . ILE A 4 142 . 14.165  22.412 10.223  1.00 11.42 142 ILE A O     1
+ATOM   1119 C CG1   . ILE A 4 142 . 13.646  23.209 7.207   1.00 8.58  142 ILE A CG1   1
+ATOM   1120 C CG2   . ILE A 4 142 . 12.710  21.167 6.343   1.00 11.82 142 ILE A CG2   1
+ATOM   1121 C CD1   . ILE A 4 142 . 14.861  23.917 6.658   1.00 6.28  142 ILE A CD1   1
+ATOM   1122 N N     . GLU A 4 143 . 16.278  22.232 9.588   1.00 10.41 143 GLU A N     1
+ATOM   1123 C CA    . GLU A 4 143 . 16.733  23.213 10.564  1.00 11.85 143 GLU A CA    1
+ATOM   1124 C C     . GLU A 4 143 . 16.713  24.672 10.090  1.00 13.98 143 GLU A C     1
+ATOM   1125 C CB    . GLU A 4 143 . 18.134  22.896 10.998  1.00 12.62 143 GLU A CB    1
+ATOM   1126 O O     . GLU A 4 143 . 17.098  24.973 8.947   1.00 13.02 143 GLU A O     1
+ATOM   1127 C CG    . GLU A 4 143 . 18.222  21.568 11.701  1.00 11.46 143 GLU A CG    1
+ATOM   1128 C CD    . GLU A 4 143 . 19.430  21.418 12.621  1.00 12.67 143 GLU A CD    1
+ATOM   1129 O OE1   . GLU A 4 143 . 20.305  22.262 12.616  1.00 11.46 143 GLU A OE1   1
+ATOM   1130 O OE2   . GLU A 4 143 . 19.502  20.437 13.356  1.00 16.35 143 GLU A OE2   1
+ATOM   1131 N N     . THR A 4 144 . 16.281  25.589 10.976  1.00 11.94 144 THR A N     1
+ATOM   1132 C CA    . THR A 4 144 . 16.132  26.988 10.639  1.00 10.34 144 THR A CA    1
+ATOM   1133 C C     . THR A 4 144 . 16.759  27.933 11.655  1.00 14.75 144 THR A C     1
+ATOM   1134 C CB    . THR A 4 144 . 14.654  27.373 10.521  1.00 12.63 144 THR A CB    1
+ATOM   1135 O O     . THR A 4 144 . 17.090  27.533 12.769  1.00 16.15 144 THR A O     1
+ATOM   1136 C CG2   . THR A 4 144 . 13.910  26.710 9.368   1.00 11.34 144 THR A CG2   1
+ATOM   1137 O OG1   . THR A 4 144 . 14.092  27.036 11.773  1.00 11.68 144 THR A OG1   1
+ATOM   1138 N N     . SER A 4 145 . 16.947  29.203 11.290  1.00 14.30 145 SER A N     1
+ATOM   1139 C CA    . SER A 4 145 . 17.335  30.255 12.233  1.00 14.12 145 SER A CA    1
+ATOM   1140 C C     . SER A 4 145 . 16.526  31.483 11.817  1.00 15.11 145 SER A C     1
+ATOM   1141 C CB    . SER A 4 145 . 18.822  30.620 12.159  1.00 11.68 145 SER A CB    1
+ATOM   1142 O O     . SER A 4 145 . 16.655  32.006 10.696  1.00 16.51 145 SER A O     1
+ATOM   1143 O OG    . SER A 4 145 . 18.981  31.847 12.872  1.00 11.02 145 SER A OG    1
+ATOM   1144 N N     . ALA A 4 146 . 15.630  31.948 12.685  1.00 15.14 146 ALA A N     1
+ATOM   1145 C CA    . ALA A 4 146 . 14.874  33.160 12.373  1.00 16.36 146 ALA A CA    1
+ATOM   1146 C C     . ALA A 4 146 . 15.850  34.328 12.477  1.00 17.69 146 ALA A C     1
+ATOM   1147 C CB    . ALA A 4 146 . 13.730  33.354 13.370  1.00 14.29 146 ALA A CB    1
+ATOM   1148 O O     . ALA A 4 146 . 15.663  35.386 11.855  1.00 18.27 146 ALA A O     1
+ATOM   1149 N N     . LYS A 4 147 . 16.936  34.104 13.235  1.00 19.32 147 LYS A N     1
+ATOM   1150 C CA    . LYS A 4 147 . 17.986  35.079 13.343  1.00 20.18 147 LYS A CA    1
+ATOM   1151 C C     . LYS A 4 147 . 18.743  35.297 12.040  1.00 24.36 147 LYS A C     1
+ATOM   1152 C CB    . LYS A 4 147 . 18.962  34.670 14.395  1.00 23.23 147 LYS A CB    1
+ATOM   1153 O O     . LYS A 4 147 . 18.806  36.447 11.589  1.00 24.62 147 LYS A O     1
+ATOM   1154 C CG    . LYS A 4 147 . 19.795  35.877 14.759  1.00 25.60 147 LYS A CG    1
+ATOM   1155 C CD    . LYS A 4 147 . 20.739  35.467 15.816  1.00 31.19 147 LYS A CD    1
+ATOM   1156 C CE    . LYS A 4 147 . 21.610  36.622 16.230  1.00 36.61 147 LYS A CE    1
+ATOM   1157 N NZ    . LYS A 4 147 . 20.869  37.628 16.980  1.00 40.61 147 LYS A NZ    1
+ATOM   1158 N N     . THR A 4 148 . 19.328  34.270 11.404  1.00 21.90 148 THR A N     1
+ATOM   1159 C CA    . THR A 4 148 . 20.060  34.536 10.191  1.00 23.08 148 THR A CA    1
+ATOM   1160 C C     . THR A 4 148 . 19.203  34.376 8.925   1.00 24.38 148 THR A C     1
+ATOM   1161 C CB    . THR A 4 148 . 21.353  33.612 10.143  1.00 24.11 148 THR A CB    1
+ATOM   1162 O O     . THR A 4 148 . 19.689  34.713 7.841   1.00 24.35 148 THR A O     1
+ATOM   1163 C CG2   . THR A 4 148 . 22.193  33.673 11.396  1.00 24.15 148 THR A CG2   1
+ATOM   1164 O OG1   . THR A 4 148 . 20.947  32.280 9.998   1.00 26.09 148 THR A OG1   1
+ATOM   1165 N N     . ARG A 4 149 . 17.924  33.954 9.013   1.00 19.04 149 ARG A N     1
+ATOM   1166 C CA    . ARG A 4 149 . 17.056  33.626 7.891   1.00 19.12 149 ARG A CA    1
+ATOM   1167 C C     . ARG A 4 149 . 17.484  32.325 7.189   1.00 19.74 149 ARG A C     1
+ATOM   1168 C CB    . ARG A 4 149 . 17.003  34.776 6.850   1.00 18.84 149 ARG A CB    1
+ATOM   1169 O O     . ARG A 4 149 . 16.977  31.944 6.126   1.00 20.42 149 ARG A O     1
+ATOM   1170 C CG    . ARG A 4 149 . 15.673  34.814 6.122   1.00 20.30 149 ARG A CG    1
+ATOM   1171 C CD    . ARG A 4 149 . 15.463  36.033 5.239   1.00 21.64 149 ARG A CD    1
+ATOM   1172 N NE    . ARG A 4 149 . 14.036  36.290 5.009   1.00 25.63 149 ARG A NE    1
+ATOM   1173 N NH1   . ARG A 4 149 . 13.975  35.029 3.068   1.00 25.82 149 ARG A NH1   1
+ATOM   1174 N NH2   . ARG A 4 149 . 12.057  36.098 3.774   1.00 25.98 149 ARG A NH2   1
+ATOM   1175 C CZ    . ARG A 4 149 . 13.361  35.805 3.952   1.00 26.14 149 ARG A CZ    1
+ATOM   1176 N N     . GLN A 4 150 . 18.446  31.609 7.797   1.00 20.02 150 GLN A N     1
+ATOM   1177 C CA    . GLN A 4 150 . 18.875  30.295 7.336   1.00 17.94 150 GLN A CA    1
+ATOM   1178 C C     . GLN A 4 150 . 17.692  29.347 7.415   1.00 14.12 150 GLN A C     1
+ATOM   1179 C CB    . GLN A 4 150 . 19.979  29.744 8.219   1.00 22.20 150 GLN A CB    1
+ATOM   1180 O O     . GLN A 4 150 . 17.050  29.179 8.453   1.00 15.86 150 GLN A O     1
+ATOM   1181 C CG    . GLN A 4 150 . 21.228  29.391 7.444   1.00 29.43 150 GLN A CG    1
+ATOM   1182 C CD    . GLN A 4 150 . 21.418  27.910 7.171   1.00 34.51 150 GLN A CD    1
+ATOM   1183 N NE2   . GLN A 4 150 . 20.776  27.295 6.165   1.00 38.03 150 GLN A NE2   1
+ATOM   1184 O OE1   . GLN A 4 150 . 22.204  27.273 7.870   1.00 34.61 150 GLN A OE1   1
+ATOM   1185 N N     . GLY A 4 151 . 17.347  28.801 6.265   1.00 12.15 151 GLY A N     1
+ATOM   1186 C CA    . GLY A 4 151 . 16.276  27.836 6.134   1.00 10.31 151 GLY A CA    1
+ATOM   1187 C C     . GLY A 4 151 . 14.824  28.313 6.248   1.00 9.62  151 GLY A C     1
+ATOM   1188 O O     . GLY A 4 151 . 13.939  27.465 6.048   1.00 7.72  151 GLY A O     1
+ATOM   1189 N N     . VAL A 4 152 . 14.480  29.589 6.509   1.00 11.67 152 VAL A N     1
+ATOM   1190 C CA    . VAL A 4 152 . 13.080  29.899 6.727   1.00 10.80 152 VAL A CA    1
+ATOM   1191 C C     . VAL A 4 152 . 12.246  29.743 5.441   1.00 10.74 152 VAL A C     1
+ATOM   1192 C CB    . VAL A 4 152 . 12.897  31.369 7.410   1.00 12.11 152 VAL A CB    1
+ATOM   1193 O O     . VAL A 4 152 . 11.253  29.019 5.542   1.00 11.26 152 VAL A O     1
+ATOM   1194 C CG1   . VAL A 4 152 . 14.045  31.630 8.380   1.00 9.61  152 VAL A CG1   1
+ATOM   1195 C CG2   . VAL A 4 152 . 12.841  32.483 6.410   1.00 16.14 152 VAL A CG2   1
+ATOM   1196 N N     . GLU A 4 153 . 12.518  30.255 4.223   1.00 9.78  153 GLU A N     1
+ATOM   1197 C CA    . GLU A 4 153 . 11.663  30.009 3.036   1.00 13.69 153 GLU A CA    1
+ATOM   1198 C C     . GLU A 4 153 . 11.627  28.536 2.647   1.00 13.06 153 GLU A C     1
+ATOM   1199 C CB    . GLU A 4 153 . 12.163  30.776 1.820   1.00 15.97 153 GLU A CB    1
+ATOM   1200 O O     . GLU A 4 153 . 10.647  27.995 2.127   1.00 11.99 153 GLU A O     1
+ATOM   1201 C CG    . GLU A 4 153 . 11.943  32.296 1.851   1.00 19.02 153 GLU A CG    1
+ATOM   1202 C CD    . GLU A 4 153 . 12.779  33.114 0.837   1.00 22.78 153 GLU A CD    1
+ATOM   1203 O OE1   . GLU A 4 153 . 13.917  32.743 0.548   1.00 26.10 153 GLU A OE1   1
+ATOM   1204 O OE2   . GLU A 4 153 . 12.328  34.152 0.357   1.00 21.79 153 GLU A OE2   1
+ATOM   1205 N N     . ASP A 4 154 . 12.747  27.869 2.918   1.00 14.79 154 ASP A N     1
+ATOM   1206 C CA    . ASP A 4 154 . 12.897  26.441 2.758   1.00 15.79 154 ASP A CA    1
+ATOM   1207 C C     . ASP A 4 154 . 11.852  25.648 3.550   1.00 15.19 154 ASP A C     1
+ATOM   1208 C CB    . ASP A 4 154 . 14.260  26.120 3.219   1.00 21.20 154 ASP A CB    1
+ATOM   1209 O O     . ASP A 4 154 . 11.034  24.909 2.981   1.00 18.48 154 ASP A O     1
+ATOM   1210 C CG    . ASP A 4 154 . 14.969  25.040 2.455   1.00 25.70 154 ASP A CG    1
+ATOM   1211 O OD1   . ASP A 4 154 . 15.368  25.301 1.333   1.00 29.77 154 ASP A OD1   1
+ATOM   1212 O OD2   . ASP A 4 154 . 15.193  23.974 3.013   1.00 28.55 154 ASP A OD2   1
+ATOM   1213 N N     . ALA A 4 155 . 11.860  25.781 4.879   1.00 13.79 155 ALA A N     1
+ATOM   1214 C CA    . ALA A 4 155 . 10.852  25.192 5.751   1.00 6.66  155 ALA A CA    1
+ATOM   1215 C C     . ALA A 4 155 . 9.453   25.512 5.252   1.00 10.59 155 ALA A C     1
+ATOM   1216 C CB    . ALA A 4 155 . 10.952  25.749 7.161   1.00 13.44 155 ALA A CB    1
+ATOM   1217 O O     . ALA A 4 155 . 8.671   24.601 5.072   1.00 10.68 155 ALA A O     1
+ATOM   1218 N N     . PHE A 4 156 . 9.094   26.770 4.961   1.00 15.94 156 PHE A N     1
+ATOM   1219 C CA    . PHE A 4 156 . 7.759   27.145 4.462   1.00 12.73 156 PHE A CA    1
+ATOM   1220 C C     . PHE A 4 156 . 7.451   26.662 3.036   1.00 12.73 156 PHE A C     1
+ATOM   1221 C CB    . PHE A 4 156 . 7.607   28.680 4.552   1.00 12.43 156 PHE A CB    1
+ATOM   1222 O O     . PHE A 4 156 . 6.330   26.222 2.813   1.00 13.37 156 PHE A O     1
+ATOM   1223 C CG    . PHE A 4 156 . 7.255   29.260 5.960   1.00 13.21 156 PHE A CG    1
+ATOM   1224 C CD1   . PHE A 4 156 . 5.918   29.315 6.385   1.00 10.26 156 PHE A CD1   1
+ATOM   1225 C CD2   . PHE A 4 156 . 8.249   29.781 6.794   1.00 9.23  156 PHE A CD2   1
+ATOM   1226 C CE1   . PHE A 4 156 . 5.590   29.881 7.614   1.00 10.17 156 PHE A CE1   1
+ATOM   1227 C CE2   . PHE A 4 156 . 7.910   30.348 8.015   1.00 10.02 156 PHE A CE2   1
+ATOM   1228 C CZ    . PHE A 4 156 . 6.580   30.403 8.431   1.00 7.46  156 PHE A CZ    1
+ATOM   1229 N N     . TYR A 4 157 . 8.362   26.665 2.038   1.00 13.64 157 TYR A N     1
+ATOM   1230 C CA    . TYR A 4 157 . 8.040   26.195 0.702   1.00 10.09 157 TYR A CA    1
+ATOM   1231 C C     . TYR A 4 157 . 7.926   24.711 0.642   1.00 10.41 157 TYR A C     1
+ATOM   1232 C CB    . TYR A 4 157 . 9.073   26.602 -0.255  1.00 13.41 157 TYR A CB    1
+ATOM   1233 O O     . TYR A 4 157 . 7.039   24.183 -0.039  1.00 8.74  157 TYR A O     1
+ATOM   1234 C CG    . TYR A 4 157 . 9.103   28.084 -0.536  1.00 13.86 157 TYR A CG    1
+ATOM   1235 C CD1   . TYR A 4 157 . 8.203   28.951 0.064   1.00 18.91 157 TYR A CD1   1
+ATOM   1236 C CD2   . TYR A 4 157 . 10.063  28.556 -1.413  1.00 15.24 157 TYR A CD2   1
+ATOM   1237 C CE1   . TYR A 4 157 . 8.265   30.299 -0.198  1.00 18.77 157 TYR A CE1   1
+ATOM   1238 C CE2   . TYR A 4 157 . 10.117  29.900 -1.686  1.00 18.05 157 TYR A CE2   1
+ATOM   1239 O OH    . TYR A 4 157 . 9.293   32.083 -1.336  1.00 19.96 157 TYR A OH    1
+ATOM   1240 C CZ    . TYR A 4 157 . 9.224   30.745 -1.078  1.00 17.38 157 TYR A CZ    1
+ATOM   1241 N N     . THR A 4 158 . 8.778   24.049 1.444   1.00 12.84 158 THR A N     1
+ATOM   1242 C CA    . THR A 4 158 . 8.705   22.599 1.587   1.00 13.60 158 THR A CA    1
+ATOM   1243 C C     . THR A 4 158 . 7.307   22.189 2.029   1.00 13.77 158 THR A C     1
+ATOM   1244 C CB    . THR A 4 158 . 9.770   22.102 2.615   1.00 12.52 158 THR A CB    1
+ATOM   1245 O O     . THR A 4 158 . 6.730   21.251 1.462   1.00 12.56 158 THR A O     1
+ATOM   1246 C CG2   . THR A 4 158 . 9.690   20.644 3.003   1.00 11.07 158 THR A CG2   1
+ATOM   1247 O OG1   . THR A 4 158 . 11.003  22.351 1.981   1.00 9.58  158 THR A OG1   1
+ATOM   1248 N N     . LEU A 4 159 . 6.734   22.912 3.004   1.00 13.78 159 LEU A N     1
+ATOM   1249 C CA    . LEU A 4 159 . 5.392   22.587 3.470   1.00 11.21 159 LEU A CA    1
+ATOM   1250 C C     . LEU A 4 159 . 4.390   22.887 2.354   1.00 8.24  159 LEU A C     1
+ATOM   1251 C CB    . LEU A 4 159 . 5.019   23.394 4.721   1.00 5.93  159 LEU A CB    1
+ATOM   1252 O O     . LEU A 4 159 . 3.541   22.055 2.125   1.00 8.72  159 LEU A O     1
+ATOM   1253 C CG    . LEU A 4 159 . 3.631   23.095 5.355   1.00 11.33 159 LEU A CG    1
+ATOM   1254 C CD1   . LEU A 4 159 . 3.517   21.640 5.720   1.00 10.10 159 LEU A CD1   1
+ATOM   1255 C CD2   . LEU A 4 159 . 3.445   23.962 6.605   1.00 10.02 159 LEU A CD2   1
+ATOM   1256 N N     . VAL A 4 160 . 4.382   24.009 1.639   1.00 12.54 160 VAL A N     1
+ATOM   1257 C CA    . VAL A 4 160 . 3.475   24.174 0.506   1.00 14.56 160 VAL A CA    1
+ATOM   1258 C C     . VAL A 4 160 . 3.641   22.988 -0.500  1.00 13.87 160 VAL A C     1
+ATOM   1259 C CB    . VAL A 4 160 . 3.788   25.552 -0.144  1.00 10.27 160 VAL A CB    1
+ATOM   1260 O O     . VAL A 4 160 . 2.630   22.518 -1.012  1.00 16.41 160 VAL A O     1
+ATOM   1261 C CG1   . VAL A 4 160 . 3.146   25.656 -1.531  1.00 12.21 160 VAL A CG1   1
+ATOM   1262 C CG2   . VAL A 4 160 . 3.278   26.664 0.752   1.00 10.25 160 VAL A CG2   1
+ATOM   1263 N N     . ARG A 4 161 . 4.817   22.455 -0.868  1.00 10.97 161 ARG A N     1
+ATOM   1264 C CA    . ARG A 4 161 . 4.876   21.333 -1.786  1.00 11.89 161 ARG A CA    1
+ATOM   1265 C C     . ARG A 4 161 . 4.345   20.035 -1.183  1.00 14.30 161 ARG A C     1
+ATOM   1266 C CB    . ARG A 4 161 . 6.320   21.159 -2.252  1.00 17.63 161 ARG A CB    1
+ATOM   1267 O O     . ARG A 4 161 . 3.896   19.137 -1.912  1.00 15.58 161 ARG A O     1
+ATOM   1268 C CG    . ARG A 4 161 . 6.665   22.290 -3.210  1.00 18.69 161 ARG A CG    1
+ATOM   1269 C CD    . ARG A 4 161 . 8.023   22.218 -3.883  1.00 23.57 161 ARG A CD    1
+ATOM   1270 N NE    . ARG A 4 161 . 9.107   22.529 -2.986  1.00 24.73 161 ARG A NE    1
+ATOM   1271 N NH1   . ARG A 4 161 . 9.656   24.581 -3.998  1.00 20.57 161 ARG A NH1   1
+ATOM   1272 N NH2   . ARG A 4 161 . 10.837  23.786 -2.200  1.00 21.96 161 ARG A NH2   1
+ATOM   1273 C CZ    . ARG A 4 161 . 9.857   23.637 -3.086  1.00 23.78 161 ARG A CZ    1
+ATOM   1274 N N     . GLU A 4 162 . 4.354   19.861 0.147   1.00 13.61 162 GLU A N     1
+ATOM   1275 C CA    . GLU A 4 162 . 3.745   18.688 0.777   1.00 15.14 162 GLU A CA    1
+ATOM   1276 C C     . GLU A 4 162 . 2.243   18.741 0.571   1.00 12.85 162 GLU A C     1
+ATOM   1277 C CB    . GLU A 4 162 . 3.993   18.640 2.300   1.00 17.49 162 GLU A CB    1
+ATOM   1278 O O     . GLU A 4 162 . 1.616   17.709 0.332   1.00 14.53 162 GLU A O     1
+ATOM   1279 C CG    . GLU A 4 162 . 5.421   18.468 2.737   1.00 16.17 162 GLU A CG    1
+ATOM   1280 C CD    . GLU A 4 162 . 5.961   17.117 2.317   1.00 20.39 162 GLU A CD    1
+ATOM   1281 O OE1   . GLU A 4 162 . 5.558   16.093 2.861   1.00 24.09 162 GLU A OE1   1
+ATOM   1282 O OE2   . GLU A 4 162 . 6.787   17.063 1.420   1.00 21.88 162 GLU A OE2   1
+ATOM   1283 N N     . ILE A 4 163 . 1.642   19.938 0.655   1.00 11.78 163 ILE A N     1
+ATOM   1284 C CA    . ILE A 4 163 . 0.202   20.059 0.489   1.00 12.76 163 ILE A CA    1
+ATOM   1285 C C     . ILE A 4 163 . -0.129  19.752 -0.964  1.00 19.76 163 ILE A C     1
+ATOM   1286 C CB    . ILE A 4 163 . -0.288  21.451 0.826   1.00 11.66 163 ILE A CB    1
+ATOM   1287 O O     . ILE A 4 163 . -1.110  19.041 -1.253  1.00 22.54 163 ILE A O     1
+ATOM   1288 C CG1   . ILE A 4 163 . -0.030  21.747 2.310   1.00 6.69  163 ILE A CG1   1
+ATOM   1289 C CG2   . ILE A 4 163 . -1.786  21.556 0.455   1.00 8.19  163 ILE A CG2   1
+ATOM   1290 C CD1   . ILE A 4 163 . -0.038  23.272 2.625   1.00 7.92  163 ILE A CD1   1
+ATOM   1291 N N     . ARG A 4 164 . 0.674   20.282 -1.898  1.00 20.40 164 ARG A N     1
+ATOM   1292 C CA    . ARG A 4 164 . 0.571   19.942 -3.323  1.00 19.18 164 ARG A CA    1
+ATOM   1293 C C     . ARG A 4 164 . 0.569   18.431 -3.623  1.00 19.38 164 ARG A C     1
+ATOM   1294 C CB    . ARG A 4 164 . 1.728   20.588 -4.059  1.00 16.56 164 ARG A CB    1
+ATOM   1295 O O     . ARG A 4 164 . -0.284  17.910 -4.322  1.00 17.51 164 ARG A O     1
+ATOM   1296 C CG    . ARG A 4 164 . 1.435   22.047 -4.043  1.00 18.30 164 ARG A CG    1
+ATOM   1297 C CD    . ARG A 4 164 . 1.663   22.575 -5.422  1.00 19.04 164 ARG A CD    1
+ATOM   1298 N NE    . ARG A 4 164 . 3.059   22.866 -5.562  1.00 17.19 164 ARG A NE    1
+ATOM   1299 N NH1   . ARG A 4 164 . 2.911   25.250 -5.474  1.00 18.28 164 ARG A NH1   1
+ATOM   1300 N NH2   . ARG A 4 164 . 4.898   24.134 -5.697  1.00 11.33 164 ARG A NH2   1
+ATOM   1301 C CZ    . ARG A 4 164 . 3.584   24.095 -5.565  1.00 16.83 164 ARG A CZ    1
+ATOM   1302 N N     . GLN A 4 165 . 1.522   17.696 -3.047  1.00 22.82 165 GLN A N     1
+ATOM   1303 C CA    . GLN A 4 165 . 1.705   16.283 -3.291  1.00 23.58 165 GLN A CA    1
+ATOM   1304 C C     . GLN A 4 165 . 0.754   15.394 -2.473  1.00 24.93 165 GLN A C     1
+ATOM   1305 C CB    . GLN A 4 165 . 3.240   16.090 -3.051  1.00 25.17 165 GLN A CB    1
+ATOM   1306 O O     . GLN A 4 165 . 0.741   14.170 -2.636  1.00 28.14 165 GLN A O     1
+ATOM   1307 C CG    . GLN A 4 165 . 4.080   16.730 -4.246  1.00 26.24 165 GLN A CG    1
+ATOM   1308 C CD    . GLN A 4 165 . 5.218   17.787 -4.082  1.00 26.62 165 GLN A CD    1
+ATOM   1309 N NE2   . GLN A 4 165 . 5.282   18.874 -4.882  1.00 22.90 165 GLN A NE2   1
+ATOM   1310 O OE1   . GLN A 4 165 . 6.149   17.644 -3.282  1.00 26.70 165 GLN A OE1   1
+ATOM   1311 N N     . HIS A 4 166 . -0.150  15.986 -1.671  1.00 21.62 166 HIS A N     1
+ATOM   1312 C CA    . HIS A 4 166 . -1.089  15.233 -0.850  1.00 21.37 166 HIS A CA    1
+ATOM   1313 C C     . HIS A 4 166 . -2.299  14.658 -1.609  1.00 19.47 166 HIS A C     1
+ATOM   1314 C CB    . HIS A 4 166 . -1.572  16.130 0.328   1.00 17.56 166 HIS A CB    1
+ATOM   1315 O O     . HIS A 4 166 . -2.731  15.229 -2.603  1.00 21.43 166 HIS A O     1
+ATOM   1316 C CG    . HIS A 4 166 . -2.402  15.387 1.384   1.00 19.13 166 HIS A CG    1
+ATOM   1317 C CD2   . HIS A 4 166 . -1.931  14.367 2.175   1.00 20.04 166 HIS A CD2   1
+ATOM   1318 N ND1   . HIS A 4 166 . -3.705  15.505 1.682   1.00 18.96 166 HIS A ND1   1
+ATOM   1319 C CE1   . HIS A 4 166 . -4.030  14.614 2.584   1.00 13.05 166 HIS A CE1   1
+ATOM   1320 N NE2   . HIS A 4 166 . -2.961  13.942 2.869   1.00 16.04 166 HIS A NE2   1
+ATOM   1321 O OXT   . HIS A 4 166 . -2.785  13.597 -1.214  1.00 19.69 166 HIS A OXT   1
+HETATM 1322 M MG    . MG  A 4 167 . 4.649   33.761 19.192  1.00 16.19 167 MG  A MG    1
+HETATM 1323 P PG    . GNP A 4 168 . 5.153   32.063 22.021  1.00 9.27  168 GNP A PG    1
+HETATM 1324 O O1G   . GNP A 4 168 . 4.899   32.446 23.420  1.00 17.15 168 GNP A O1G   1
+HETATM 1325 O O2G   . GNP A 4 168 . 4.175   32.663 21.132  1.00 9.55  168 GNP A O2G   1
+HETATM 1326 O O3G   . GNP A 4 168 . 4.652   30.549 21.973  1.00 10.53 168 GNP A O3G   1
+HETATM 1327 N N3B   . GNP A 4 168 . 6.749   32.123 21.582  1.00 8.97  168 GNP A N3B   1
+HETATM 1328 P PB    . GNP A 4 168 . 7.308   31.872 20.024  1.00 9.99  168 GNP A PB    1
+HETATM 1329 O O1B   . GNP A 4 168 . 7.464   30.462 19.680  1.00 7.09  168 GNP A O1B   1
+HETATM 1330 O O2B   . GNP A 4 168 . 6.634   32.602 18.959  1.00 8.52  168 GNP A O2B   1
+HETATM 1331 O O3A   . GNP A 4 168 . 8.773   32.489 19.980  1.00 6.32  168 GNP A O3A   1
+HETATM 1332 P PA    . GNP A 4 168 . 9.267   34.007 19.557  1.00 10.47 168 GNP A PA    1
+HETATM 1333 O O1A   . GNP A 4 168 . 9.418   34.078 18.100  1.00 10.38 168 GNP A O1A   1
+HETATM 1334 O O2A   . GNP A 4 168 . 8.529   35.074 20.303  1.00 11.77 168 GNP A O2A   1
+HETATM 1335 O 'O5'' . GNP A 4 168 . 10.745  33.961 20.117  1.00 10.69 168 GNP A 'O5'' 1
+HETATM 1336 C 'C5'' . GNP A 4 168 . 11.111  33.756 21.476  1.00 9.95  168 GNP A 'C5'' 1
+HETATM 1337 C 'C4'' . GNP A 4 168 . 12.556  34.200 21.659  1.00 12.11 168 GNP A 'C4'' 1
+HETATM 1338 O 'O4'' . GNP A 4 168 . 13.486  33.420 20.870  1.00 10.56 168 GNP A 'O4'' 1
+HETATM 1339 C 'C3'' . GNP A 4 168 . 12.747  35.664 21.239  1.00 12.63 168 GNP A 'C3'' 1
+HETATM 1340 O 'O3'' . GNP A 4 168 . 13.669  36.330 22.086  1.00 13.41 168 GNP A 'O3'' 1
+HETATM 1341 C 'C2'' . GNP A 4 168 . 13.368  35.525 19.868  1.00 10.98 168 GNP A 'C2'' 1
+HETATM 1342 O 'O2'' . GNP A 4 168 . 14.109  36.694 19.511  1.00 10.96 168 GNP A 'O2'' 1
+HETATM 1343 C 'C1'' . GNP A 4 168 . 14.275  34.294 20.069  1.00 10.70 168 GNP A 'C1'' 1
+HETATM 1344 N N9    . GNP A 4 168 . 14.437  33.559 18.803  1.00 13.20 168 GNP A N9    1
+HETATM 1345 C C8    . GNP A 4 168 . 13.459  33.105 17.932  1.00 8.66  168 GNP A C8    1
+HETATM 1346 N N7    . GNP A 4 168 . 13.902  32.453 16.903  1.00 14.05 168 GNP A N7    1
+HETATM 1347 C C5    . GNP A 4 168 . 15.283  32.503 17.073  1.00 10.73 168 GNP A C5    1
+HETATM 1348 C C6    . GNP A 4 168 . 16.300  31.944 16.305  1.00 11.14 168 GNP A C6    1
+HETATM 1349 O O6    . GNP A 4 168 . 16.226  31.385 15.239  1.00 13.80 168 GNP A O6    1
+HETATM 1350 N N1    . GNP A 4 168 . 17.526  32.120 16.874  1.00 12.41 168 GNP A N1    1
+HETATM 1351 C C2    . GNP A 4 168 . 17.789  32.816 18.030  1.00 11.82 168 GNP A C2    1
+HETATM 1352 N N2    . GNP A 4 168 . 19.080  32.988 18.341  1.00 15.41 168 GNP A N2    1
+HETATM 1353 N N3    . GNP A 4 168 . 16.837  33.331 18.789  1.00 10.31 168 GNP A N3    1
+HETATM 1354 C C4    . GNP A 4 168 . 15.618  33.154 18.242  1.00 11.85 168 GNP A C4    1
+ATOM   1355 N N     . MET B 4 1   . 31.790  10.088 6.570   1.00 17.39 1   MET B N     1
+ATOM   1356 C CA    . MET B 4 1   . 30.639  10.964 6.717   1.00 21.56 1   MET B CA    1
+ATOM   1357 C C     . MET B 4 1   . 29.732  10.484 5.657   1.00 19.87 1   MET B C     1
+ATOM   1358 C CB    . MET B 4 1   . 30.931  12.453 6.463   1.00 21.63 1   MET B CB    1
+ATOM   1359 O O     . MET B 4 1   . 30.157  9.729  4.772   1.00 22.03 1   MET B O     1
+ATOM   1360 C CG    . MET B 4 1   . 31.239  12.903 5.061   1.00 22.93 1   MET B CG    1
+ATOM   1361 S SD    . MET B 4 1   . 31.790  14.623 5.049   1.00 28.30 1   MET B SD    1
+ATOM   1362 C CE    . MET B 4 1   . 33.489  14.135 4.890   1.00 26.84 1   MET B CE    1
+ATOM   1363 N N     . THR B 4 2   . 28.489  10.907 5.806   1.00 23.06 2   THR B N     1
+ATOM   1364 C CA    . THR B 4 2   . 27.475  10.463 4.877   1.00 21.79 2   THR B CA    1
+ATOM   1365 C C     . THR B 4 2   . 27.790  11.054 3.519   1.00 19.63 2   THR B C     1
+ATOM   1366 C CB    . THR B 4 2   . 26.124  10.927 5.367   1.00 20.84 2   THR B CB    1
+ATOM   1367 O O     . THR B 4 2   . 28.125  12.231 3.448   1.00 15.86 2   THR B O     1
+ATOM   1368 C CG2   . THR B 4 2   . 24.980  10.393 4.537   1.00 21.59 2   THR B CG2   1
+ATOM   1369 O OG1   . THR B 4 2   . 25.998  10.421 6.678   1.00 25.79 2   THR B OG1   1
+ATOM   1370 N N     . GLU B 4 3   . 27.777  10.243 2.458   1.00 20.28 3   GLU B N     1
+ATOM   1371 C CA    . GLU B 4 3   . 27.916  10.806 1.118   1.00 22.28 3   GLU B CA    1
+ATOM   1372 C C     . GLU B 4 3   . 26.630  10.545 0.346   1.00 17.63 3   GLU B C     1
+ATOM   1373 C CB    . GLU B 4 3   . 29.073  10.182 0.381   1.00 24.90 3   GLU B CB    1
+ATOM   1374 O O     . GLU B 4 3   . 25.951  9.547  0.570   1.00 17.65 3   GLU B O     1
+ATOM   1375 C CG    . GLU B 4 3   . 30.323  10.337 1.224   1.00 27.80 3   GLU B CG    1
+ATOM   1376 C CD    . GLU B 4 3   . 31.669  10.063 0.570   1.00 29.48 3   GLU B CD    1
+ATOM   1377 O OE1   . GLU B 4 3   . 31.726  9.830  -0.636  1.00 27.39 3   GLU B OE1   1
+ATOM   1378 O OE2   . GLU B 4 3   . 32.676  10.118 1.288   1.00 33.53 3   GLU B OE2   1
+ATOM   1379 N N     . TYR B 4 4   . 26.240  11.485 -0.494  1.00 13.72 4   TYR B N     1
+ATOM   1380 C CA    . TYR B 4 4   . 25.034  11.351 -1.286  1.00 12.99 4   TYR B CA    1
+ATOM   1381 C C     . TYR B 4 4   . 25.475  11.499 -2.726  1.00 12.18 4   TYR B C     1
+ATOM   1382 C CB    . TYR B 4 4   . 24.067  12.435 -0.940  1.00 12.70 4   TYR B CB    1
+ATOM   1383 O O     . TYR B 4 4   . 26.068  12.511 -3.098  1.00 11.40 4   TYR B O     1
+ATOM   1384 C CG    . TYR B 4 4   . 23.519  12.386 0.470   1.00 13.42 4   TYR B CG    1
+ATOM   1385 C CD1   . TYR B 4 4   . 22.431  11.552 0.730   1.00 13.88 4   TYR B CD1   1
+ATOM   1386 C CD2   . TYR B 4 4   . 24.123  13.178 1.455   1.00 15.41 4   TYR B CD2   1
+ATOM   1387 C CE1   . TYR B 4 4   . 21.935  11.507 2.011   1.00 12.73 4   TYR B CE1   1
+ATOM   1388 C CE2   . TYR B 4 4   . 23.633  13.152 2.743   1.00 12.65 4   TYR B CE2   1
+ATOM   1389 O OH    . TYR B 4 4   . 22.118  12.160 4.294   1.00 12.99 4   TYR B OH    1
+ATOM   1390 C CZ    . TYR B 4 4   . 22.549  12.296 2.992   1.00 14.61 4   TYR B CZ    1
+ATOM   1391 N N     . LYS B 4 5   . 25.215  10.469 -3.532  1.00 16.13 5   LYS B N     1
+ATOM   1392 C CA    . LYS B 4 5   . 25.647  10.399 -4.923  1.00 14.98 5   LYS B CA    1
+ATOM   1393 C C     . LYS B 4 5   . 24.494  10.877 -5.781  1.00 11.27 5   LYS B C     1
+ATOM   1394 C CB    . LYS B 4 5   . 26.052  8.944  -5.212  1.00 18.95 5   LYS B CB    1
+ATOM   1395 O O     . LYS B 4 5   . 23.507  10.192 -6.020  1.00 13.26 5   LYS B O     1
+ATOM   1396 C CG    . LYS B 4 5   . 26.264  8.527  -6.683  1.00 24.97 5   LYS B CG    1
+ATOM   1397 C CD    . LYS B 4 5   . 27.605  8.829  -7.368  1.00 28.72 5   LYS B CD    1
+ATOM   1398 C CE    . LYS B 4 5   . 27.458  9.713  -8.625  1.00 29.78 5   LYS B CE    1
+ATOM   1399 N NZ    . LYS B 4 5   . 27.505  11.120 -8.267  1.00 31.62 5   LYS B NZ    1
+ATOM   1400 N N     . LEU B 4 6   . 24.650  12.137 -6.168  1.00 10.35 6   LEU B N     1
+ATOM   1401 C CA    . LEU B 4 6   . 23.659  12.893 -6.939  1.00 10.82 6   LEU B CA    1
+ATOM   1402 C C     . LEU B 4 6   . 24.023  12.949 -8.418  1.00 9.50  6   LEU B C     1
+ATOM   1403 C CB    . LEU B 4 6   . 23.559  14.335 -6.394  1.00 9.36  6   LEU B CB    1
+ATOM   1404 O O     . LEU B 4 6   . 25.223  13.110 -8.709  1.00 11.11 6   LEU B O     1
+ATOM   1405 C CG    . LEU B 4 6   . 22.714  14.812 -5.203  1.00 11.39 6   LEU B CG    1
+ATOM   1406 C CD1   . LEU B 4 6   . 22.608  13.804 -4.112  1.00 13.78 6   LEU B CD1   1
+ATOM   1407 C CD2   . LEU B 4 6   . 23.342  16.049 -4.681  1.00 10.60 6   LEU B CD2   1
+ATOM   1408 N N     . VAL B 4 7   . 23.068  12.749 -9.364  1.00 11.49 7   VAL B N     1
+ATOM   1409 C CA    . VAL B 4 7   . 23.394  13.066 -10.758 1.00 11.06 7   VAL B CA    1
+ATOM   1410 C C     . VAL B 4 7   . 22.380  14.010 -11.448 1.00 7.54  7   VAL B C     1
+ATOM   1411 C CB    . VAL B 4 7   . 23.696  11.657 -11.582 1.00 14.01 7   VAL B CB    1
+ATOM   1412 O O     . VAL B 4 7   . 21.166  13.953 -11.268 1.00 4.81  7   VAL B O     1
+ATOM   1413 C CG1   . VAL B 4 7   . 23.874  10.453 -10.629 1.00 10.28 7   VAL B CG1   1
+ATOM   1414 C CG2   . VAL B 4 7   . 22.666  11.421 -12.604 1.00 15.93 7   VAL B CG2   1
+ATOM   1415 N N     . VAL B 4 8   . 22.905  15.023 -12.144 1.00 6.61  8   VAL B N     1
+ATOM   1416 C CA    . VAL B 4 8   . 22.101  16.050 -12.869 1.00 6.42  8   VAL B CA    1
+ATOM   1417 C C     . VAL B 4 8   . 21.902  15.562 -14.318 1.00 10.01 8   VAL B C     1
+ATOM   1418 C CB    . VAL B 4 8   . 22.856  17.380 -12.842 1.00 7.58  8   VAL B CB    1
+ATOM   1419 O O     . VAL B 4 8   . 22.843  15.325 -15.068 1.00 9.77  8   VAL B O     1
+ATOM   1420 C CG1   . VAL B 4 8   . 21.985  18.497 -13.386 1.00 4.13  8   VAL B CG1   1
+ATOM   1421 C CG2   . VAL B 4 8   . 23.208  17.749 -11.405 1.00 7.72  8   VAL B CG2   1
+ATOM   1422 N N     . VAL B 4 9   . 20.658  15.373 -14.750 1.00 12.37 9   VAL B N     1
+ATOM   1423 C CA    . VAL B 4 9   . 20.290  14.723 -16.012 1.00 11.60 9   VAL B CA    1
+ATOM   1424 C C     . VAL B 4 9   . 19.393  15.668 -16.805 1.00 9.03  9   VAL B C     1
+ATOM   1425 C CB    . VAL B 4 9   . 19.669  13.403 -15.480 1.00 9.76  9   VAL B CB    1
+ATOM   1426 O O     . VAL B 4 9   . 18.778  16.550 -16.223 1.00 6.96  9   VAL B O     1
+ATOM   1427 C CG1   . VAL B 4 9   . 18.375  13.066 -16.073 1.00 8.97  9   VAL B CG1   1
+ATOM   1428 C CG2   . VAL B 4 9   . 20.708  12.357 -15.685 1.00 8.44  9   VAL B CG2   1
+ATOM   1429 N N     . GLY B 4 10  . 19.336  15.570 -18.122 1.00 5.40  10  GLY B N     1
+ATOM   1430 C CA    . GLY B 4 10  . 18.534  16.468 -18.951 1.00 9.50  10  GLY B CA    1
+ATOM   1431 C C     . GLY B 4 10  . 19.178  16.807 -20.317 1.00 10.97 10  GLY B C     1
+ATOM   1432 O O     . GLY B 4 10  . 20.365  16.560 -20.568 1.00 8.91  10  GLY B O     1
+ATOM   1433 N N     . ALA B 4 11  . 18.353  17.427 -21.185 1.00 11.74 11  ALA B N     1
+ATOM   1434 C CA    . ALA B 4 11  . 18.676  17.800 -22.550 1.00 10.30 11  ALA B CA    1
+ATOM   1435 C C     . ALA B 4 11  . 19.774  18.843 -22.627 1.00 7.59  11  ALA B C     1
+ATOM   1436 C CB    . ALA B 4 11  . 17.418  18.339 -23.251 1.00 5.26  11  ALA B CB    1
+ATOM   1437 O O     . ALA B 4 11  . 20.003  19.613 -21.704 1.00 9.59  11  ALA B O     1
+ATOM   1438 N N     . GLY B 4 12  . 20.466  18.871 -23.767 1.00 13.13 12  GLY B N     1
+ATOM   1439 C CA    . GLY B 4 12  . 21.547  19.815 -24.046 1.00 10.37 12  GLY B CA    1
+ATOM   1440 C C     . GLY B 4 12  . 21.051  21.242 -23.961 1.00 8.39  12  GLY B C     1
+ATOM   1441 O O     . GLY B 4 12  . 19.952  21.536 -24.442 1.00 12.77 12  GLY B O     1
+ATOM   1442 N N     . GLY B 4 13  . 21.850  22.042 -23.242 1.00 3.43  13  GLY B N     1
+ATOM   1443 C CA    . GLY B 4 13  . 21.687  23.478 -23.111 1.00 2.72  13  GLY B CA    1
+ATOM   1444 C C     . GLY B 4 13  . 20.703  23.914 -22.053 1.00 2.00  13  GLY B C     1
+ATOM   1445 O O     . GLY B 4 13  . 20.491  25.110 -21.928 1.00 5.95  13  GLY B O     1
+ATOM   1446 N N     . VAL B 4 14  . 20.082  23.021 -21.280 1.00 5.87  14  VAL B N     1
+ATOM   1447 C CA    . VAL B 4 14  . 19.093  23.396 -20.241 1.00 8.14  14  VAL B CA    1
+ATOM   1448 C C     . VAL B 4 14  . 19.631  24.099 -18.956 1.00 9.48  14  VAL B C     1
+ATOM   1449 C CB    . VAL B 4 14  . 18.230  22.129 -19.793 1.00 8.30  14  VAL B CB    1
+ATOM   1450 O O     . VAL B 4 14  . 18.861  24.718 -18.220 1.00 11.28 14  VAL B O     1
+ATOM   1451 C CG1   . VAL B 4 14  . 17.449  21.613 -20.995 1.00 2.18  14  VAL B CG1   1
+ATOM   1452 C CG2   . VAL B 4 14  . 19.102  21.020 -19.166 1.00 9.19  14  VAL B CG2   1
+ATOM   1453 N N     . GLY B 4 15  . 20.933  24.114 -18.668 1.00 7.97  15  GLY B N     1
+ATOM   1454 C CA    . GLY B 4 15  . 21.497  24.766 -17.494 1.00 10.23 15  GLY B CA    1
+ATOM   1455 C C     . GLY B 4 15  . 21.991  23.763 -16.460 1.00 10.49 15  GLY B C     1
+ATOM   1456 O O     . GLY B 4 15  . 22.220  24.183 -15.331 1.00 11.65 15  GLY B O     1
+ATOM   1457 N N     . LYS B 4 16  . 22.155  22.455 -16.781 1.00 11.05 16  LYS B N     1
+ATOM   1458 C CA    . LYS B 4 16  . 22.655  21.441 -15.834 1.00 8.71  16  LYS B CA    1
+ATOM   1459 C C     . LYS B 4 16  . 23.898  21.914 -15.134 1.00 11.00 16  LYS B C     1
+ATOM   1460 C CB    . LYS B 4 16  . 22.978  20.121 -16.563 1.00 5.15  16  LYS B CB    1
+ATOM   1461 O O     . LYS B 4 16  . 23.934  21.985 -13.912 1.00 15.58 16  LYS B O     1
+ATOM   1462 C CG    . LYS B 4 16  . 21.756  19.393 -17.099 1.00 5.63  16  LYS B CG    1
+ATOM   1463 C CD    . LYS B 4 16  . 22.062  17.989 -17.597 1.00 3.46  16  LYS B CD    1
+ATOM   1464 C CE    . LYS B 4 16  . 22.969  17.907 -18.844 1.00 8.41  16  LYS B CE    1
+ATOM   1465 N NZ    . LYS B 4 16  . 22.398  18.464 -20.042 1.00 7.94  16  LYS B NZ    1
+ATOM   1466 N N     . SER B 4 17  . 24.934  22.269 -15.915 1.00 13.06 17  SER B N     1
+ATOM   1467 C CA    . SER B 4 17  . 26.227  22.748 -15.460 1.00 8.74  17  SER B CA    1
+ATOM   1468 C C     . SER B 4 17  . 26.211  24.099 -14.792 1.00 11.65 17  SER B C     1
+ATOM   1469 C CB    . SER B 4 17  . 27.213  22.838 -16.622 1.00 11.04 17  SER B CB    1
+ATOM   1470 O O     . SER B 4 17  . 26.883  24.275 -13.794 1.00 10.52 17  SER B O     1
+ATOM   1471 O OG    . SER B 4 17  . 27.701  21.613 -17.190 1.00 9.37  17  SER B OG    1
+ATOM   1472 N N     . ALA B 4 18  . 25.525  25.107 -15.318 1.00 10.95 18  ALA B N     1
+ATOM   1473 C CA    . ALA B 4 18  . 25.412  26.380 -14.620 1.00 10.40 18  ALA B CA    1
+ATOM   1474 C C     . ALA B 4 18  . 24.704  26.183 -13.283 1.00 9.76  18  ALA B C     1
+ATOM   1475 C CB    . ALA B 4 18  . 24.610  27.365 -15.471 1.00 7.61  18  ALA B CB    1
+ATOM   1476 O O     . ALA B 4 18  . 24.904  26.927 -12.338 1.00 14.62 18  ALA B O     1
+ATOM   1477 N N     . LEU B 4 19  . 23.793  25.229 -13.153 1.00 10.29 19  LEU B N     1
+ATOM   1478 C CA    . LEU B 4 19  . 23.138  24.982 -11.870 1.00 11.49 19  LEU B CA    1
+ATOM   1479 C C     . LEU B 4 19  . 24.158  24.460 -10.870 1.00 8.80  19  LEU B C     1
+ATOM   1480 C CB    . LEU B 4 19  . 22.029  23.946 -12.034 1.00 7.54  19  LEU B CB    1
+ATOM   1481 O O     . LEU B 4 19  . 24.263  24.937 -9.741  1.00 8.29  19  LEU B O     1
+ATOM   1482 C CG    . LEU B 4 19  . 20.595  24.210 -11.795 1.00 10.78 19  LEU B CG    1
+ATOM   1483 C CD1   . LEU B 4 19  . 20.264  25.692 -11.638 1.00 15.81 19  LEU B CD1   1
+ATOM   1484 C CD2   . LEU B 4 19  . 19.883  23.514 -12.932 1.00 12.47 19  LEU B CD2   1
+ATOM   1485 N N     . THR B 4 20  . 24.889  23.453 -11.329 1.00 11.27 20  THR B N     1
+ATOM   1486 C CA    . THR B 4 20  . 25.924  22.802 -10.558 1.00 12.01 20  THR B CA    1
+ATOM   1487 C C     . THR B 4 20  . 27.032  23.735 -10.045 1.00 13.59 20  THR B C     1
+ATOM   1488 C CB    . THR B 4 20  . 26.495  21.691 -11.446 1.00 10.38 20  THR B CB    1
+ATOM   1489 O O     . THR B 4 20  . 27.468  23.644 -8.892  1.00 15.31 20  THR B O     1
+ATOM   1490 C CG2   . THR B 4 20  . 27.596  20.879 -10.777 1.00 14.18 20  THR B CG2   1
+ATOM   1491 O OG1   . THR B 4 20  . 25.419  20.822 -11.713 1.00 11.24 20  THR B OG1   1
+ATOM   1492 N N     . ILE B 4 21  . 27.510  24.618 -10.920 1.00 9.59  21  ILE B N     1
+ATOM   1493 C CA    . ILE B 4 21  . 28.555  25.565 -10.642 1.00 12.82 21  ILE B CA    1
+ATOM   1494 C C     . ILE B 4 21  . 28.117  26.757 -9.770  1.00 12.40 21  ILE B C     1
+ATOM   1495 C CB    . ILE B 4 21  . 29.079  25.948 -12.026 1.00 13.85 21  ILE B CB    1
+ATOM   1496 O O     . ILE B 4 21  . 28.906  27.318 -9.004  1.00 14.79 21  ILE B O     1
+ATOM   1497 C CG1   . ILE B 4 21  . 29.916  24.772 -12.532 1.00 12.86 21  ILE B CG1   1
+ATOM   1498 C CG2   . ILE B 4 21  . 29.755  27.301 -11.972 1.00 10.82 21  ILE B CG2   1
+ATOM   1499 C CD1   . ILE B 4 21  . 30.698  24.988 -13.822 1.00 17.21 21  ILE B CD1   1
+ATOM   1500 N N     . GLN B 4 22  . 26.867  27.181 -9.871  1.00 11.76 22  GLN B N     1
+ATOM   1501 C CA    . GLN B 4 22  . 26.335  28.181 -8.954  1.00 13.98 22  GLN B CA    1
+ATOM   1502 C C     . GLN B 4 22  . 26.391  27.546 -7.533  1.00 16.15 22  GLN B C     1
+ATOM   1503 C CB    . GLN B 4 22  . 24.952  28.498 -9.518  1.00 7.23  22  GLN B CB    1
+ATOM   1504 O O     . GLN B 4 22  . 26.980  28.152 -6.614  1.00 20.32 22  GLN B O     1
+ATOM   1505 C CG    . GLN B 4 22  . 24.178  29.616 -8.938  1.00 13.24 22  GLN B CG    1
+ATOM   1506 C CD    . GLN B 4 22  . 24.886  30.948 -8.890  1.00 12.26 22  GLN B CD    1
+ATOM   1507 N NE2   . GLN B 4 22  . 24.673  31.829 -9.860  1.00 10.61 22  GLN B NE2   1
+ATOM   1508 O OE1   . GLN B 4 22  . 25.604  31.234 -7.935  1.00 14.29 22  GLN B OE1   1
+ATOM   1509 N N     . LEU B 4 23  . 25.926  26.290 -7.304  1.00 15.21 23  LEU B N     1
+ATOM   1510 C CA    . LEU B 4 23  . 26.045  25.595 -5.990  1.00 17.11 23  LEU B CA    1
+ATOM   1511 C C     . LEU B 4 23  . 27.465  25.479 -5.404  1.00 17.19 23  LEU B C     1
+ATOM   1512 C CB    . LEU B 4 23  . 25.489  24.164 -6.107  1.00 10.86 23  LEU B CB    1
+ATOM   1513 O O     . LEU B 4 23  . 27.653  25.771 -4.236  1.00 21.87 23  LEU B O     1
+ATOM   1514 C CG    . LEU B 4 23  . 24.663  23.392 -5.100  1.00 15.35 23  LEU B CG    1
+ATOM   1515 C CD1   . LEU B 4 23  . 25.402  22.142 -4.835  1.00 15.34 23  LEU B CD1   1
+ATOM   1516 C CD2   . LEU B 4 23  . 24.407  24.129 -3.811  1.00 16.54 23  LEU B CD2   1
+ATOM   1517 N N     . ILE B 4 24  . 28.448  25.001 -6.186  1.00 18.20 24  ILE B N     1
+ATOM   1518 C CA    . ILE B 4 24  . 29.807  24.680 -5.779  1.00 19.80 24  ILE B CA    1
+ATOM   1519 C C     . ILE B 4 24  . 30.760  25.880 -5.890  1.00 23.98 24  ILE B C     1
+ATOM   1520 C CB    . ILE B 4 24  . 30.365  23.517 -6.666  1.00 15.64 24  ILE B CB    1
+ATOM   1521 O O     . ILE B 4 24  . 31.725  25.984 -5.115  1.00 23.17 24  ILE B O     1
+ATOM   1522 C CG1   . ILE B 4 24  . 29.503  22.278 -6.607  1.00 18.21 24  ILE B CG1   1
+ATOM   1523 C CG2   . ILE B 4 24  . 31.733  23.113 -6.190  1.00 17.62 24  ILE B CG2   1
+ATOM   1524 C CD1   . ILE B 4 24  . 29.294  21.520 -5.252  1.00 19.50 24  ILE B CD1   1
+ATOM   1525 N N     . GLN B 4 25  . 30.571  26.760 -6.882  1.00 22.23 25  GLN B N     1
+ATOM   1526 C CA    . GLN B 4 25  . 31.502  27.848 -7.083  1.00 22.85 25  GLN B CA    1
+ATOM   1527 C C     . GLN B 4 25  . 30.877  29.217 -7.039  1.00 21.11 25  GLN B C     1
+ATOM   1528 C CB    . GLN B 4 25  . 32.226  27.684 -8.411  1.00 26.50 25  GLN B CB    1
+ATOM   1529 O O     . GLN B 4 25  . 31.534  30.238 -7.254  1.00 21.65 25  GLN B O     1
+ATOM   1530 C CG    . GLN B 4 25  . 33.207  26.515 -8.508  1.00 30.11 25  GLN B CG    1
+ATOM   1531 C CD    . GLN B 4 25  . 33.827  26.383 -9.909  1.00 32.62 25  GLN B CD    1
+ATOM   1532 N NE2   . GLN B 4 25  . 34.026  25.157 -10.399 1.00 30.07 25  GLN B NE2   1
+ATOM   1533 O OE1   . GLN B 4 25  . 34.140  27.372 -10.581 1.00 33.70 25  GLN B OE1   1
+ATOM   1534 N N     . ASN B 4 26  . 29.587  29.304 -6.765  1.00 26.31 26  ASN B N     1
+ATOM   1535 C CA    . ASN B 4 26  . 28.980  30.597 -6.549  1.00 28.48 26  ASN B CA    1
+ATOM   1536 C C     . ASN B 4 26  . 29.189  31.625 -7.662  1.00 27.56 26  ASN B C     1
+ATOM   1537 C CB    . ASN B 4 26  . 29.505  31.123 -5.209  1.00 31.88 26  ASN B CB    1
+ATOM   1538 O O     . ASN B 4 26  . 29.717  32.721 -7.459  1.00 30.03 26  ASN B O     1
+ATOM   1539 C CG    . ASN B 4 26  . 28.687  32.305 -4.742  1.00 38.18 26  ASN B CG    1
+ATOM   1540 N ND2   . ASN B 4 26  . 29.314  33.481 -4.621  1.00 41.94 26  ASN B ND2   1
+ATOM   1541 O OD1   . ASN B 4 26  . 27.483  32.165 -4.491  1.00 41.14 26  ASN B OD1   1
+ATOM   1542 N N     . HIS B 4 27  . 28.834  31.251 -8.882  1.00 24.40 27  HIS B N     1
+ATOM   1543 C CA    . HIS B 4 27  . 28.831  32.204 -9.988  1.00 24.23 27  HIS B CA    1
+ATOM   1544 C C     . HIS B 4 27  . 28.148  31.602 -11.195 1.00 21.87 27  HIS B C     1
+ATOM   1545 C CB    . HIS B 4 27  . 30.259  32.651 -10.429 1.00 23.04 27  HIS B CB    1
+ATOM   1546 O O     . HIS B 4 27  . 28.082  30.379 -11.350 1.00 19.42 27  HIS B O     1
+ATOM   1547 C CG    . HIS B 4 27  . 31.086  31.692 -11.264 1.00 27.03 27  HIS B CG    1
+ATOM   1548 C CD2   . HIS B 4 27  . 31.490  30.431 -10.908 1.00 28.81 27  HIS B CD2   1
+ATOM   1549 N ND1   . HIS B 4 27  . 31.558  32.078 -12.431 1.00 28.94 27  HIS B ND1   1
+ATOM   1550 C CE1   . HIS B 4 27  . 32.275  31.046 -12.821 1.00 28.40 27  HIS B CE1   1
+ATOM   1551 N NE2   . HIS B 4 27  . 32.233  30.078 -11.922 1.00 29.56 27  HIS B NE2   1
+ATOM   1552 N N     . PHE B 4 28  . 27.660  32.502 -12.048 1.00 22.54 28  PHE B N     1
+ATOM   1553 C CA    . PHE B 4 28  . 26.986  32.157 -13.277 1.00 19.44 28  PHE B CA    1
+ATOM   1554 C C     . PHE B 4 28  . 27.957  32.142 -14.451 1.00 18.80 28  PHE B C     1
+ATOM   1555 C CB    . PHE B 4 28  . 25.881  33.158 -13.495 1.00 17.76 28  PHE B CB    1
+ATOM   1556 O O     . PHE B 4 28  . 28.754  33.048 -14.702 1.00 17.58 28  PHE B O     1
+ATOM   1557 C CG    . PHE B 4 28  . 25.040  32.913 -14.730 1.00 18.01 28  PHE B CG    1
+ATOM   1558 C CD1   . PHE B 4 28  . 24.269  31.755 -14.829 1.00 18.34 28  PHE B CD1   1
+ATOM   1559 C CD2   . PHE B 4 28  . 25.036  33.865 -15.731 1.00 18.40 28  PHE B CD2   1
+ATOM   1560 C CE1   . PHE B 4 28  . 23.493  31.567 -15.937 1.00 17.77 28  PHE B CE1   1
+ATOM   1561 C CE2   . PHE B 4 28  . 24.242  33.654 -16.847 1.00 19.53 28  PHE B CE2   1
+ATOM   1562 C CZ    . PHE B 4 28  . 23.476  32.514 -16.946 1.00 16.35 28  PHE B CZ    1
+ATOM   1563 N N     . VAL B 4 29  . 27.879  30.995 -15.118 1.00 19.19 29  VAL B N     1
+ATOM   1564 C CA    . VAL B 4 29  . 28.651  30.743 -16.319 1.00 23.68 29  VAL B CA    1
+ATOM   1565 C C     . VAL B 4 29  . 27.687  31.134 -17.452 1.00 27.40 29  VAL B C     1
+ATOM   1566 C CB    . VAL B 4 29  . 29.040  29.242 -16.417 1.00 21.40 29  VAL B CB    1
+ATOM   1567 O O     . VAL B 4 29  . 26.655  30.486 -17.682 1.00 25.78 29  VAL B O     1
+ATOM   1568 C CG1   . VAL B 4 29  . 29.845  29.026 -17.677 1.00 22.94 29  VAL B CG1   1
+ATOM   1569 C CG2   . VAL B 4 29  . 29.910  28.805 -15.237 1.00 23.24 29  VAL B CG2   1
+ATOM   1570 N N     . ASP B 4 30  . 28.039  32.228 -18.136 1.00 28.85 30  ASP B N     1
+ATOM   1571 C CA    . ASP B 4 30  . 27.239  32.796 -19.224 1.00 30.28 30  ASP B CA    1
+ATOM   1572 C C     . ASP B 4 30  . 27.593  32.198 -20.615 1.00 31.13 30  ASP B C     1
+ATOM   1573 C CB    . ASP B 4 30  . 27.465  34.337 -19.117 1.00 33.44 30  ASP B CB    1
+ATOM   1574 O O     . ASP B 4 30  . 26.946  32.532 -21.618 1.00 34.55 30  ASP B O     1
+ATOM   1575 C CG    . ASP B 4 30  . 26.426  35.342 -19.645 1.00 37.21 30  ASP B CG    1
+ATOM   1576 O OD1   . ASP B 4 30  . 25.246  35.011 -19.786 1.00 40.34 30  ASP B OD1   1
+ATOM   1577 O OD2   . ASP B 4 30  . 26.796  36.492 -19.903 1.00 39.26 30  ASP B OD2   1
+ATOM   1578 N N     . GLU B 4 31  . 28.553  31.250 -20.742 1.00 28.81 31  GLU B N     1
+ATOM   1579 C CA    . GLU B 4 31  . 28.993  30.745 -22.043 1.00 27.43 31  GLU B CA    1
+ATOM   1580 C C     . GLU B 4 31  . 28.747  29.309 -22.426 1.00 23.95 31  GLU B C     1
+ATOM   1581 C CB    . GLU B 4 31  . 30.482  30.951 -22.248 1.00 26.52 31  GLU B CB    1
+ATOM   1582 O O     . GLU B 4 31  . 28.329  28.444 -21.653 1.00 22.11 31  GLU B O     1
+ATOM   1583 C CG    . GLU B 4 31  . 31.371  30.126 -21.379 1.00 31.16 31  GLU B CG    1
+ATOM   1584 C CD    . GLU B 4 31  . 32.220  31.077 -20.593 1.00 35.47 31  GLU B CD    1
+ATOM   1585 O OE1   . GLU B 4 31  . 31.690  31.766 -19.708 1.00 36.58 31  GLU B OE1   1
+ATOM   1586 O OE2   . GLU B 4 31  . 33.412  31.132 -20.898 1.00 39.46 31  GLU B OE2   1
+ATOM   1587 N N     . TYR B 4 32  . 29.085  29.183 -23.715 1.00 21.32 32  TYR B N     1
+ATOM   1588 C CA    . TYR B 4 32  . 29.002  27.947 -24.452 1.00 20.70 32  TYR B CA    1
+ATOM   1589 C C     . TYR B 4 32  . 30.124  27.018 -23.981 1.00 19.76 32  TYR B C     1
+ATOM   1590 C CB    . TYR B 4 32  . 29.098  28.282 -25.984 1.00 17.09 32  TYR B CB    1
+ATOM   1591 O O     . TYR B 4 32  . 31.311  27.241 -24.255 1.00 18.76 32  TYR B O     1
+ATOM   1592 C CG    . TYR B 4 32  . 28.733  27.103 -26.903 1.00 15.38 32  TYR B CG    1
+ATOM   1593 C CD1   . TYR B 4 32  . 29.683  26.153 -27.251 1.00 16.04 32  TYR B CD1   1
+ATOM   1594 C CD2   . TYR B 4 32  . 27.440  26.971 -27.345 1.00 14.05 32  TYR B CD2   1
+ATOM   1595 C CE1   . TYR B 4 32  . 29.326  25.079 -28.034 1.00 13.20 32  TYR B CE1   1
+ATOM   1596 C CE2   . TYR B 4 32  . 27.077  25.902 -28.124 1.00 13.66 32  TYR B CE2   1
+ATOM   1597 O OH    . TYR B 4 32  . 27.633  23.884 -29.178 1.00 13.02 32  TYR B OH    1
+ATOM   1598 C CZ    . TYR B 4 32  . 28.022  24.973 -28.451 1.00 12.22 32  TYR B CZ    1
+ATOM   1599 N N     . ASP B 4 33  . 29.738  25.975 -23.227 1.00 17.30 33  ASP B N     1
+ATOM   1600 C CA    . ASP B 4 33  . 30.715  25.017 -22.772 1.00 17.06 33  ASP B CA    1
+ATOM   1601 C C     . ASP B 4 33  . 30.185  23.597 -22.532 1.00 18.74 33  ASP B C     1
+ATOM   1602 C CB    . ASP B 4 33  . 31.313  25.622 -21.521 1.00 15.86 33  ASP B CB    1
+ATOM   1603 O O     . ASP B 4 33  . 30.048  23.173 -21.367 1.00 16.60 33  ASP B O     1
+ATOM   1604 C CG    . ASP B 4 33  . 32.561  24.934 -21.014 1.00 16.58 33  ASP B CG    1
+ATOM   1605 O OD1   . ASP B 4 33  . 33.118  24.046 -21.661 1.00 20.14 33  ASP B OD1   1
+ATOM   1606 O OD2   . ASP B 4 33  . 33.010  25.337 -19.954 1.00 17.28 33  ASP B OD2   1
+ATOM   1607 N N     . PRO B 4 34  . 29.841  22.807 -23.583 1.00 14.85 34  PRO B N     1
+ATOM   1608 C CA    . PRO B 4 34  . 29.136  21.527 -23.471 1.00 12.63 34  PRO B CA    1
+ATOM   1609 C C     . PRO B 4 34  . 29.947  20.582 -22.627 1.00 9.18  34  PRO B C     1
+ATOM   1610 C CB    . PRO B 4 34  . 28.977  21.006 -24.846 1.00 10.39 34  PRO B CB    1
+ATOM   1611 O O     . PRO B 4 34  . 31.161  20.666 -22.610 1.00 13.30 34  PRO B O     1
+ATOM   1612 C CG    . PRO B 4 34  . 29.055  22.273 -25.627 1.00 13.12 34  PRO B CG    1
+ATOM   1613 C CD    . PRO B 4 34  . 30.168  23.045 -24.960 1.00 15.14 34  PRO B CD    1
+ATOM   1614 N N     . THR B 4 35  . 29.282  19.691 -21.916 1.00 11.37 35  THR B N     1
+ATOM   1615 C CA    . THR B 4 35  . 29.893  18.746 -20.993 1.00 10.07 35  THR B CA    1
+ATOM   1616 C C     . THR B 4 35  . 29.952  17.407 -21.634 1.00 11.03 35  THR B C     1
+ATOM   1617 C CB    . THR B 4 35  . 29.046  18.640 -19.732 1.00 5.59  35  THR B CB    1
+ATOM   1618 O O     . THR B 4 35  . 29.066  17.050 -22.404 1.00 11.01 35  THR B O     1
+ATOM   1619 C CG2   . THR B 4 35  . 29.545  17.709 -18.639 1.00 6.30  35  THR B CG2   1
+ATOM   1620 O OG1   . THR B 4 35  . 29.050  19.962 -19.268 1.00 6.36  35  THR B OG1   1
+ATOM   1621 N N     . ILE B 4 36  . 31.011  16.698 -21.235 1.00 14.57 36  ILE B N     1
+ATOM   1622 C CA    . ILE B 4 36  . 31.169  15.277 -21.556 1.00 18.28 36  ILE B CA    1
+ATOM   1623 C C     . ILE B 4 36  . 30.786  14.623 -20.222 1.00 16.18 36  ILE B C     1
+ATOM   1624 C CB    . ILE B 4 36  . 32.692  14.918 -21.993 1.00 18.48 36  ILE B CB    1
+ATOM   1625 O O     . ILE B 4 36  . 29.725  14.033 -20.054 1.00 17.75 36  ILE B O     1
+ATOM   1626 C CG1   . ILE B 4 36  . 33.042  15.495 -23.394 1.00 18.87 36  ILE B CG1   1
+ATOM   1627 C CG2   . ILE B 4 36  . 32.855  13.408 -22.044 1.00 16.25 36  ILE B CG2   1
+ATOM   1628 C CD1   . ILE B 4 36  . 34.515  15.411 -23.918 1.00 22.85 36  ILE B CD1   1
+ATOM   1629 N N     . GLU B 4 37  . 31.621  14.849 -19.227 1.00 18.33 37  GLU B N     1
+ATOM   1630 C CA    . GLU B 4 37  . 31.363  14.345 -17.905 1.00 22.50 37  GLU B CA    1
+ATOM   1631 C C     . GLU B 4 37  . 32.282  15.091 -16.955 1.00 22.10 37  GLU B C     1
+ATOM   1632 C CB    . GLU B 4 37  . 31.629  12.845 -17.853 1.00 23.67 37  GLU B CB    1
+ATOM   1633 O O     . GLU B 4 37  . 33.484  15.243 -17.198 1.00 24.14 37  GLU B O     1
+ATOM   1634 C CG    . GLU B 4 37  . 30.501  12.167 -17.081 1.00 30.80 37  GLU B CG    1
+ATOM   1635 C CD    . GLU B 4 37  . 30.636  10.658 -16.874 1.00 34.92 37  GLU B CD    1
+ATOM   1636 O OE1   . GLU B 4 37  . 31.743  10.156 -16.666 1.00 35.36 37  GLU B OE1   1
+ATOM   1637 O OE2   . GLU B 4 37  . 29.610  9.971  -16.896 1.00 38.35 37  GLU B OE2   1
+ATOM   1638 N N     . ASP B 4 38  . 31.632  15.580 -15.895 1.00 19.49 38  ASP B N     1
+ATOM   1639 C CA    . ASP B 4 38  . 32.268  16.320 -14.825 1.00 18.38 38  ASP B CA    1
+ATOM   1640 C C     . ASP B 4 38  . 31.752  15.932 -13.446 1.00 16.39 38  ASP B C     1
+ATOM   1641 C CB    . ASP B 4 38  . 32.053  17.815 -15.043 1.00 20.45 38  ASP B CB    1
+ATOM   1642 O O     . ASP B 4 38  . 30.563  15.756 -13.243 1.00 12.96 38  ASP B O     1
+ATOM   1643 C CG    . ASP B 4 38  . 32.711  18.386 -16.306 1.00 23.48 38  ASP B CG    1
+ATOM   1644 O OD1   . ASP B 4 38  . 33.718  17.851 -16.775 1.00 20.24 38  ASP B OD1   1
+ATOM   1645 O OD2   . ASP B 4 38  . 32.219  19.396 -16.810 1.00 26.72 38  ASP B OD2   1
+ATOM   1646 N N     . SER B 4 39  . 32.674  15.881 -12.482 1.00 16.24 39  SER B N     1
+ATOM   1647 C CA    . SER B 4 39  . 32.404  15.398 -11.140 1.00 18.13 39  SER B CA    1
+ATOM   1648 C C     . SER B 4 39  . 32.724  16.442 -10.083 1.00 17.69 39  SER B C     1
+ATOM   1649 C CB    . SER B 4 39  . 33.239  14.178 -10.909 1.00 19.11 39  SER B CB    1
+ATOM   1650 O O     . SER B 4 39  . 33.797  17.048 -10.105 1.00 18.74 39  SER B O     1
+ATOM   1651 O OG    . SER B 4 39  . 32.867  13.568 -9.686  1.00 27.01 39  SER B OG    1
+ATOM   1652 N N     . TYR B 4 40  . 31.830  16.709 -9.141  1.00 20.34 40  TYR B N     1
+ATOM   1653 C CA    . TYR B 4 40  . 32.125  17.671 -8.083  1.00 22.19 40  TYR B CA    1
+ATOM   1654 C C     . TYR B 4 40  . 31.849  17.147 -6.668  1.00 22.63 40  TYR B C     1
+ATOM   1655 C CB    . TYR B 4 40  . 31.306  18.924 -8.307  1.00 19.14 40  TYR B CB    1
+ATOM   1656 O O     . TYR B 4 40  . 30.754  16.651 -6.361  1.00 21.54 40  TYR B O     1
+ATOM   1657 C CG    . TYR B 4 40  . 31.575  19.648 -9.620  1.00 19.40 40  TYR B CG    1
+ATOM   1658 C CD1   . TYR B 4 40  . 30.904  19.269 -10.764 1.00 17.75 40  TYR B CD1   1
+ATOM   1659 C CD2   . TYR B 4 40  . 32.462  20.711 -9.646  1.00 20.82 40  TYR B CD2   1
+ATOM   1660 C CE1   . TYR B 4 40  . 31.106  19.947 -11.939 1.00 15.94 40  TYR B CE1   1
+ATOM   1661 C CE2   . TYR B 4 40  . 32.658  21.389 -10.830 1.00 20.24 40  TYR B CE2   1
+ATOM   1662 O OH    . TYR B 4 40  . 32.182  21.659 -13.125 1.00 19.99 40  TYR B OH    1
+ATOM   1663 C CZ    . TYR B 4 40  . 31.977  20.994 -11.956 1.00 16.49 40  TYR B CZ    1
+ATOM   1664 N N     . ARG B 4 41  . 32.837  17.267 -5.776  1.00 20.12 41  ARG B N     1
+ATOM   1665 C CA    . ARG B 4 41  . 32.633  16.866 -4.386  1.00 18.50 41  ARG B CA    1
+ATOM   1666 C C     . ARG B 4 41  . 32.801  18.087 -3.523  1.00 18.83 41  ARG B C     1
+ATOM   1667 C CB    . ARG B 4 41  . 33.650  15.884 -3.939  1.00 15.44 41  ARG B CB    1
+ATOM   1668 O O     . ARG B 4 41  . 33.793  18.812 -3.724  1.00 14.28 41  ARG B O     1
+ATOM   1669 C CG    . ARG B 4 41  . 33.444  14.661 -4.741  1.00 17.34 41  ARG B CG    1
+ATOM   1670 C CD    . ARG B 4 41  . 34.726  13.907 -4.739  1.00 18.47 41  ARG B CD    1
+ATOM   1671 N NE    . ARG B 4 41  . 35.102  13.376 -3.428  1.00 17.90 41  ARG B NE    1
+ATOM   1672 N NH1   . ARG B 4 41  . 33.630  11.560 -3.434  1.00 18.14 41  ARG B NH1   1
+ATOM   1673 N NH2   . ARG B 4 41  . 35.146  11.796 -1.744  1.00 21.06 41  ARG B NH2   1
+ATOM   1674 C CZ    . ARG B 4 41  . 34.629  12.241 -2.894  1.00 18.44 41  ARG B CZ    1
+ATOM   1675 N N     . LYS B 4 42  . 31.852  18.253 -2.575  1.00 16.63 42  LYS B N     1
+ATOM   1676 C CA    . LYS B 4 42  . 31.852  19.375 -1.642  1.00 16.51 42  LYS B CA    1
+ATOM   1677 C C     . LYS B 4 42  . 31.323  18.954 -0.288  1.00 15.80 42  LYS B C     1
+ATOM   1678 C CB    . LYS B 4 42  . 30.978  20.536 -2.115  1.00 17.12 42  LYS B CB    1
+ATOM   1679 O O     . LYS B 4 42  . 30.312  18.280 -0.173  1.00 13.96 42  LYS B O     1
+ATOM   1680 C CG    . LYS B 4 42  . 31.290  21.804 -1.313  1.00 19.06 42  LYS B CG    1
+ATOM   1681 C CD    . LYS B 4 42  . 30.376  22.972 -1.762  1.00 23.40 42  LYS B CD    1
+ATOM   1682 C CE    . LYS B 4 42  . 30.581  24.306 -1.023  1.00 21.30 42  LYS B CE    1
+ATOM   1683 N NZ    . LYS B 4 42  . 31.995  24.642 -0.998  1.00 24.34 42  LYS B NZ    1
+ATOM   1684 N N     . GLN B 4 43  . 32.047  19.311 0.761   1.00 16.94 43  GLN B N     1
+ATOM   1685 C CA    . GLN B 4 43  . 31.606  19.018 2.108   1.00 18.11 43  GLN B CA    1
+ATOM   1686 C C     . GLN B 4 43  . 30.691  20.158 2.492   1.00 15.74 43  GLN B C     1
+ATOM   1687 C CB    . GLN B 4 43  . 32.745  18.972 3.087   1.00 17.51 43  GLN B CB    1
+ATOM   1688 O O     . GLN B 4 43  . 31.015  21.337 2.420   1.00 18.16 43  GLN B O     1
+ATOM   1689 C CG    . GLN B 4 43  . 33.797  17.922 2.825   1.00 19.98 43  GLN B CG    1
+ATOM   1690 C CD    . GLN B 4 43  . 35.004  18.080 3.761   1.00 24.44 43  GLN B CD    1
+ATOM   1691 N NE2   . GLN B 4 43  . 35.951  19.013 3.602   1.00 25.98 43  GLN B NE2   1
+ATOM   1692 O OE1   . GLN B 4 43  . 35.119  17.322 4.711   1.00 28.07 43  GLN B OE1   1
+ATOM   1693 N N     . VAL B 4 44  . 29.537  19.788 3.006   1.00 16.35 44  VAL B N     1
+ATOM   1694 C CA    . VAL B 4 44  . 28.473  20.743 3.181   1.00 13.51 44  VAL B CA    1
+ATOM   1695 C C     . VAL B 4 44  . 27.764  20.318 4.485   1.00 13.48 44  VAL B C     1
+ATOM   1696 C CB    . VAL B 4 44  . 27.817  20.554 1.753   1.00 14.41 44  VAL B CB    1
+ATOM   1697 O O     . VAL B 4 44  . 28.036  19.237 5.028   1.00 12.84 44  VAL B O     1
+ATOM   1698 C CG1   . VAL B 4 44  . 26.468  19.880 1.839   1.00 15.20 44  VAL B CG1   1
+ATOM   1699 C CG2   . VAL B 4 44  . 27.783  21.875 1.055   1.00 13.27 44  VAL B CG2   1
+ATOM   1700 N N     . VAL B 4 45  . 26.972  21.197 5.105   1.00 11.40 45  VAL B N     1
+ATOM   1701 C CA    . VAL B 4 45  . 26.194  20.841 6.281   1.00 9.50  45  VAL B CA    1
+ATOM   1702 C C     . VAL B 4 45  . 24.740  21.065 5.928   1.00 7.87  45  VAL B C     1
+ATOM   1703 C CB    . VAL B 4 45  . 26.587  21.712 7.525   1.00 13.43 45  VAL B CB    1
+ATOM   1704 O O     . VAL B 4 45  . 24.328  22.199 5.682   1.00 9.48  45  VAL B O     1
+ATOM   1705 C CG1   . VAL B 4 45  . 25.737  21.285 8.745   1.00 12.51 45  VAL B CG1   1
+ATOM   1706 C CG2   . VAL B 4 45  . 28.062  21.525 7.869   1.00 11.76 45  VAL B CG2   1
+ATOM   1707 N N     . ILE B 4 46  . 23.930  20.003 5.910   1.00 8.46  46  ILE B N     1
+ATOM   1708 C CA    . ILE B 4 46  . 22.519  20.149 5.612   1.00 9.16  46  ILE B CA    1
+ATOM   1709 C C     . ILE B 4 46  . 21.741  19.680 6.814   1.00 11.00 46  ILE B C     1
+ATOM   1710 C CB    . ILE B 4 46  . 22.165  19.317 4.388   1.00 8.48  46  ILE B CB    1
+ATOM   1711 O O     . ILE B 4 46  . 21.870  18.527 7.252   1.00 14.11 46  ILE B O     1
+ATOM   1712 C CG1   . ILE B 4 46  . 22.973  19.777 3.175   1.00 11.76 46  ILE B CG1   1
+ATOM   1713 C CG2   . ILE B 4 46  . 20.688  19.497 4.070   1.00 10.64 46  ILE B CG2   1
+ATOM   1714 C CD1   . ILE B 4 46  . 22.801  18.811 1.974   1.00 11.38 46  ILE B CD1   1
+ATOM   1715 N N     . ASP B 4 47  . 20.888  20.572 7.328   1.00 13.00 47  ASP B N     1
+ATOM   1716 C CA    . ASP B 4 47  . 20.017  20.272 8.472   1.00 10.36 47  ASP B CA    1
+ATOM   1717 C C     . ASP B 4 47  . 20.733  19.645 9.663   1.00 10.06 47  ASP B C     1
+ATOM   1718 C CB    . ASP B 4 47  . 18.902  19.338 8.049   1.00 9.72  47  ASP B CB    1
+ATOM   1719 O O     . ASP B 4 47  . 20.297  18.672 10.294  1.00 9.28  47  ASP B O     1
+ATOM   1720 C CG    . ASP B 4 47  . 18.054  19.862 6.929   1.00 11.98 47  ASP B CG    1
+ATOM   1721 O OD1   . ASP B 4 47  . 17.751  21.048 6.957   1.00 10.72 47  ASP B OD1   1
+ATOM   1722 O OD2   . ASP B 4 47  . 17.710  19.096 6.019   1.00 12.80 47  ASP B OD2   1
+ATOM   1723 N N     . GLY B 4 48  . 21.895  20.277 9.873   1.00 13.83 48  GLY B N     1
+ATOM   1724 C CA    . GLY B 4 48  . 22.827  19.927 10.929  1.00 14.95 48  GLY B CA    1
+ATOM   1725 C C     . GLY B 4 48  . 23.700  18.725 10.656  1.00 13.63 48  GLY B C     1
+ATOM   1726 O O     . GLY B 4 48  . 24.654  18.511 11.384  1.00 11.73 48  GLY B O     1
+ATOM   1727 N N     . GLU B 4 49  . 23.455  17.907 9.638   1.00 16.59 49  GLU B N     1
+ATOM   1728 C CA    . GLU B 4 49  . 24.306  16.748 9.389   1.00 17.06 49  GLU B CA    1
+ATOM   1729 C C     . GLU B 4 49  . 25.470  17.111 8.470   1.00 17.60 49  GLU B C     1
+ATOM   1730 C CB    . GLU B 4 49  . 23.440  15.660 8.777   1.00 20.35 49  GLU B CB    1
+ATOM   1731 O O     . GLU B 4 49  . 25.312  17.823 7.477   1.00 14.55 49  GLU B O     1
+ATOM   1732 C CG    . GLU B 4 49  . 24.203  14.470 8.184   1.00 22.55 49  GLU B CG    1
+ATOM   1733 C CD    . GLU B 4 49  . 23.322  13.501 7.416   1.00 23.72 49  GLU B CD    1
+ATOM   1734 O OE1   . GLU B 4 49  . 22.812  13.879 6.359   1.00 21.94 49  GLU B OE1   1
+ATOM   1735 O OE2   . GLU B 4 49  . 23.161  12.372 7.881   1.00 23.99 49  GLU B OE2   1
+ATOM   1736 N N     . THR B 4 50  . 26.672  16.633 8.810   1.00 21.09 50  THR B N     1
+ATOM   1737 C CA    . THR B 4 50  . 27.863  16.805 7.979   1.00 19.56 50  THR B CA    1
+ATOM   1738 C C     . THR B 4 50  . 27.764  15.784 6.860   1.00 16.68 50  THR B C     1
+ATOM   1739 C CB    . THR B 4 50  . 29.157  16.557 8.812   1.00 22.00 50  THR B CB    1
+ATOM   1740 O O     . THR B 4 50  . 27.635  14.580 7.086   1.00 18.30 50  THR B O     1
+ATOM   1741 C CG2   . THR B 4 50  . 30.419  16.773 7.978   1.00 26.15 50  THR B CG2   1
+ATOM   1742 O OG1   . THR B 4 50  . 29.174  17.480 9.893   1.00 24.20 50  THR B OG1   1
+ATOM   1743 N N     . CYS B 4 51  . 27.785  16.246 5.626   1.00 15.83 51  CYS B N     1
+ATOM   1744 C CA    . CYS B 4 51  . 27.813  15.305 4.546   1.00 13.80 51  CYS B CA    1
+ATOM   1745 C C     . CYS B 4 51  . 28.671  15.802 3.390   1.00 14.96 51  CYS B C     1
+ATOM   1746 C CB    . CYS B 4 51  . 26.361  15.041 4.110   1.00 11.02 51  CYS B CB    1
+ATOM   1747 O O     . CYS B 4 51  . 29.114  16.969 3.325   1.00 14.55 51  CYS B O     1
+ATOM   1748 S SG    . CYS B 4 51  . 25.413  16.523 3.743   1.00 14.49 51  CYS B SG    1
+ATOM   1749 N N     . LEU B 4 52  . 28.930  14.856 2.486   1.00 12.48 52  LEU B N     1
+ATOM   1750 C CA    . LEU B 4 52  . 29.627  15.218 1.261   1.00 16.72 52  LEU B CA    1
+ATOM   1751 C C     . LEU B 4 52  . 28.716  14.860 0.092   1.00 13.08 52  LEU B C     1
+ATOM   1752 C CB    . LEU B 4 52  . 31.009  14.481 1.134   1.00 15.77 52  LEU B CB    1
+ATOM   1753 O O     . LEU B 4 52  . 28.090  13.800 -0.054  1.00 13.87 52  LEU B O     1
+ATOM   1754 C CG    . LEU B 4 52  . 31.928  14.817 -0.064  1.00 20.03 52  LEU B CG    1
+ATOM   1755 C CD1   . LEU B 4 52  . 33.371  15.005 0.353   1.00 17.85 52  LEU B CD1   1
+ATOM   1756 C CD2   . LEU B 4 52  . 31.876  13.652 -1.042  1.00 17.90 52  LEU B CD2   1
+ATOM   1757 N N     . LEU B 4 53  . 28.645  15.883 -0.735  1.00 12.42 53  LEU B N     1
+ATOM   1758 C CA    . LEU B 4 53  . 27.868  15.861 -1.954  1.00 9.77  53  LEU B CA    1
+ATOM   1759 C C     . LEU B 4 53  . 28.824  15.520 -3.086  1.00 9.97  53  LEU B C     1
+ATOM   1760 C CB    . LEU B 4 53  . 27.269  17.230 -2.112  1.00 10.85 53  LEU B CB    1
+ATOM   1761 O O     . LEU B 4 53  . 29.827  16.195 -3.304  1.00 7.99  53  LEU B O     1
+ATOM   1762 C CG    . LEU B 4 53  . 25.807  17.514 -1.776  1.00 13.67 53  LEU B CG    1
+ATOM   1763 C CD1   . LEU B 4 53  . 25.305  16.906 -0.476  1.00 14.55 53  LEU B CD1   1
+ATOM   1764 C CD2   . LEU B 4 53  . 25.728  19.032 -1.876  1.00 13.42 53  LEU B CD2   1
+ATOM   1765 N N     . ASP B 4 54  . 28.506  14.444 -3.771  1.00 11.68 54  ASP B N     1
+ATOM   1766 C CA    . ASP B 4 54  . 29.325  13.962 -4.850  1.00 14.27 54  ASP B CA    1
+ATOM   1767 C C     . ASP B 4 54  . 28.483  14.070 -6.107  1.00 11.16 54  ASP B C     1
+ATOM   1768 C CB    . ASP B 4 54  . 29.695  12.533 -4.510  1.00 17.91 54  ASP B CB    1
+ATOM   1769 O O     . ASP B 4 54  . 27.737  13.152 -6.414  1.00 16.62 54  ASP B O     1
+ATOM   1770 C CG    . ASP B 4 54  . 30.552  11.880 -5.571  1.00 22.60 54  ASP B CG    1
+ATOM   1771 O OD1   . ASP B 4 54  . 31.078  12.564 -6.438  1.00 26.09 54  ASP B OD1   1
+ATOM   1772 O OD2   . ASP B 4 54  . 30.695  10.667 -5.529  1.00 27.61 54  ASP B OD2   1
+ATOM   1773 N N     . ILE B 4 55  . 28.564  15.164 -6.859  1.00 10.59 55  ILE B N     1
+ATOM   1774 C CA    . ILE B 4 55  . 27.674  15.439 -7.985  1.00 8.47  55  ILE B CA    1
+ATOM   1775 C C     . ILE B 4 55  . 28.280  15.056 -9.314  1.00 11.81 55  ILE B C     1
+ATOM   1776 C CB    . ILE B 4 55  . 27.328  16.928 -8.072  1.00 9.56  55  ILE B CB    1
+ATOM   1777 O O     . ILE B 4 55  . 29.386  15.474 -9.623  1.00 12.50 55  ILE B O     1
+ATOM   1778 C CG1   . ILE B 4 55  . 26.819  17.406 -6.743  1.00 9.53  55  ILE B CG1   1
+ATOM   1779 C CG2   . ILE B 4 55  . 26.272  17.156 -9.179  1.00 9.71  55  ILE B CG2   1
+ATOM   1780 C CD1   . ILE B 4 55  . 26.608  18.934 -6.748  1.00 13.99 55  ILE B CD1   1
+ATOM   1781 N N     . LEU B 4 56  . 27.521  14.337 -10.149 1.00 14.24 56  LEU B N     1
+ATOM   1782 C CA    . LEU B 4 56  . 27.989  13.972 -11.478 1.00 14.72 56  LEU B CA    1
+ATOM   1783 C C     . LEU B 4 56  . 27.177  14.796 -12.459 1.00 12.67 56  LEU B C     1
+ATOM   1784 C CB    . LEU B 4 56  . 27.775  12.450 -11.701 1.00 18.10 56  LEU B CB    1
+ATOM   1785 O O     . LEU B 4 56  . 25.962  14.665 -12.540 1.00 14.14 56  LEU B O     1
+ATOM   1786 C CG    . LEU B 4 56  . 28.613  11.595 -12.701 1.00 19.81 56  LEU B CG    1
+ATOM   1787 C CD1   . LEU B 4 56  . 28.233  11.895 -14.120 1.00 19.35 56  LEU B CD1   1
+ATOM   1788 C CD2   . LEU B 4 56  . 30.076  11.899 -12.555 1.00 15.55 56  LEU B CD2   1
+ATOM   1789 N N     . ASP B 4 57  . 27.859  15.715 -13.140 1.00 13.40 57  ASP B N     1
+ATOM   1790 C CA    . ASP B 4 57  . 27.306  16.575 -14.172 1.00 12.96 57  ASP B CA    1
+ATOM   1791 C C     . ASP B 4 57  . 27.457  15.909 -15.534 1.00 12.78 57  ASP B C     1
+ATOM   1792 C CB    . ASP B 4 57  . 28.056  17.838 -14.159 1.00 12.74 57  ASP B CB    1
+ATOM   1793 O O     . ASP B 4 57  . 28.573  15.731 -16.027 1.00 14.40 57  ASP B O     1
+ATOM   1794 C CG    . ASP B 4 57  . 27.482  18.926 -15.013 1.00 13.49 57  ASP B CG    1
+ATOM   1795 O OD1   . ASP B 4 57  . 26.308  18.878 -15.395 1.00 13.16 57  ASP B OD1   1
+ATOM   1796 O OD2   . ASP B 4 57  . 28.251  19.840 -15.282 1.00 14.48 57  ASP B OD2   1
+ATOM   1797 N N     . THR B 4 58  . 26.341  15.578 -16.184 1.00 11.86 58  THR B N     1
+ATOM   1798 C CA    . THR B 4 58  . 26.379  14.748 -17.372 1.00 11.91 58  THR B CA    1
+ATOM   1799 C C     . THR B 4 58  . 26.207  15.482 -18.696 1.00 15.63 58  THR B C     1
+ATOM   1800 C CB    . THR B 4 58  . 25.305  13.655 -17.179 1.00 7.25  58  THR B CB    1
+ATOM   1801 O O     . THR B 4 58  . 25.883  16.667 -18.724 1.00 17.13 58  THR B O     1
+ATOM   1802 C CG2   . THR B 4 58  . 25.455  12.974 -15.811 1.00 7.19  58  THR B CG2   1
+ATOM   1803 O OG1   . THR B 4 58  . 24.022  14.256 -17.277 1.00 8.81  58  THR B OG1   1
+ATOM   1804 N N     . ALA B 4 59  . 26.520  14.817 -19.817 1.00 17.06 59  ALA B N     1
+ATOM   1805 C CA    . ALA B 4 59  . 26.274  15.356 -21.142 1.00 18.63 59  ALA B CA    1
+ATOM   1806 C C     . ALA B 4 59  . 24.772  15.263 -21.502 1.00 21.26 59  ALA B C     1
+ATOM   1807 C CB    . ALA B 4 59  . 27.087  14.558 -22.163 1.00 20.47 59  ALA B CB    1
+ATOM   1808 O O     . ALA B 4 59  . 24.081  14.283 -21.181 1.00 17.89 59  ALA B O     1
+ATOM   1809 N N     . GLY B 4 60  . 24.217  16.269 -22.194 1.00 27.85 60  GLY B N     1
+ATOM   1810 C CA    . GLY B 4 60  . 22.805  16.281 -22.603 1.00 34.76 60  GLY B CA    1
+ATOM   1811 C C     . GLY B 4 60  . 22.428  15.384 -23.779 1.00 40.18 60  GLY B C     1
+ATOM   1812 O O     . GLY B 4 60  . 21.564  14.510 -23.631 1.00 43.73 60  GLY B O     1
+ATOM   1813 N N     . LEU B 4 61  . 23.118  15.586 -24.917 1.00 43.53 61  LEU B N     1
+ATOM   1814 C CA    . LEU B 4 61  . 22.898  14.903 -26.204 1.00 48.01 61  LEU B CA    1
+ATOM   1815 C C     . LEU B 4 61  . 23.642  13.571 -26.421 1.00 48.19 61  LEU B C     1
+ATOM   1816 C CB    . LEU B 4 61  . 23.270  15.933 -27.313 1.00 50.49 61  LEU B CB    1
+ATOM   1817 O O     . LEU B 4 61  . 23.054  12.490 -26.450 1.00 45.51 61  LEU B O     1
+ATOM   1818 C CG    . LEU B 4 61  . 23.258  15.681 -28.835 1.00 50.47 61  LEU B CG    1
+ATOM   1819 C CD1   . LEU B 4 61  . 21.970  16.253 -29.423 1.00 51.00 61  LEU B CD1   1
+ATOM   1820 C CD2   . LEU B 4 61  . 24.448  16.384 -29.503 1.00 47.03 61  LEU B CD2   1
+ATOM   1821 N N     . GLU B 4 62  . 24.968  13.704 -26.581 1.00 51.26 62  GLU B N     1
+ATOM   1822 C CA    . GLU B 4 62  . 25.955  12.646 -26.852 1.00 54.13 62  GLU B CA    1
+ATOM   1823 C C     . GLU B 4 62  . 25.610  11.284 -27.546 1.00 56.12 62  GLU B C     1
+ATOM   1824 C CB    . GLU B 4 62  . 26.723  12.350 -25.469 1.00 51.97 62  GLU B CB    1
+ATOM   1825 O O     . GLU B 4 62  . 24.525  10.941 -28.064 1.00 51.72 62  GLU B O     1
+ATOM   1826 C CG    . GLU B 4 62  . 28.291  12.521 -25.460 1.00 46.75 62  GLU B CG    1
+ATOM   1827 C CD    . GLU B 4 62  . 29.235  11.453 -24.865 1.00 43.32 62  GLU B CD    1
+ATOM   1828 O OE1   . GLU B 4 62  . 28.832  10.322 -24.598 1.00 39.12 62  GLU B OE1   1
+ATOM   1829 O OE2   . GLU B 4 62  . 30.420  11.757 -24.698 1.00 40.41 62  GLU B OE2   1
+ATOM   1830 N N     . GLU B 4 63  . 26.775  10.604 -27.605 1.00 57.28 63  GLU B N     1
+ATOM   1831 C CA    . GLU B 4 63  . 26.936  9.195  -27.872 1.00 56.86 63  GLU B CA    1
+ATOM   1832 C C     . GLU B 4 63  . 26.730  8.569  -26.473 1.00 55.14 63  GLU B C     1
+ATOM   1833 C CB    . GLU B 4 63  . 28.376  8.937  -28.406 1.00 57.11 63  GLU B CB    1
+ATOM   1834 O O     . GLU B 4 63  . 27.184  7.441  -26.245 1.00 56.67 63  GLU B O     1
+ATOM   1835 C CG    . GLU B 4 63  . 28.610  7.619  -29.198 1.00 56.40 63  GLU B CG    1
+ATOM   1836 C CD    . GLU B 4 63  . 30.057  7.138  -29.348 1.00 55.00 63  GLU B CD    1
+ATOM   1837 O OE1   . GLU B 4 63  . 30.895  7.887  -29.859 1.00 54.92 63  GLU B OE1   1
+ATOM   1838 O OE2   . GLU B 4 63  . 30.342  5.999  -28.958 1.00 53.70 63  GLU B OE2   1
+ATOM   1839 N N     . TYR B 4 64  . 26.055  9.246  -25.506 1.00 52.50 64  TYR B N     1
+ATOM   1840 C CA    . TYR B 4 64  . 25.788  8.690  -24.183 1.00 50.78 64  TYR B CA    1
+ATOM   1841 C C     . TYR B 4 64  . 24.519  7.863  -24.279 1.00 49.98 64  TYR B C     1
+ATOM   1842 C CB    . TYR B 4 64  . 25.583  9.785  -23.110 1.00 51.61 64  TYR B CB    1
+ATOM   1843 O O     . TYR B 4 64  . 23.435  8.367  -24.600 1.00 47.14 64  TYR B O     1
+ATOM   1844 C CG    . TYR B 4 64  . 26.733  9.897  -22.119 1.00 52.79 64  TYR B CG    1
+ATOM   1845 C CD1   . TYR B 4 64  . 27.680  8.895  -22.062 1.00 53.84 64  TYR B CD1   1
+ATOM   1846 C CD2   . TYR B 4 64  . 26.886  11.026 -21.331 1.00 54.06 64  TYR B CD2   1
+ATOM   1847 C CE1   . TYR B 4 64  . 28.789  9.000  -21.253 1.00 55.75 64  TYR B CE1   1
+ATOM   1848 C CE2   . TYR B 4 64  . 28.003  11.143 -20.506 1.00 57.04 64  TYR B CE2   1
+ATOM   1849 O OH    . TYR B 4 64  . 30.132  10.239 -19.738 1.00 56.79 64  TYR B OH    1
+ATOM   1850 C CZ    . TYR B 4 64  . 28.960  10.127 -20.478 1.00 57.57 64  TYR B CZ    1
+ATOM   1851 N N     . SER B 4 65  . 24.687  6.574  -23.979 1.00 47.94 65  SER B N     1
+ATOM   1852 C CA    . SER B 4 65  . 23.599  5.638  -24.132 1.00 50.39 65  SER B CA    1
+ATOM   1853 C C     . SER B 4 65  . 23.575  4.729  -22.905 1.00 49.65 65  SER B C     1
+ATOM   1854 C CB    . SER B 4 65  . 23.877  4.921  -25.467 1.00 50.97 65  SER B CB    1
+ATOM   1855 O O     . SER B 4 65  . 23.234  5.165  -21.814 1.00 46.17 65  SER B O     1
+ATOM   1856 O OG    . SER B 4 65  . 25.147  4.267  -25.481 1.00 53.47 65  SER B OG    1
+ATOM   1857 N N     . ALA B 4 66  . 23.870  3.435  -23.017 1.00 52.05 66  ALA B N     1
+ATOM   1858 C CA    . ALA B 4 66  . 24.144  2.634  -21.843 1.00 50.41 66  ALA B CA    1
+ATOM   1859 C C     . ALA B 4 66  . 25.501  3.103  -21.238 1.00 48.94 66  ALA B C     1
+ATOM   1860 C CB    . ALA B 4 66  . 24.190  1.164  -22.267 1.00 52.68 66  ALA B CB    1
+ATOM   1861 O O     . ALA B 4 66  . 26.041  2.539  -20.280 1.00 49.74 66  ALA B O     1
+ATOM   1862 N N     . MET B 4 67  . 26.140  4.127  -21.830 1.00 43.56 67  MET B N     1
+ATOM   1863 C CA    . MET B 4 67  . 27.232  4.819  -21.175 1.00 39.49 67  MET B CA    1
+ATOM   1864 C C     . MET B 4 67  . 26.561  5.741  -20.113 1.00 36.36 67  MET B C     1
+ATOM   1865 C CB    . MET B 4 67  . 27.996  5.572  -22.276 1.00 44.51 67  MET B CB    1
+ATOM   1866 O O     . MET B 4 67  . 27.190  6.241  -19.159 1.00 33.14 67  MET B O     1
+ATOM   1867 C CG    . MET B 4 67  . 29.536  5.562  -22.176 1.00 48.48 67  MET B CG    1
+ATOM   1868 S SD    . MET B 4 67  . 30.450  6.735  -23.235 1.00 53.91 67  MET B SD    1
+ATOM   1869 C CE    . MET B 4 67  . 30.274  6.036  -24.857 1.00 50.97 67  MET B CE    1
+ATOM   1870 N N     . ARG B 4 68  . 25.237  5.982  -20.278 1.00 32.16 68  ARG B N     1
+ATOM   1871 C CA    . ARG B 4 68  . 24.417  6.624  -19.264 1.00 28.74 68  ARG B CA    1
+ATOM   1872 C C     . ARG B 4 68  . 23.997  5.529  -18.314 1.00 24.40 68  ARG B C     1
+ATOM   1873 C CB    . ARG B 4 68  . 23.114  7.234  -19.766 1.00 32.54 68  ARG B CB    1
+ATOM   1874 O O     . ARG B 4 68  . 23.879  5.795  -17.134 1.00 25.66 68  ARG B O     1
+ATOM   1875 C CG    . ARG B 4 68  . 23.241  8.223  -20.906 1.00 39.06 68  ARG B CG    1
+ATOM   1876 C CD    . ARG B 4 68  . 21.880  8.719  -21.400 1.00 41.85 68  ARG B CD    1
+ATOM   1877 N NE    . ARG B 4 68  . 22.008  9.533  -22.606 1.00 45.58 68  ARG B NE    1
+ATOM   1878 N NH1   . ARG B 4 68  . 22.392  11.606 -21.496 1.00 49.30 68  ARG B NH1   1
+ATOM   1879 N NH2   . ARG B 4 68  . 22.300  11.455 -23.811 1.00 50.26 68  ARG B NH2   1
+ATOM   1880 C CZ    . ARG B 4 68  . 22.227  10.862 -22.617 1.00 48.76 68  ARG B CZ    1
+ATOM   1881 N N     . ASP B 4 69  . 23.710  4.300  -18.741 1.00 25.77 69  ASP B N     1
+ATOM   1882 C CA    . ASP B 4 69  . 23.336  3.217  -17.837 1.00 22.56 69  ASP B CA    1
+ATOM   1883 C C     . ASP B 4 69  . 24.239  3.113  -16.637 1.00 20.79 69  ASP B C     1
+ATOM   1884 C CB    . ASP B 4 69  . 23.374  1.885  -18.559 1.00 21.73 69  ASP B CB    1
+ATOM   1885 O O     . ASP B 4 69  . 23.775  2.984  -15.521 1.00 21.01 69  ASP B O     1
+ATOM   1886 C CG    . ASP B 4 69  . 22.095  1.514  -19.283 1.00 22.44 69  ASP B CG    1
+ATOM   1887 O OD1   . ASP B 4 69  . 21.381  2.376  -19.809 1.00 26.68 69  ASP B OD1   1
+ATOM   1888 O OD2   . ASP B 4 69  . 21.808  0.322  -19.309 1.00 22.03 69  ASP B OD2   1
+ATOM   1889 N N     . GLN B 4 70  . 25.539  3.206  -16.879 1.00 22.60 70  GLN B N     1
+ATOM   1890 C CA    . GLN B 4 70  . 26.544  3.167  -15.845 1.00 27.15 70  GLN B CA    1
+ATOM   1891 C C     . GLN B 4 70  . 26.320  4.262  -14.801 1.00 27.63 70  GLN B C     1
+ATOM   1892 C CB    . GLN B 4 70  . 27.949  3.294  -16.485 1.00 27.58 70  GLN B CB    1
+ATOM   1893 O O     . GLN B 4 70  . 26.056  3.854  -13.664 1.00 31.79 70  GLN B O     1
+ATOM   1894 C CG    . GLN B 4 70  . 29.096  3.135  -15.477 1.00 31.03 70  GLN B CG    1
+ATOM   1895 C CD    . GLN B 4 70  . 30.518  3.054  -16.065 1.00 32.23 70  GLN B CD    1
+ATOM   1896 N NE2   . GLN B 4 70  . 31.208  1.919  -15.847 1.00 29.95 70  GLN B NE2   1
+ATOM   1897 O OE1   . GLN B 4 70  . 31.016  3.989  -16.708 1.00 31.84 70  GLN B OE1   1
+ATOM   1898 N N     . TYR B 4 71  . 26.351  5.592  -15.045 1.00 24.70 71  TYR B N     1
+ATOM   1899 C CA    . TYR B 4 71  . 26.111  6.538  -13.958 1.00 20.66 71  TYR B CA    1
+ATOM   1900 C C     . TYR B 4 71  . 24.708  6.519  -13.363 1.00 19.60 71  TYR B C     1
+ATOM   1901 C CB    . TYR B 4 71  . 26.463  7.960  -14.426 1.00 21.11 71  TYR B CB    1
+ATOM   1902 O O     . TYR B 4 71  . 24.522  6.915  -12.215 1.00 20.98 71  TYR B O     1
+ATOM   1903 C CG    . TYR B 4 71  . 25.666  8.636  -15.535 1.00 22.22 71  TYR B CG    1
+ATOM   1904 C CD1   . TYR B 4 71  . 24.349  8.990  -15.314 1.00 22.79 71  TYR B CD1   1
+ATOM   1905 C CD2   . TYR B 4 71  . 26.254  8.915  -16.755 1.00 22.98 71  TYR B CD2   1
+ATOM   1906 C CE1   . TYR B 4 71  . 23.606  9.608  -16.297 1.00 23.68 71  TYR B CE1   1
+ATOM   1907 C CE2   . TYR B 4 71  . 25.518  9.543  -17.747 1.00 25.34 71  TYR B CE2   1
+ATOM   1908 O OH    . TYR B 4 71  . 23.405  10.479 -18.504 1.00 27.19 71  TYR B OH    1
+ATOM   1909 C CZ    . TYR B 4 71  . 24.188  9.884  -17.516 1.00 26.28 71  TYR B CZ    1
+ATOM   1910 N N     . MET B 4 72  . 23.694  6.043  -14.077 1.00 16.15 72  MET B N     1
+ATOM   1911 C CA    . MET B 4 72  . 22.350  5.970  -13.547 1.00 17.98 72  MET B CA    1
+ATOM   1912 C C     . MET B 4 72  . 22.249  4.846  -12.541 1.00 19.84 72  MET B C     1
+ATOM   1913 C CB    . MET B 4 72  . 21.334  5.710  -14.619 1.00 14.17 72  MET B CB    1
+ATOM   1914 O O     . MET B 4 72  . 21.455  4.982  -11.614 1.00 19.37 72  MET B O     1
+ATOM   1915 C CG    . MET B 4 72  . 21.214  6.875  -15.553 1.00 15.59 72  MET B CG    1
+ATOM   1916 S SD    . MET B 4 72  . 20.006  6.535  -16.849 1.00 18.05 72  MET B SD    1
+ATOM   1917 C CE    . MET B 4 72  . 20.212  8.078  -17.691 1.00 16.01 72  MET B CE    1
+ATOM   1918 N N     . ARG B 4 73  . 23.000  3.734  -12.641 1.00 21.73 73  ARG B N     1
+ATOM   1919 C CA    . ARG B 4 73  . 22.881  2.736  -11.580 1.00 23.95 73  ARG B CA    1
+ATOM   1920 C C     . ARG B 4 73  . 23.602  3.075  -10.303 1.00 22.33 73  ARG B C     1
+ATOM   1921 C CB    . ARG B 4 73  . 23.364  1.357  -11.976 1.00 24.45 73  ARG B CB    1
+ATOM   1922 O O     . ARG B 4 73  . 23.129  2.619  -9.256  1.00 26.26 73  ARG B O     1
+ATOM   1923 C CG    . ARG B 4 73  . 24.656  1.163  -12.701 1.00 24.24 73  ARG B CG    1
+ATOM   1924 C CD    . ARG B 4 73  . 24.725  -0.334 -12.933 1.00 30.28 73  ARG B CD    1
+ATOM   1925 N NE    . ARG B 4 73  . 23.428  -0.942 -13.230 1.00 30.91 73  ARG B NE    1
+ATOM   1926 N NH1   . ARG B 4 73  . 23.986  -1.453 -15.436 1.00 31.56 73  ARG B NH1   1
+ATOM   1927 N NH2   . ARG B 4 73  . 21.852  -1.858 -14.581 1.00 32.38 73  ARG B NH2   1
+ATOM   1928 C CZ    . ARG B 4 73  . 23.098  -1.404 -14.432 1.00 31.48 73  ARG B CZ    1
+ATOM   1929 N N     . THR B 4 74  . 24.660  3.901  -10.336 1.00 21.70 74  THR B N     1
+ATOM   1930 C CA    . THR B 4 74  . 25.317  4.305  -9.090  1.00 20.85 74  THR B CA    1
+ATOM   1931 C C     . THR B 4 74  . 24.797  5.552  -8.389  1.00 19.39 74  THR B C     1
+ATOM   1932 C CB    . THR B 4 74  . 26.821  4.471  -9.314  1.00 17.30 74  THR B CB    1
+ATOM   1933 O O     . THR B 4 74  . 25.114  5.763  -7.222  1.00 18.35 74  THR B O     1
+ATOM   1934 C CG2   . THR B 4 74  . 27.417  3.112  -9.621  1.00 21.31 74  THR B CG2   1
+ATOM   1935 O OG1   . THR B 4 74  . 27.072  5.382  -10.370 1.00 22.34 74  THR B OG1   1
+ATOM   1936 N N     . GLY B 4 75  . 23.974  6.343  -9.086  1.00 16.48 75  GLY B N     1
+ATOM   1937 C CA    . GLY B 4 75  . 23.371  7.540  -8.559  1.00 11.86 75  GLY B CA    1
+ATOM   1938 C C     . GLY B 4 75  . 22.287  7.166  -7.596  1.00 11.55 75  GLY B C     1
+ATOM   1939 O O     . GLY B 4 75  . 21.492  6.263  -7.818  1.00 11.88 75  GLY B O     1
+ATOM   1940 N N     . GLU B 4 76  . 22.302  7.847  -6.465  1.00 13.72 76  GLU B N     1
+ATOM   1941 C CA    . GLU B 4 76  . 21.300  7.661  -5.425  1.00 14.17 76  GLU B CA    1
+ATOM   1942 C C     . GLU B 4 76  . 20.049  8.486  -5.612  1.00 11.10 76  GLU B C     1
+ATOM   1943 C CB    . GLU B 4 76  . 21.910  8.018  -4.102  1.00 18.29 76  GLU B CB    1
+ATOM   1944 O O     . GLU B 4 76  . 18.982  8.092  -5.191  1.00 14.62 76  GLU B O     1
+ATOM   1945 C CG    . GLU B 4 76  . 22.861  6.951  -3.654  1.00 17.27 76  GLU B CG    1
+ATOM   1946 C CD    . GLU B 4 76  . 23.464  7.264  -2.302  1.00 19.90 76  GLU B CD    1
+ATOM   1947 O OE1   . GLU B 4 76  . 22.885  6.917  -1.279  1.00 24.68 76  GLU B OE1   1
+ATOM   1948 O OE2   . GLU B 4 76  . 24.523  7.863  -2.279  1.00 22.10 76  GLU B OE2   1
+ATOM   1949 N N     . GLY B 4 77  . 20.198  9.646  -6.223  1.00 12.03 77  GLY B N     1
+ATOM   1950 C CA    . GLY B 4 77  . 19.118  10.562 -6.519  1.00 9.01  77  GLY B CA    1
+ATOM   1951 C C     . GLY B 4 77  . 19.488  11.391 -7.728  1.00 7.34  77  GLY B C     1
+ATOM   1952 O O     . GLY B 4 77  . 20.667  11.592 -8.017  1.00 6.72  77  GLY B O     1
+ATOM   1953 N N     . PHE B 4 78  . 18.443  11.841 -8.431  1.00 8.71  78  PHE B N     1
+ATOM   1954 C CA    . PHE B 4 78  . 18.524  12.548 -9.699  1.00 11.73 78  PHE B CA    1
+ATOM   1955 C C     . PHE B 4 78  . 17.768  13.876 -9.785  1.00 11.17 78  PHE B C     1
+ATOM   1956 C CB    . PHE B 4 78  . 18.019  11.611 -10.865 1.00 9.22  78  PHE B CB    1
+ATOM   1957 O O     . PHE B 4 78  . 16.613  14.015 -9.366  1.00 9.11  78  PHE B O     1
+ATOM   1958 C CG    . PHE B 4 78  . 18.712  10.250 -10.922 1.00 11.02 78  PHE B CG    1
+ATOM   1959 C CD1   . PHE B 4 78  . 18.293  9.204  -10.108 1.00 9.86  78  PHE B CD1   1
+ATOM   1960 C CD2   . PHE B 4 78  . 19.798  10.051 -11.748 1.00 12.53 78  PHE B CD2   1
+ATOM   1961 C CE1   . PHE B 4 78  . 18.946  7.992  -10.101 1.00 6.80  78  PHE B CE1   1
+ATOM   1962 C CE2   . PHE B 4 78  . 20.455  8.828  -11.740 1.00 10.80 78  PHE B CE2   1
+ATOM   1963 C CZ    . PHE B 4 78  . 20.039  7.806  -10.920 1.00 9.77  78  PHE B CZ    1
+ATOM   1964 N N     . LEU B 4 79  . 18.481  14.890 -10.308 1.00 8.94  79  LEU B N     1
+ATOM   1965 C CA    . LEU B 4 79  . 17.850  16.138 -10.653 1.00 8.28  79  LEU B CA    1
+ATOM   1966 C C     . LEU B 4 79  . 17.509  16.015 -12.142 1.00 8.21  79  LEU B C     1
+ATOM   1967 C CB    . LEU B 4 79  . 18.778  17.336 -10.496 1.00 9.92  79  LEU B CB    1
+ATOM   1968 O O     . LEU B 4 79  . 18.404  15.759 -12.943 1.00 9.42  79  LEU B O     1
+ATOM   1969 C CG    . LEU B 4 79  . 19.102  18.006 -9.202  1.00 13.43 79  LEU B CG    1
+ATOM   1970 C CD1   . LEU B 4 79  . 19.784  19.321 -9.501  1.00 11.70 79  LEU B CD1   1
+ATOM   1971 C CD2   . LEU B 4 79  . 17.843  18.303 -8.451  1.00 11.71 79  LEU B CD2   1
+ATOM   1972 N N     . CYS B 4 80  . 16.251  16.146 -12.553 1.00 7.39  80  CYS B N     1
+ATOM   1973 C CA    . CYS B 4 80  . 15.865  16.016 -13.954 1.00 10.19 80  CYS B CA    1
+ATOM   1974 C C     . CYS B 4 80  . 15.440  17.401 -14.381 1.00 8.47  80  CYS B C     1
+ATOM   1975 C CB    . CYS B 4 80  . 14.688  15.043 -14.172 1.00 10.94 80  CYS B CB    1
+ATOM   1976 O O     . CYS B 4 80  . 14.358  17.892 -14.062 1.00 7.27  80  CYS B O     1
+ATOM   1977 S SG    . CYS B 4 80  . 15.005  13.302 -13.764 1.00 16.52 80  CYS B SG    1
+ATOM   1978 N N     . VAL B 4 81  . 16.373  18.005 -15.128 1.00 8.02  81  VAL B N     1
+ATOM   1979 C CA    . VAL B 4 81  . 16.280  19.399 -15.554 1.00 9.14  81  VAL B CA    1
+ATOM   1980 C C     . VAL B 4 81  . 15.773  19.619 -16.995 1.00 10.69 81  VAL B C     1
+ATOM   1981 C CB    . VAL B 4 81  . 17.692  20.084 -15.395 1.00 7.96  81  VAL B CB    1
+ATOM   1982 O O     . VAL B 4 81  . 16.130  18.893 -17.930 1.00 10.74 81  VAL B O     1
+ATOM   1983 C CG1   . VAL B 4 81  . 17.508  21.589 -15.585 1.00 3.47  81  VAL B CG1   1
+ATOM   1984 C CG2   . VAL B 4 81  . 18.335  19.761 -14.031 1.00 3.04  81  VAL B CG2   1
+ATOM   1985 N N     . PHE B 4 82  . 14.937  20.652 -17.158 1.00 8.32  82  PHE B N     1
+ATOM   1986 C CA    . PHE B 4 82  . 14.511  21.121 -18.467 1.00 8.45  82  PHE B CA    1
+ATOM   1987 C C     . PHE B 4 82  . 14.502  22.620 -18.298 1.00 4.38  82  PHE B C     1
+ATOM   1988 C CB    . PHE B 4 82  . 13.094  20.621 -18.865 1.00 4.90  82  PHE B CB    1
+ATOM   1989 O O     . PHE B 4 82  . 14.684  23.170 -17.197 1.00 10.21 82  PHE B O     1
+ATOM   1990 C CG    . PHE B 4 82  . 11.944  21.067 -18.000 1.00 3.93  82  PHE B CG    1
+ATOM   1991 C CD1   . PHE B 4 82  . 11.297  22.239 -18.298 1.00 4.56  82  PHE B CD1   1
+ATOM   1992 C CD2   . PHE B 4 82  . 11.551  20.303 -16.903 1.00 5.37  82  PHE B CD2   1
+ATOM   1993 C CE1   . PHE B 4 82  . 10.262  22.642 -17.483 1.00 6.51  82  PHE B CE1   1
+ATOM   1994 C CE2   . PHE B 4 82  . 10.510  20.721 -16.099 1.00 2.58  82  PHE B CE2   1
+ATOM   1995 C CZ    . PHE B 4 82  . 9.861   21.891 -16.387 1.00 5.78  82  PHE B CZ    1
+ATOM   1996 N N     . ALA B 4 83  . 14.302  23.323 -19.388 1.00 5.05  83  ALA B N     1
+ATOM   1997 C CA    . ALA B 4 83  . 14.290  24.780 -19.376 1.00 6.63  83  ALA B CA    1
+ATOM   1998 C C     . ALA B 4 83  . 12.899  25.208 -19.721 1.00 5.92  83  ALA B C     1
+ATOM   1999 C CB    . ALA B 4 83  . 15.225  25.288 -20.398 1.00 5.77  83  ALA B CB    1
+ATOM   2000 O O     . ALA B 4 83  . 12.262  24.563 -20.560 1.00 6.93  83  ALA B O     1
+ATOM   2001 N N     . ILE B 4 84  . 12.419  26.266 -19.058 1.00 9.03  84  ILE B N     1
+ATOM   2002 C CA    . ILE B 4 84  . 11.023  26.668 -19.190 1.00 11.81 84  ILE B CA    1
+ATOM   2003 C C     . ILE B 4 84  . 10.725  27.369 -20.493 1.00 14.85 84  ILE B C     1
+ATOM   2004 C CB    . ILE B 4 84  . 10.533  27.620 -17.993 1.00 12.75 84  ILE B CB    1
+ATOM   2005 O O     . ILE B 4 84  . 9.558   27.621 -20.780 1.00 11.68 84  ILE B O     1
+ATOM   2006 C CG1   . ILE B 4 84  . 11.357  28.897 -17.829 1.00 9.92  84  ILE B CG1   1
+ATOM   2007 C CG2   . ILE B 4 84  . 10.558  26.788 -16.703 1.00 13.31 84  ILE B CG2   1
+ATOM   2008 C CD1   . ILE B 4 84  . 11.078  30.084 -18.768 1.00 14.14 84  ILE B CD1   1
+ATOM   2009 N N     . ASN B 4 85  . 11.766  27.752 -21.252 1.00 15.97 85  ASN B N     1
+ATOM   2010 C CA    . ASN B 4 85  . 11.579  28.387 -22.553 1.00 16.19 85  ASN B CA    1
+ATOM   2011 C C     . ASN B 4 85  . 11.876  27.421 -23.702 1.00 15.70 85  ASN B C     1
+ATOM   2012 C CB    . ASN B 4 85  . 12.497  29.608 -22.645 1.00 20.22 85  ASN B CB    1
+ATOM   2013 O O     . ASN B 4 85  . 11.998  27.832 -24.858 1.00 15.79 85  ASN B O     1
+ATOM   2014 C CG    . ASN B 4 85  . 13.978  29.275 -22.874 1.00 22.66 85  ASN B CG    1
+ATOM   2015 N ND2   . ASN B 4 85  . 14.573  29.895 -23.894 1.00 19.66 85  ASN B ND2   1
+ATOM   2016 O OD1   . ASN B 4 85  . 14.587  28.449 -22.183 1.00 21.30 85  ASN B OD1   1
+ATOM   2017 N N     . ASN B 4 86  . 11.996  26.122 -23.397 1.00 14.92 86  ASN B N     1
+ATOM   2018 C CA    . ASN B 4 86  . 12.251  25.075 -24.376 1.00 12.76 86  ASN B CA    1
+ATOM   2019 C C     . ASN B 4 86  . 11.277  23.888 -24.280 1.00 11.01 86  ASN B C     1
+ATOM   2020 C CB    . ASN B 4 86  . 13.669  24.679 -24.143 1.00 12.26 86  ASN B CB    1
+ATOM   2021 O O     . ASN B 4 86  . 11.563  22.921 -23.573 1.00 11.08 86  ASN B O     1
+ATOM   2022 C CG    . ASN B 4 86  . 14.256  23.753 -25.174 1.00 17.16 86  ASN B CG    1
+ATOM   2023 N ND2   . ASN B 4 86  . 13.518  23.150 -26.087 1.00 19.06 86  ASN B ND2   1
+ATOM   2024 O OD1   . ASN B 4 86  . 15.461  23.532 -25.148 1.00 24.53 86  ASN B OD1   1
+ATOM   2025 N N     . THR B 4 87  . 10.118  23.867 -24.959 1.00 8.93  87  THR B N     1
+ATOM   2026 C CA    . THR B 4 87  . 9.129   22.780 -24.854 1.00 12.31 87  THR B CA    1
+ATOM   2027 C C     . THR B 4 87  . 9.688   21.393 -25.139 1.00 14.99 87  THR B C     1
+ATOM   2028 C CB    . THR B 4 87  . 7.939   23.053 -25.809 1.00 10.72 87  THR B CB    1
+ATOM   2029 O O     . THR B 4 87  . 9.427   20.455 -24.395 1.00 18.15 87  THR B O     1
+ATOM   2030 C CG2   . THR B 4 87  . 6.736   22.182 -25.557 1.00 12.92 87  THR B CG2   1
+ATOM   2031 O OG1   . THR B 4 87  . 7.459   24.341 -25.520 1.00 10.88 87  THR B OG1   1
+ATOM   2032 N N     . LYS B 4 88  . 10.503  21.208 -26.169 1.00 16.39 88  LYS B N     1
+ATOM   2033 C CA    . LYS B 4 88  . 11.153  19.940 -26.469 1.00 15.05 88  LYS B CA    1
+ATOM   2034 C C     . LYS B 4 88  . 11.937  19.371 -25.302 1.00 13.25 88  LYS B C     1
+ATOM   2035 C CB    . LYS B 4 88  . 12.049  20.198 -27.662 1.00 24.27 88  LYS B CB    1
+ATOM   2036 O O     . LYS B 4 88  . 11.940  18.163 -25.097 1.00 10.07 88  LYS B O     1
+ATOM   2037 C CG    . LYS B 4 88  . 12.942  19.138 -28.308 1.00 28.26 88  LYS B CG    1
+ATOM   2038 C CD    . LYS B 4 88  . 13.176  19.678 -29.749 1.00 35.40 88  LYS B CD    1
+ATOM   2039 C CE    . LYS B 4 88  . 14.572  19.561 -30.418 1.00 37.94 88  LYS B CE    1
+ATOM   2040 N NZ    . LYS B 4 88  . 15.495  20.649 -30.094 1.00 38.82 88  LYS B NZ    1
+ATOM   2041 N N     . SER B 4 89  . 12.633  20.209 -24.525 1.00 11.98 89  SER B N     1
+ATOM   2042 C CA    . SER B 4 89  . 13.422  19.720 -23.389 1.00 10.81 89  SER B CA    1
+ATOM   2043 C C     . SER B 4 89  . 12.524  19.094 -22.330 1.00 9.83  89  SER B C     1
+ATOM   2044 C CB    . SER B 4 89  . 14.240  20.848 -22.705 1.00 10.90 89  SER B CB    1
+ATOM   2045 O O     . SER B 4 89  . 12.978  18.187 -21.652 1.00 7.52  89  SER B O     1
+ATOM   2046 O OG    . SER B 4 89  . 13.488  21.937 -22.135 1.00 8.68  89  SER B OG    1
+ATOM   2047 N N     . PHE B 4 90  . 11.294  19.602 -22.183 1.00 11.15 90  PHE B N     1
+ATOM   2048 C CA    . PHE B 4 90  . 10.278  19.164 -21.235 1.00 11.53 90  PHE B CA    1
+ATOM   2049 C C     . PHE B 4 90  . 9.704   17.830 -21.650 1.00 14.97 90  PHE B C     1
+ATOM   2050 C CB    . PHE B 4 90  . 9.156   20.243 -21.143 1.00 11.64 90  PHE B CB    1
+ATOM   2051 O O     . PHE B 4 90  . 9.486   16.945 -20.800 1.00 17.06 90  PHE B O     1
+ATOM   2052 C CG    . PHE B 4 90  . 7.947   19.891 -20.266 1.00 14.40 90  PHE B CG    1
+ATOM   2053 C CD1   . PHE B 4 90  . 8.106   19.543 -18.934 1.00 15.62 90  PHE B CD1   1
+ATOM   2054 C CD2   . PHE B 4 90  . 6.676   19.884 -20.793 1.00 16.16 90  PHE B CD2   1
+ATOM   2055 C CE1   . PHE B 4 90  . 7.019   19.193 -18.152 1.00 18.83 90  PHE B CE1   1
+ATOM   2056 C CE2   . PHE B 4 90  . 5.587   19.531 -19.995 1.00 17.55 90  PHE B CE2   1
+ATOM   2057 C CZ    . PHE B 4 90  . 5.746   19.182 -18.671 1.00 15.90 90  PHE B CZ    1
+ATOM   2058 N N     . GLU B 4 91  . 9.501   17.629 -22.956 1.00 15.45 91  GLU B N     1
+ATOM   2059 C CA    . GLU B 4 91  . 8.994   16.346 -23.454 1.00 19.17 91  GLU B CA    1
+ATOM   2060 C C     . GLU B 4 91  . 10.048  15.263 -23.299 1.00 18.92 91  GLU B C     1
+ATOM   2061 C CB    . GLU B 4 91  . 8.603   16.443 -24.923 1.00 20.12 91  GLU B CB    1
+ATOM   2062 O O     . GLU B 4 91  . 9.731   14.107 -22.965 1.00 20.46 91  GLU B O     1
+ATOM   2063 C CG    . GLU B 4 91  . 7.501   17.483 -25.096 1.00 26.55 91  GLU B CG    1
+ATOM   2064 C CD    . GLU B 4 91  . 7.088   17.873 -26.513 1.00 29.19 91  GLU B CD    1
+ATOM   2065 O OE1   . GLU B 4 91  . 7.679   17.419 -27.499 1.00 31.44 91  GLU B OE1   1
+ATOM   2066 O OE2   . GLU B 4 91  . 6.146   18.659 -26.609 1.00 34.15 91  GLU B OE2   1
+ATOM   2067 N N     . ASP B 4 92  . 11.323  15.622 -23.545 1.00 17.92 92  ASP B N     1
+ATOM   2068 C CA    . ASP B 4 92  . 12.387  14.661 -23.302 1.00 16.73 92  ASP B CA    1
+ATOM   2069 C C     . ASP B 4 92  . 12.509  14.239 -21.842 1.00 15.45 92  ASP B C     1
+ATOM   2070 C CB    . ASP B 4 92  . 13.721  15.236 -23.747 1.00 19.30 92  ASP B CB    1
+ATOM   2071 O O     . ASP B 4 92  . 13.147  13.227 -21.577 1.00 10.57 92  ASP B O     1
+ATOM   2072 C CG    . ASP B 4 92  . 13.871  15.476 -25.247 1.00 19.92 92  ASP B CG    1
+ATOM   2073 O OD1   . ASP B 4 92  . 12.994  15.122 -26.036 1.00 18.28 92  ASP B OD1   1
+ATOM   2074 O OD2   . ASP B 4 92  . 14.888  16.048 -25.619 1.00 21.06 92  ASP B OD2   1
+ATOM   2075 N N     . ILE B 4 93  . 11.939  14.948 -20.853 1.00 15.69 93  ILE B N     1
+ATOM   2076 C CA    . ILE B 4 93  . 12.066  14.526 -19.461 1.00 16.80 93  ILE B CA    1
+ATOM   2077 C C     . ILE B 4 93  . 11.587  13.099 -19.324 1.00 17.42 93  ILE B C     1
+ATOM   2078 C CB    . ILE B 4 93  . 11.260  15.460 -18.465 1.00 11.84 93  ILE B CB    1
+ATOM   2079 O O     . ILE B 4 93  . 12.302  12.307 -18.708 1.00 14.18 93  ILE B O     1
+ATOM   2080 C CG1   . ILE B 4 93  . 12.129  16.677 -18.199 1.00 9.53  93  ILE B CG1   1
+ATOM   2081 C CG2   . ILE B 4 93  . 10.861  14.752 -17.172 1.00 8.81  93  ILE B CG2   1
+ATOM   2082 C CD1   . ILE B 4 93  . 13.537  16.349 -17.615 1.00 13.09 93  ILE B CD1   1
+ATOM   2083 N N     . HIS B 4 94  . 10.439  12.754 -19.919 1.00 18.61 94  HIS B N     1
+ATOM   2084 C CA    . HIS B 4 94  . 9.967   11.376 -19.824 1.00 21.55 94  HIS B CA    1
+ATOM   2085 C C     . HIS B 4 94  . 11.027  10.301 -20.131 1.00 18.71 94  HIS B C     1
+ATOM   2086 C CB    . HIS B 4 94  . 8.771   11.201 -20.753 1.00 23.57 94  HIS B CB    1
+ATOM   2087 O O     . HIS B 4 94  . 11.185  9.340  -19.386 1.00 17.88 94  HIS B O     1
+ATOM   2088 C CG    . HIS B 4 94  . 7.959   10.033 -20.208 1.00 26.77 94  HIS B CG    1
+ATOM   2089 C CD2   . HIS B 4 94  . 7.943   8.767  -20.710 1.00 26.64 94  HIS B CD2   1
+ATOM   2090 N ND1   . HIS B 4 94  . 7.304   10.145 -19.060 1.00 27.60 94  HIS B ND1   1
+ATOM   2091 C CE1   . HIS B 4 94  . 6.860   8.935  -18.803 1.00 28.74 94  HIS B CE1   1
+ATOM   2092 N NE2   . HIS B 4 94  . 7.245   8.135  -19.782 1.00 30.21 94  HIS B NE2   1
+ATOM   2093 N N     . GLN B 4 95  . 11.818  10.522 -21.196 1.00 19.99 95  GLN B N     1
+ATOM   2094 C CA    . GLN B 4 95  . 12.919  9.674  -21.648 1.00 19.06 95  GLN B CA    1
+ATOM   2095 C C     . GLN B 4 95  . 13.905  9.278  -20.577 1.00 17.93 95  GLN B C     1
+ATOM   2096 C CB    . GLN B 4 95  . 13.760  10.359 -22.755 1.00 20.35 95  GLN B CB    1
+ATOM   2097 O O     . GLN B 4 95  . 14.372  8.136  -20.522 1.00 12.78 95  GLN B O     1
+ATOM   2098 C CG    . GLN B 4 95  . 13.467  9.878  -24.166 1.00 27.68 95  GLN B CG    1
+ATOM   2099 C CD    . GLN B 4 95  . 11.997  9.585  -24.379 1.00 28.31 95  GLN B CD    1
+ATOM   2100 N NE2   . GLN B 4 95  . 11.165  10.600 -24.619 1.00 30.64 95  GLN B NE2   1
+ATOM   2101 O OE1   . GLN B 4 95  . 11.577  8.429  -24.273 1.00 31.88 95  GLN B OE1   1
+ATOM   2102 N N     . TYR B 4 96  . 14.294  10.324 -19.839 1.00 17.68 96  TYR B N     1
+ATOM   2103 C CA    . TYR B 4 96  . 15.303  10.216 -18.788 1.00 16.56 96  TYR B CA    1
+ATOM   2104 C C     . TYR B 4 96  . 14.635  9.476  -17.630 1.00 15.39 96  TYR B C     1
+ATOM   2105 C CB    . TYR B 4 96  . 15.812  11.661 -18.387 1.00 18.76 96  TYR B CB    1
+ATOM   2106 O O     . TYR B 4 96  . 15.204  8.494  -17.146 1.00 18.14 96  TYR B O     1
+ATOM   2107 C CG    . TYR B 4 96  . 16.779  12.304 -19.407 1.00 17.69 96  TYR B CG    1
+ATOM   2108 C CD1   . TYR B 4 96  . 18.103  11.904 -19.501 1.00 17.72 96  TYR B CD1   1
+ATOM   2109 C CD2   . TYR B 4 96  . 16.310  13.235 -20.316 1.00 18.24 96  TYR B CD2   1
+ATOM   2110 C CE1   . TYR B 4 96  . 18.928  12.419 -20.502 1.00 21.39 96  TYR B CE1   1
+ATOM   2111 C CE2   . TYR B 4 96  . 17.137  13.755 -21.318 1.00 18.64 96  TYR B CE2   1
+ATOM   2112 O OH    . TYR B 4 96  . 19.239  13.843 -22.443 1.00 23.11 96  TYR B OH    1
+ATOM   2113 C CZ    . TYR B 4 96  . 18.443  13.343 -21.413 1.00 16.86 96  TYR B CZ    1
+ATOM   2114 N N     . ARG B 4 97  . 13.415  9.841  -17.237 1.00 14.09 97  ARG B N     1
+ATOM   2115 C CA    . ARG B 4 97  . 12.688  9.114  -16.185 1.00 15.75 97  ARG B CA    1
+ATOM   2116 C C     . ARG B 4 97  . 12.563  7.594  -16.446 1.00 15.48 97  ARG B C     1
+ATOM   2117 C CB    . ARG B 4 97  . 11.347  9.776  -16.095 1.00 14.89 97  ARG B CB    1
+ATOM   2118 O O     . ARG B 4 97  . 12.847  6.788  -15.570 1.00 16.18 97  ARG B O     1
+ATOM   2119 C CG    . ARG B 4 97  . 10.207  8.990  -15.484 1.00 19.80 97  ARG B CG    1
+ATOM   2120 C CD    . ARG B 4 97  . 10.131  9.291  -14.034 1.00 18.95 97  ARG B CD    1
+ATOM   2121 N NE    . ARG B 4 97  . 9.081   8.507  -13.391 1.00 23.04 97  ARG B NE    1
+ATOM   2122 N NH1   . ARG B 4 97  . 9.873   9.082  -11.279 1.00 24.38 97  ARG B NH1   1
+ATOM   2123 N NH2   . ARG B 4 97  . 8.106   7.619  -11.492 1.00 21.32 97  ARG B NH2   1
+ATOM   2124 C CZ    . ARG B 4 97  . 9.026   8.396  -12.056 1.00 22.40 97  ARG B CZ    1
+ATOM   2125 N N     . GLU B 4 98  . 12.186  7.122  -17.633 1.00 14.98 98  GLU B N     1
+ATOM   2126 C CA    . GLU B 4 98  . 12.025  5.691  -17.857 1.00 16.28 98  GLU B CA    1
+ATOM   2127 C C     . GLU B 4 98  . 13.341  4.939  -17.881 1.00 16.55 98  GLU B C     1
+ATOM   2128 C CB    . GLU B 4 98  . 11.278  5.479  -19.171 1.00 19.65 98  GLU B CB    1
+ATOM   2129 O O     . GLU B 4 98  . 13.529  3.840  -17.334 1.00 14.44 98  GLU B O     1
+ATOM   2130 C CG    . GLU B 4 98  . 9.861   6.034  -19.197 1.00 23.49 98  GLU B CG    1
+ATOM   2131 C CD    . GLU B 4 98  . 8.878   5.465  -18.171 1.00 24.91 98  GLU B CD    1
+ATOM   2132 O OE1   . GLU B 4 98  . 8.748   4.246  -18.094 1.00 26.24 98  GLU B OE1   1
+ATOM   2133 O OE2   . GLU B 4 98  . 8.223   6.232  -17.451 1.00 25.77 98  GLU B OE2   1
+ATOM   2134 N N     . GLN B 4 99  . 14.317  5.538  -18.546 1.00 16.35 99  GLN B N     1
+ATOM   2135 C CA    . GLN B 4 99  . 15.623  4.931  -18.504 1.00 18.81 99  GLN B CA    1
+ATOM   2136 C C     . GLN B 4 99  . 16.151  4.930  -17.076 1.00 16.82 99  GLN B C     1
+ATOM   2137 C CB    . GLN B 4 99  . 16.584  5.676  -19.394 1.00 20.01 99  GLN B CB    1
+ATOM   2138 O O     . GLN B 4 99  . 16.805  3.947  -16.720 1.00 19.61 99  GLN B O     1
+ATOM   2139 C CG    . GLN B 4 99  . 17.818  4.791  -19.575 1.00 27.49 99  GLN B CG    1
+ATOM   2140 C CD    . GLN B 4 99  . 18.892  5.321  -20.531 1.00 29.05 99  GLN B CD    1
+ATOM   2141 N NE2   . GLN B 4 99  . 19.997  4.623  -20.245 1.00 26.83 99  GLN B NE2   1
+ATOM   2142 O OE1   . GLN B 4 99  . 18.911  6.263  -21.339 1.00 28.47 99  GLN B OE1   1
+ATOM   2143 N N     . ILE B 4 100 . 15.959  5.939  -16.211 1.00 13.90 100 ILE B N     1
+ATOM   2144 C CA    . ILE B 4 100 . 16.386  5.771  -14.811 1.00 10.37 100 ILE B CA    1
+ATOM   2145 C C     . ILE B 4 100 . 15.636  4.570  -14.174 1.00 12.44 100 ILE B C     1
+ATOM   2146 C CB    . ILE B 4 100 . 16.099  7.114  -14.075 1.00 10.73 100 ILE B CB    1
+ATOM   2147 O O     . ILE B 4 100 . 16.209  3.698  -13.493 1.00 12.92 100 ILE B O     1
+ATOM   2148 C CG1   . ILE B 4 100 . 17.208  8.085  -14.407 1.00 8.73  100 ILE B CG1   1
+ATOM   2149 C CG2   . ILE B 4 100 . 16.003  6.923  -12.586 1.00 13.65 100 ILE B CG2   1
+ATOM   2150 C CD1   . ILE B 4 100 . 16.927  9.573  -14.073 1.00 6.57  100 ILE B CD1   1
+ATOM   2151 N N     . LYS B 4 101 . 14.345  4.436  -14.409 1.00 11.29 101 LYS B N     1
+ATOM   2152 C CA    . LYS B 4 101 . 13.553  3.368  -13.782 1.00 16.26 101 LYS B CA    1
+ATOM   2153 C C     . LYS B 4 101 . 13.951  1.943  -14.116 1.00 17.56 101 LYS B C     1
+ATOM   2154 C CB    . LYS B 4 101 . 12.114  3.548  -14.141 1.00 20.40 101 LYS B CB    1
+ATOM   2155 O O     . LYS B 4 101 . 14.002  1.083  -13.236 1.00 17.75 101 LYS B O     1
+ATOM   2156 C CG    . LYS B 4 101 . 11.463  4.686  -13.359 1.00 25.96 101 LYS B CG    1
+ATOM   2157 C CD    . LYS B 4 101 . 10.166  5.054  -14.067 1.00 31.77 101 LYS B CD    1
+ATOM   2158 C CE    . LYS B 4 101 . 9.259   3.859  -14.322 1.00 33.22 101 LYS B CE    1
+ATOM   2159 N NZ    . LYS B 4 101 . 8.147   4.236  -15.176 1.00 37.16 101 LYS B NZ    1
+ATOM   2160 N N     . ARG B 4 102 . 14.251  1.771  -15.404 1.00 21.60 102 ARG B N     1
+ATOM   2161 C CA    . ARG B 4 102 . 14.757  0.576  -16.060 1.00 22.65 102 ARG B CA    1
+ATOM   2162 C C     . ARG B 4 102 . 16.029  0.070  -15.402 1.00 24.09 102 ARG B C     1
+ATOM   2163 C CB    . ARG B 4 102 . 15.140  0.858  -17.513 1.00 26.77 102 ARG B CB    1
+ATOM   2164 O O     . ARG B 4 102 . 16.132  -1.113 -15.068 1.00 25.87 102 ARG B O     1
+ATOM   2165 C CG    . ARG B 4 102 . 14.466  0.236  -18.738 1.00 32.02 102 ARG B CG    1
+ATOM   2166 C CD    . ARG B 4 102 . 15.474  0.264  -19.900 1.00 32.09 102 ARG B CD    1
+ATOM   2167 N NE    . ARG B 4 102 . 16.610  -0.584 -19.562 1.00 33.70 102 ARG B NE    1
+ATOM   2168 N NH1   . ARG B 4 102 . 18.284  1.035  -19.987 1.00 31.68 102 ARG B NH1   1
+ATOM   2169 N NH2   . ARG B 4 102 . 18.776  -1.058 -19.182 1.00 37.72 102 ARG B NH2   1
+ATOM   2170 C CZ    . ARG B 4 102 . 17.879  -0.175 -19.575 1.00 33.00 102 ARG B CZ    1
+ATOM   2171 N N     . VAL B 4 103 . 17.043  0.935  -15.295 1.00 21.82 103 VAL B N     1
+ATOM   2172 C CA    . VAL B 4 103 . 18.311  0.480  -14.771 1.00 21.59 103 VAL B CA    1
+ATOM   2173 C C     . VAL B 4 103 . 18.284  0.352  -13.263 1.00 20.64 103 VAL B C     1
+ATOM   2174 C CB    . VAL B 4 103 . 19.494  1.415  -15.160 1.00 22.45 103 VAL B CB    1
+ATOM   2175 O O     . VAL B 4 103 . 19.046  -0.451 -12.736 1.00 24.79 103 VAL B O     1
+ATOM   2176 C CG1   . VAL B 4 103 . 19.413  1.631  -16.659 1.00 26.06 103 VAL B CG1   1
+ATOM   2177 C CG2   . VAL B 4 103 . 19.472  2.740  -14.447 1.00 23.64 103 VAL B CG2   1
+ATOM   2178 N N     . LYS B 4 104 . 17.454  1.080  -12.528 1.00 19.12 104 LYS B N     1
+ATOM   2179 C CA    . LYS B 4 104 . 17.446  0.956  -11.073 1.00 19.72 104 LYS B CA    1
+ATOM   2180 C C     . LYS B 4 104 . 16.500  -0.107 -10.572 1.00 20.92 104 LYS B C     1
+ATOM   2181 C CB    . LYS B 4 104 . 17.063  2.287  -10.411 1.00 18.48 104 LYS B CB    1
+ATOM   2182 O O     . LYS B 4 104 . 16.395  -0.299 -9.348  1.00 22.74 104 LYS B O     1
+ATOM   2183 C CG    . LYS B 4 104 . 17.987  3.517  -10.658 1.00 18.26 104 LYS B CG    1
+ATOM   2184 C CD    . LYS B 4 104 . 19.389  3.473  -10.029 1.00 16.72 104 LYS B CD    1
+ATOM   2185 C CE    . LYS B 4 104 . 19.421  3.970  -8.587  1.00 14.87 104 LYS B CE    1
+ATOM   2186 N NZ    . LYS B 4 104 . 20.731  3.832  -7.975  1.00 12.36 104 LYS B NZ    1
+ATOM   2187 N N     . ASP B 4 105 . 15.784  -0.776 -11.507 1.00 21.60 105 ASP B N     1
+ATOM   2188 C CA    . ASP B 4 105 . 14.781  -1.791 -11.164 1.00 21.23 105 ASP B CA    1
+ATOM   2189 C C     . ASP B 4 105 . 13.736  -1.184 -10.249 1.00 22.05 105 ASP B C     1
+ATOM   2190 C CB    . ASP B 4 105 . 15.327  -2.993 -10.362 1.00 24.78 105 ASP B CB    1
+ATOM   2191 O O     . ASP B 4 105 . 13.165  -1.880 -9.412  1.00 21.37 105 ASP B O     1
+ATOM   2192 C CG    . ASP B 4 105 . 16.187  -4.024 -11.041 1.00 29.15 105 ASP B CG    1
+ATOM   2193 O OD1   . ASP B 4 105 . 16.169  -4.055 -12.279 1.00 28.61 105 ASP B OD1   1
+ATOM   2194 O OD2   . ASP B 4 105 . 16.836  -4.797 -10.306 1.00 32.15 105 ASP B OD2   1
+ATOM   2195 N N     . SER B 4 106 . 13.442  0.106  -10.319 1.00 22.08 106 SER B N     1
+ATOM   2196 C CA    . SER B 4 106 . 12.563  0.684  -9.337  1.00 21.39 106 SER B CA    1
+ATOM   2197 C C     . SER B 4 106 . 11.684  1.792  -9.922  1.00 19.60 106 SER B C     1
+ATOM   2198 C CB    . SER B 4 106 . 13.515  1.126  -8.188  1.00 23.74 106 SER B CB    1
+ATOM   2199 O O     . SER B 4 106 . 12.012  2.472  -10.889 1.00 17.78 106 SER B O     1
+ATOM   2200 O OG    . SER B 4 106 . 12.895  1.485  -6.959  1.00 24.91 106 SER B OG    1
+ATOM   2201 N N     . ASP B 4 107 . 10.485  1.873  -9.359  1.00 21.92 107 ASP B N     1
+ATOM   2202 C CA    . ASP B 4 107 . 9.525   2.894  -9.702  1.00 23.92 107 ASP B CA    1
+ATOM   2203 C C     . ASP B 4 107 . 9.575   4.073  -8.741  1.00 21.88 107 ASP B C     1
+ATOM   2204 C CB    . ASP B 4 107 . 8.134   2.220  -9.743  1.00 23.04 107 ASP B CB    1
+ATOM   2205 O O     . ASP B 4 107 . 9.064   5.151  -9.029  1.00 21.60 107 ASP B O     1
+ATOM   2206 C CG    . ASP B 4 107 . 7.969   1.239  -10.911 1.00 24.05 107 ASP B CG    1
+ATOM   2207 O OD1   . ASP B 4 107 . 8.469   1.477  -12.012 1.00 28.33 107 ASP B OD1   1
+ATOM   2208 O OD2   . ASP B 4 107 . 7.336   0.215  -10.734 1.00 22.05 107 ASP B OD2   1
+ATOM   2209 N N     . ASP B 4 108 . 10.258  3.884  -7.613  1.00 26.95 108 ASP B N     1
+ATOM   2210 C CA    . ASP B 4 108 . 10.403  4.871  -6.555  1.00 29.01 108 ASP B CA    1
+ATOM   2211 C C     . ASP B 4 108 . 11.876  5.255  -6.384  1.00 29.23 108 ASP B C     1
+ATOM   2212 C CB    . ASP B 4 108 . 9.802   4.315  -5.198  1.00 34.99 108 ASP B CB    1
+ATOM   2213 O O     . ASP B 4 108 . 12.526  4.935  -5.385  1.00 31.16 108 ASP B O     1
+ATOM   2214 C CG    . ASP B 4 108 . 10.448  3.275  -4.237  1.00 40.51 108 ASP B CG    1
+ATOM   2215 O OD1   . ASP B 4 108 . 11.068  2.284  -4.652  1.00 45.23 108 ASP B OD1   1
+ATOM   2216 O OD2   . ASP B 4 108 . 10.279  3.438  -3.018  1.00 42.53 108 ASP B OD2   1
+ATOM   2217 N N     . VAL B 4 109 . 12.470  5.923  -7.372  1.00 24.05 109 VAL B N     1
+ATOM   2218 C CA    . VAL B 4 109 . 13.855  6.324  -7.171  1.00 23.13 109 VAL B CA    1
+ATOM   2219 C C     . VAL B 4 109 . 13.893  7.829  -6.832  1.00 19.24 109 VAL B C     1
+ATOM   2220 C CB    . VAL B 4 109 . 14.717  5.855  -8.471  1.00 25.42 109 VAL B CB    1
+ATOM   2221 O O     . VAL B 4 109 . 13.087  8.583  -7.385  1.00 18.43 109 VAL B O     1
+ATOM   2222 C CG1   . VAL B 4 109 . 13.910  5.807  -9.767  1.00 25.67 109 VAL B CG1   1
+ATOM   2223 C CG2   . VAL B 4 109 . 15.933  6.782  -8.579  1.00 19.99 109 VAL B CG2   1
+ATOM   2224 N N     . PRO B 4 110 . 14.693  8.276  -5.816  1.00 17.48 110 PRO B N     1
+ATOM   2225 C CA    . PRO B 4 110 . 14.845  9.677  -5.411  1.00 12.56 110 PRO B CA    1
+ATOM   2226 C C     . PRO B 4 110 . 15.038  10.569 -6.638  1.00 10.99 110 PRO B C     1
+ATOM   2227 C CB    . PRO B 4 110 . 16.038  9.624  -4.475  1.00 13.32 110 PRO B CB    1
+ATOM   2228 O O     . PRO B 4 110 . 15.978  10.389 -7.406  1.00 9.09  110 PRO B O     1
+ATOM   2229 C CG    . PRO B 4 110 . 15.852  8.310  -3.765  1.00 15.02 110 PRO B CG    1
+ATOM   2230 C CD    . PRO B 4 110 . 15.535  7.418  -4.952  1.00 13.08 110 PRO B CD    1
+ATOM   2231 N N     . MET B 4 111 . 14.167  11.554 -6.857  1.00 13.85 111 MET B N     1
+ATOM   2232 C CA    . MET B 4 111 . 14.200  12.385 -8.067  1.00 15.34 111 MET B CA    1
+ATOM   2233 C C     . MET B 4 111 . 13.469  13.715 -7.886  1.00 17.02 111 MET B C     1
+ATOM   2234 C CB    . MET B 4 111 . 13.557  11.565 -9.183  1.00 17.36 111 MET B CB    1
+ATOM   2235 O O     . MET B 4 111 . 12.468  13.764 -7.169  1.00 14.33 111 MET B O     1
+ATOM   2236 C CG    . MET B 4 111 . 13.728  11.986 -10.609 1.00 18.58 111 MET B CG    1
+ATOM   2237 S SD    . MET B 4 111 . 13.018  10.703 -11.665 1.00 21.20 111 MET B SD    1
+ATOM   2238 C CE    . MET B 4 111 . 13.942  9.299  -11.129 1.00 15.10 111 MET B CE    1
+ATOM   2239 N N     . VAL B 4 112 . 13.946  14.823 -8.472  1.00 15.99 112 VAL B N     1
+ATOM   2240 C CA    . VAL B 4 112 . 13.186  16.065 -8.466  1.00 13.92 112 VAL B CA    1
+ATOM   2241 C C     . VAL B 4 112 . 13.312  16.704 -9.827  1.00 10.66 112 VAL B C     1
+ATOM   2242 C CB    . VAL B 4 112 . 13.654  17.058 -7.277  1.00 16.36 112 VAL B CB    1
+ATOM   2243 O O     . VAL B 4 112 . 14.372  16.712 -10.438 1.00 10.35 112 VAL B O     1
+ATOM   2244 C CG1   . VAL B 4 112 . 15.132  16.979 -7.091  1.00 16.89 112 VAL B CG1   1
+ATOM   2245 C CG2   . VAL B 4 112 . 13.296  18.529 -7.573  1.00 13.20 112 VAL B CG2   1
+ATOM   2246 N N     . LEU B 4 113 . 12.134  17.087 -10.314 1.00 6.03  113 LEU B N     1
+ATOM   2247 C CA    . LEU B 4 113 . 11.940  17.812 -11.568 1.00 8.77  113 LEU B CA    1
+ATOM   2248 C C     . LEU B 4 113 . 12.241  19.283 -11.366 1.00 5.87  113 LEU B C     1
+ATOM   2249 C CB    . LEU B 4 113 . 10.501  17.677 -12.052 1.00 11.27 113 LEU B CB    1
+ATOM   2250 O O     . LEU B 4 113 . 11.643  19.943 -10.514 1.00 5.60  113 LEU B O     1
+ATOM   2251 C CG    . LEU B 4 113 . 10.150  18.202 -13.419 1.00 8.37  113 LEU B CG    1
+ATOM   2252 C CD1   . LEU B 4 113 . 10.923  17.438 -14.437 1.00 9.92  113 LEU B CD1   1
+ATOM   2253 C CD2   . LEU B 4 113 . 8.661   18.037 -13.667 1.00 9.68  113 LEU B CD2   1
+ATOM   2254 N N     . VAL B 4 114 . 13.219  19.788 -12.127 1.00 6.61  114 VAL B N     1
+ATOM   2255 C CA    . VAL B 4 114 . 13.684  21.132 -11.975 1.00 4.83  114 VAL B CA    1
+ATOM   2256 C C     . VAL B 4 114 . 13.353  21.911 -13.218 1.00 5.26  114 VAL B C     1
+ATOM   2257 C CB    . VAL B 4 114 . 15.179  21.057 -11.715 1.00 2.00  114 VAL B CB    1
+ATOM   2258 O O     . VAL B 4 114 . 13.762  21.493 -14.289 1.00 9.45  114 VAL B O     1
+ATOM   2259 C CG1   . VAL B 4 114 . 15.727  22.448 -11.655 1.00 3.92  114 VAL B CG1   1
+ATOM   2260 C CG2   . VAL B 4 114 . 15.461  20.363 -10.394 1.00 4.23  114 VAL B CG2   1
+ATOM   2261 N N     . GLY B 4 115 . 12.616  23.008 -13.160 1.00 4.75  115 GLY B N     1
+ATOM   2262 C CA    . GLY B 4 115 . 12.359  23.783 -14.345 1.00 5.03  115 GLY B CA    1
+ATOM   2263 C C     . GLY B 4 115 . 13.287  24.990 -14.295 1.00 4.53  115 GLY B C     1
+ATOM   2264 O O     . GLY B 4 115 . 12.999  25.970 -13.610 1.00 6.33  115 GLY B O     1
+ATOM   2265 N N     . ASN B 4 116 . 14.383  24.994 -15.036 1.00 6.13  116 ASN B N     1
+ATOM   2266 C CA    . ASN B 4 116 . 15.358  26.073 -14.946 1.00 8.71  116 ASN B CA    1
+ATOM   2267 C C     . ASN B 4 116 . 15.066  27.205 -15.964 1.00 11.32 116 ASN B C     1
+ATOM   2268 C CB    . ASN B 4 116 . 16.729  25.413 -15.144 1.00 6.49  116 ASN B CB    1
+ATOM   2269 O O     . ASN B 4 116 . 14.223  27.084 -16.856 1.00 9.77  116 ASN B O     1
+ATOM   2270 C CG    . ASN B 4 116 . 17.961  26.277 -14.946 1.00 9.62  116 ASN B CG    1
+ATOM   2271 N ND2   . ASN B 4 116 . 18.867  26.339 -15.944 1.00 5.40  116 ASN B ND2   1
+ATOM   2272 O OD1   . ASN B 4 116 . 18.127  26.888 -13.889 1.00 8.62  116 ASN B OD1   1
+ATOM   2273 N N     . LYS B 4 117 . 15.790  28.310 -15.784 1.00 11.65 117 LYS B N     1
+ATOM   2274 C CA    . LYS B 4 117 . 15.770  29.574 -16.526 1.00 13.46 117 LYS B CA    1
+ATOM   2275 C C     . LYS B 4 117 . 14.527  30.433 -16.273 1.00 14.84 117 LYS B C     1
+ATOM   2276 C CB    . LYS B 4 117 . 15.949  29.265 -18.040 1.00 14.11 117 LYS B CB    1
+ATOM   2277 O O     . LYS B 4 117 . 14.057  31.211 -17.120 1.00 14.23 117 LYS B O     1
+ATOM   2278 C CG    . LYS B 4 117 . 17.116  28.287 -18.308 1.00 10.72 117 LYS B CG    1
+ATOM   2279 C CD    . LYS B 4 117 . 17.418  28.230 -19.786 1.00 11.84 117 LYS B CD    1
+ATOM   2280 C CE    . LYS B 4 117 . 18.636  27.395 -20.032 1.00 11.09 117 LYS B CE    1
+ATOM   2281 N NZ    . LYS B 4 117 . 19.054  27.615 -21.394 1.00 13.07 117 LYS B NZ    1
+ATOM   2282 N N     . CYS B 4 118 . 14.035  30.377 -15.031 1.00 11.43 118 CYS B N     1
+ATOM   2283 C CA    . CYS B 4 118 . 12.799  31.068 -14.675 1.00 14.91 118 CYS B CA    1
+ATOM   2284 C C     . CYS B 4 118 . 12.852  32.596 -14.641 1.00 15.03 118 CYS B C     1
+ATOM   2285 C CB    . CYS B 4 118 . 12.279  30.506 -13.306 1.00 17.21 118 CYS B CB    1
+ATOM   2286 O O     . CYS B 4 118 . 11.838  33.283 -14.557 1.00 15.03 118 CYS B O     1
+ATOM   2287 S SG    . CYS B 4 118 . 13.133  30.874 -11.752 1.00 18.09 118 CYS B SG    1
+ATOM   2288 N N     . ASP B 4 119 . 14.073  33.115 -14.715 1.00 16.62 119 ASP B N     1
+ATOM   2289 C CA    . ASP B 4 119 . 14.368  34.529 -14.855 1.00 17.35 119 ASP B CA    1
+ATOM   2290 C C     . ASP B 4 119 . 13.992  35.052 -16.252 1.00 17.86 119 ASP B C     1
+ATOM   2291 C CB    . ASP B 4 119 . 15.881  34.725 -14.575 1.00 15.36 119 ASP B CB    1
+ATOM   2292 O O     . ASP B 4 119 . 13.821  36.252 -16.452 1.00 16.29 119 ASP B O     1
+ATOM   2293 C CG    . ASP B 4 119 . 16.767  33.960 -15.528 1.00 13.01 119 ASP B CG    1
+ATOM   2294 O OD1   . ASP B 4 119 . 16.981  32.784 -15.306 1.00 7.12  119 ASP B OD1   1
+ATOM   2295 O OD2   . ASP B 4 119 . 17.222  34.523 -16.513 1.00 13.71 119 ASP B OD2   1
+ATOM   2296 N N     . LEU B 4 120 . 13.850  34.167 -17.256 1.00 19.76 120 LEU B N     1
+ATOM   2297 C CA    . LEU B 4 120 . 13.558  34.559 -18.631 1.00 19.60 120 LEU B CA    1
+ATOM   2298 C C     . LEU B 4 120 . 12.069  34.729 -18.875 1.00 21.53 120 LEU B C     1
+ATOM   2299 C CB    . LEU B 4 120 . 14.081  33.511 -19.617 1.00 19.93 120 LEU B CB    1
+ATOM   2300 O O     . LEU B 4 120 . 11.264  33.881 -18.467 1.00 20.24 120 LEU B O     1
+ATOM   2301 C CG    . LEU B 4 120 . 15.569  33.298 -19.875 1.00 17.20 120 LEU B CG    1
+ATOM   2302 C CD1   . LEU B 4 120 . 15.685  32.153 -20.869 1.00 19.86 120 LEU B CD1   1
+ATOM   2303 C CD2   . LEU B 4 120 . 16.249  34.572 -20.372 1.00 16.37 120 LEU B CD2   1
+ATOM   2304 N N     . ALA B 4 121 . 11.710  35.851 -19.510 1.00 19.27 121 ALA B N     1
+ATOM   2305 C CA    . ALA B 4 121 . 10.329  36.100 -19.882 1.00 23.61 121 ALA B CA    1
+ATOM   2306 C C     . ALA B 4 121 . 10.302  35.653 -21.323 1.00 25.94 121 ALA B C     1
+ATOM   2307 C CB    . ALA B 4 121 . 9.988   37.582 -19.805 1.00 23.12 121 ALA B CB    1
+ATOM   2308 O O     . ALA B 4 121 . 10.838  36.296 -22.220 1.00 30.79 121 ALA B O     1
+ATOM   2309 N N     . ALA B 4 122 . 9.770   34.461 -21.517 1.00 26.89 122 ALA B N     1
+ATOM   2310 C CA    . ALA B 4 122 . 9.746   33.818 -22.813 1.00 25.13 122 ALA B CA    1
+ATOM   2311 C C     . ALA B 4 122 . 9.468   32.347 -22.586 1.00 24.10 122 ALA B C     1
+ATOM   2312 O O     . ALA B 4 122 . 9.941   31.462 -23.297 1.00 24.67 122 ALA B O     1
+ATOM   2313 N N     . ARG B 4 123 . 8.650   32.142 -21.564 1.00 23.10 123 ARG B N     1
+ATOM   2314 C CA    . ARG B 4 123 . 8.202   30.854 -21.104 1.00 20.91 123 ARG B CA    1
+ATOM   2315 C C     . ARG B 4 123 . 7.272   30.181 -22.106 1.00 21.93 123 ARG B C     1
+ATOM   2316 C CB    . ARG B 4 123 . 7.505   31.077 -19.781 1.00 19.67 123 ARG B CB    1
+ATOM   2317 O O     . ARG B 4 123 . 6.339   30.799 -22.628 1.00 18.99 123 ARG B O     1
+ATOM   2318 C CG    . ARG B 4 123 . 6.783   29.875 -19.215 1.00 22.60 123 ARG B CG    1
+ATOM   2319 C CD    . ARG B 4 123 . 6.056   30.179 -17.906 1.00 20.37 123 ARG B CD    1
+ATOM   2320 N NE    . ARG B 4 123 . 6.984   30.624 -16.886 1.00 21.63 123 ARG B NE    1
+ATOM   2321 N NH1   . ARG B 4 123 . 7.070   28.540 -15.769 1.00 16.45 123 ARG B NH1   1
+ATOM   2322 N NH2   . ARG B 4 123 . 8.263   30.427 -15.058 1.00 18.84 123 ARG B NH2   1
+ATOM   2323 C CZ    . ARG B 4 123 . 7.421   29.842 -15.901 1.00 19.02 123 ARG B CZ    1
+ATOM   2324 N N     . THR B 4 124 . 7.531   28.902 -22.396 1.00 21.48 124 THR B N     1
+ATOM   2325 C CA    . THR B 4 124 . 6.669   28.142 -23.271 1.00 18.90 124 THR B CA    1
+ATOM   2326 C C     . THR B 4 124 . 6.154   26.930 -22.521 1.00 19.00 124 THR B C     1
+ATOM   2327 C CB    . THR B 4 124 . 7.428   27.716 -24.524 1.00 20.99 124 THR B CB    1
+ATOM   2328 O O     . THR B 4 124 . 5.222   26.297 -22.990 1.00 18.55 124 THR B O     1
+ATOM   2329 C CG2   . THR B 4 124 . 8.089   28.909 -25.219 1.00 21.51 124 THR B CG2   1
+ATOM   2330 O OG1   . THR B 4 124 . 8.371   26.735 -24.134 1.00 18.03 124 THR B OG1   1
+ATOM   2331 N N     . VAL B 4 125 . 6.726   26.590 -21.352 1.00 19.39 125 VAL B N     1
+ATOM   2332 C CA    . VAL B 4 125 . 6.225   25.504 -20.522 1.00 17.84 125 VAL B CA    1
+ATOM   2333 C C     . VAL B 4 125 . 5.535   26.157 -19.318 1.00 20.64 125 VAL B C     1
+ATOM   2334 C CB    . VAL B 4 125 . 7.399   24.586 -20.043 1.00 15.08 125 VAL B CB    1
+ATOM   2335 O O     . VAL B 4 125 . 6.215   26.720 -18.456 1.00 23.00 125 VAL B O     1
+ATOM   2336 C CG1   . VAL B 4 125 . 6.855   23.543 -19.119 1.00 14.15 125 VAL B CG1   1
+ATOM   2337 C CG2   . VAL B 4 125 . 8.082   23.877 -21.207 1.00 15.51 125 VAL B CG2   1
+ATOM   2338 N N     . GLU B 4 126 . 4.198   26.156 -19.212 1.00 22.21 126 GLU B N     1
+ATOM   2339 C CA    . GLU B 4 126 . 3.516   26.660 -18.004 1.00 24.80 126 GLU B CA    1
+ATOM   2340 C C     . GLU B 4 126 . 3.819   25.836 -16.763 1.00 21.61 126 GLU B C     1
+ATOM   2341 C CB    . GLU B 4 126 . 1.970   26.658 -18.121 1.00 28.88 126 GLU B CB    1
+ATOM   2342 O O     . GLU B 4 126 . 3.925   24.605 -16.815 1.00 18.61 126 GLU B O     1
+ATOM   2343 C CG    . GLU B 4 126 . 1.369   27.746 -19.020 1.00 36.04 126 GLU B CG    1
+ATOM   2344 C CD    . GLU B 4 126 . 1.715   29.202 -18.669 1.00 38.33 126 GLU B CD    1
+ATOM   2345 O OE1   . GLU B 4 126 . 2.779   29.695 -19.038 1.00 38.50 126 GLU B OE1   1
+ATOM   2346 O OE2   . GLU B 4 126 . 0.909   29.870 -18.029 1.00 41.84 126 GLU B OE2   1
+ATOM   2347 N N     . SER B 4 127 . 3.911   26.512 -15.616 1.00 22.77 127 SER B N     1
+ATOM   2348 C CA    . SER B 4 127 . 4.115   25.855 -14.327 1.00 19.90 127 SER B CA    1
+ATOM   2349 C C     . SER B 4 127 . 3.098   24.778 -14.093 1.00 18.95 127 SER B C     1
+ATOM   2350 C CB    . SER B 4 127 . 3.992   26.823 -13.184 1.00 20.73 127 SER B CB    1
+ATOM   2351 O O     . SER B 4 127 . 3.505   23.689 -13.681 1.00 13.90 127 SER B O     1
+ATOM   2352 O OG    . SER B 4 127 . 5.100   27.687 -13.381 1.00 28.29 127 SER B OG    1
+ATOM   2353 N N     . ARG B 4 128 . 1.813   25.040 -14.427 1.00 21.70 128 ARG B N     1
+ATOM   2354 C CA    . ARG B 4 128 . 0.792   24.012 -14.188 1.00 23.63 128 ARG B CA    1
+ATOM   2355 C C     . ARG B 4 128 . 1.072   22.743 -14.959 1.00 22.65 128 ARG B C     1
+ATOM   2356 C CB    . ARG B 4 128 . -0.641  24.468 -14.546 1.00 26.74 128 ARG B CB    1
+ATOM   2357 O O     . ARG B 4 128 . 0.849   21.674 -14.399 1.00 26.46 128 ARG B O     1
+ATOM   2358 C CG    . ARG B 4 128 . -1.569  24.287 -13.317 1.00 31.78 128 ARG B CG    1
+ATOM   2359 C CD    . ARG B 4 128 . -2.616  25.424 -13.091 1.00 34.94 128 ARG B CD    1
+ATOM   2360 N NE    . ARG B 4 128 . -2.961  25.697 -11.681 1.00 39.35 128 ARG B NE    1
+ATOM   2361 N NH1   . ARG B 4 128 . -1.621  27.641 -11.538 1.00 42.73 128 ARG B NH1   1
+ATOM   2362 N NH2   . ARG B 4 128 . -2.832  26.990 -9.698  1.00 40.83 128 ARG B NH2   1
+ATOM   2363 C CZ    . ARG B 4 128 . -2.476  26.764 -10.981 1.00 41.93 128 ARG B CZ    1
+ATOM   2364 N N     . GLN B 4 129 . 1.643   22.780 -16.170 1.00 22.80 129 GLN B N     1
+ATOM   2365 C CA    . GLN B 4 129 . 1.909   21.561 -16.934 1.00 19.79 129 GLN B CA    1
+ATOM   2366 C C     . GLN B 4 129 . 2.873   20.643 -16.193 1.00 16.84 129 GLN B C     1
+ATOM   2367 C CB    . GLN B 4 129 . 2.566   21.869 -18.255 1.00 23.95 129 GLN B CB    1
+ATOM   2368 O O     . GLN B 4 129 . 2.752   19.427 -16.160 1.00 15.03 129 GLN B O     1
+ATOM   2369 C CG    . GLN B 4 129 . 1.921   22.731 -19.317 1.00 27.95 129 GLN B CG    1
+ATOM   2370 C CD    . GLN B 4 129 . 2.823   22.865 -20.544 1.00 29.52 129 GLN B CD    1
+ATOM   2371 N NE2   . GLN B 4 129 . 3.439   21.786 -21.017 1.00 31.02 129 GLN B NE2   1
+ATOM   2372 O OE1   . GLN B 4 129 . 2.989   23.940 -21.109 1.00 31.31 129 GLN B OE1   1
+ATOM   2373 N N     . ALA B 4 130 . 3.946   21.296 -15.756 1.00 14.26 130 ALA B N     1
+ATOM   2374 C CA    . ALA B 4 130 . 5.047   20.644 -15.099 1.00 16.59 130 ALA B CA    1
+ATOM   2375 C C     . ALA B 4 130 . 4.700   20.182 -13.690 1.00 17.00 130 ALA B C     1
+ATOM   2376 C CB    . ALA B 4 130 . 6.186   21.612 -15.029 1.00 16.88 130 ALA B CB    1
+ATOM   2377 O O     . ALA B 4 130 . 5.274   19.203 -13.220 1.00 16.14 130 ALA B O     1
+ATOM   2378 N N     . GLN B 4 131 . 3.807   20.928 -13.002 1.00 16.98 131 GLN B N     1
+ATOM   2379 C CA    . GLN B 4 131 . 3.303   20.583 -11.671 1.00 15.92 131 GLN B CA    1
+ATOM   2380 C C     . GLN B 4 131 . 2.500   19.294 -11.636 1.00 15.07 131 GLN B C     1
+ATOM   2381 C CB    . GLN B 4 131 . 2.389   21.642 -11.127 1.00 16.68 131 GLN B CB    1
+ATOM   2382 O O     . GLN B 4 131 . 2.601   18.459 -10.717 1.00 15.86 131 GLN B O     1
+ATOM   2383 C CG    . GLN B 4 131 . 2.949   22.513 -10.044 1.00 21.18 131 GLN B CG    1
+ATOM   2384 C CD    . GLN B 4 131 . 3.674   21.694 -8.996  1.00 22.20 131 GLN B CD    1
+ATOM   2385 N NE2   . GLN B 4 131 . 3.420   20.416 -8.643  1.00 21.00 131 GLN B NE2   1
+ATOM   2386 O OE1   . GLN B 4 131 . 4.604   22.262 -8.458  1.00 26.46 131 GLN B OE1   1
+ATOM   2387 N N     . ASP B 4 132 . 1.681   19.179 -12.684 1.00 15.18 132 ASP B N     1
+ATOM   2388 C CA    . ASP B 4 132 . 0.872   18.001 -12.891 1.00 14.74 132 ASP B CA    1
+ATOM   2389 C C     . ASP B 4 132 . 1.752   16.855 -13.303 1.00 16.46 132 ASP B C     1
+ATOM   2390 C CB    . ASP B 4 132 . -0.124  18.360 -13.932 1.00 17.73 132 ASP B CB    1
+ATOM   2391 O O     . ASP B 4 132 . 1.598   15.757 -12.783 1.00 20.62 132 ASP B O     1
+ATOM   2392 C CG    . ASP B 4 132 . -1.113  19.441 -13.488 1.00 22.37 132 ASP B CG    1
+ATOM   2393 O OD1   . ASP B 4 132 . -0.940  20.128 -12.459 1.00 24.08 132 ASP B OD1   1
+ATOM   2394 O OD2   . ASP B 4 132 . -2.097  19.590 -14.212 1.00 25.11 132 ASP B OD2   1
+ATOM   2395 N N     . LEU B 4 133 . 2.731   17.039 -14.203 1.00 16.15 133 LEU B N     1
+ATOM   2396 C CA    . LEU B 4 133 . 3.644   15.949 -14.566 1.00 14.26 133 LEU B CA    1
+ATOM   2397 C C     . LEU B 4 133 . 4.320   15.376 -13.335 1.00 12.39 133 LEU B C     1
+ATOM   2398 C CB    . LEU B 4 133 . 4.766   16.417 -15.526 1.00 15.29 133 LEU B CB    1
+ATOM   2399 O O     . LEU B 4 133 . 4.276   14.173 -13.063 1.00 13.12 133 LEU B O     1
+ATOM   2400 C CG    . LEU B 4 133 . 5.578   15.338 -16.234 1.00 11.53 133 LEU B CG    1
+ATOM   2401 C CD1   . LEU B 4 133 . 4.738   14.781 -17.356 1.00 14.77 133 LEU B CD1   1
+ATOM   2402 C CD2   . LEU B 4 133 . 6.822   15.902 -16.891 1.00 10.29 133 LEU B CD2   1
+ATOM   2403 N N     . ALA B 4 134 . 4.977   16.285 -12.618 1.00 12.99 134 ALA B N     1
+ATOM   2404 C CA    . ALA B 4 134 . 5.734   15.905 -11.433 1.00 15.23 134 ALA B CA    1
+ATOM   2405 C C     . ALA B 4 134 . 4.867   15.194 -10.414 1.00 18.90 134 ALA B C     1
+ATOM   2406 C CB    . ALA B 4 134 . 6.324   17.126 -10.771 1.00 16.46 134 ALA B CB    1
+ATOM   2407 O O     . ALA B 4 134 . 5.385   14.323 -9.740  1.00 18.15 134 ALA B O     1
+ATOM   2408 N N     . ARG B 4 135 . 3.582   15.569 -10.270 1.00 23.36 135 ARG B N     1
+ATOM   2409 C CA    . ARG B 4 135 . 2.616   14.885 -9.406  1.00 26.54 135 ARG B CA    1
+ATOM   2410 C C     . ARG B 4 135 . 2.291   13.469 -9.925  1.00 25.49 135 ARG B C     1
+ATOM   2411 C CB    . ARG B 4 135 . 1.271   15.671 -9.294  1.00 26.86 135 ARG B CB    1
+ATOM   2412 O O     . ARG B 4 135 . 2.074   12.579 -9.080  1.00 22.41 135 ARG B O     1
+ATOM   2413 C CG    . ARG B 4 135 . 0.488   15.201 -8.061  1.00 31.82 135 ARG B CG    1
+ATOM   2414 C CD    . ARG B 4 135 . -1.030  15.510 -7.996  1.00 34.52 135 ARG B CD    1
+ATOM   2415 N NE    . ARG B 4 135 . -1.766  14.352 -7.461  1.00 38.12 135 ARG B NE    1
+ATOM   2416 N NH1   . ARG B 4 135 . -1.387  14.853 -5.198  1.00 37.11 135 ARG B NH1   1
+ATOM   2417 N NH2   . ARG B 4 135 . -2.418  12.891 -5.796  1.00 34.93 135 ARG B NH2   1
+ATOM   2418 C CZ    . ARG B 4 135 . -1.831  14.031 -6.154  1.00 37.37 135 ARG B CZ    1
+ATOM   2419 N N     . SER B 4 136 . 2.239   13.242 -11.269 1.00 24.71 136 SER B N     1
+ATOM   2420 C CA    . SER B 4 136 . 1.961   11.906 -11.835 1.00 24.23 136 SER B CA    1
+ATOM   2421 C C     . SER B 4 136 . 3.137   10.965 -11.517 1.00 23.36 136 SER B C     1
+ATOM   2422 C CB    . SER B 4 136 . 1.725   11.996 -13.376 1.00 20.59 136 SER B CB    1
+ATOM   2423 O O     . SER B 4 136 . 2.935   9.829  -11.078 1.00 24.82 136 SER B O     1
+ATOM   2424 O OG    . SER B 4 136 . 2.860   12.161 -14.208 1.00 17.68 136 SER B OG    1
+ATOM   2425 N N     . TYR B 4 137 . 4.391   11.382 -11.770 1.00 23.44 137 TYR B N     1
+ATOM   2426 C CA    . TYR B 4 137 . 5.580   10.702 -11.225 1.00 23.92 137 TYR B CA    1
+ATOM   2427 C C     . TYR B 4 137 . 5.432   10.942 -9.714  1.00 23.25 137 TYR B C     1
+ATOM   2428 C CB    . TYR B 4 137 . 6.880   11.391 -11.663 1.00 22.96 137 TYR B CB    1
+ATOM   2429 O O     . TYR B 4 137 . 4.879   12.000 -9.453  1.00 31.14 137 TYR B O     1
+ATOM   2430 C CG    . TYR B 4 137 . 7.130   11.646 -13.143 1.00 25.11 137 TYR B CG    1
+ATOM   2431 C CD1   . TYR B 4 137 . 6.467   10.878 -14.099 1.00 26.64 137 TYR B CD1   1
+ATOM   2432 C CD2   . TYR B 4 137 . 8.051   12.639 -13.541 1.00 25.18 137 TYR B CD2   1
+ATOM   2433 C CE1   . TYR B 4 137 . 6.721   11.081 -15.453 1.00 24.00 137 TYR B CE1   1
+ATOM   2434 C CE2   . TYR B 4 137 . 8.307   12.842 -14.896 1.00 21.24 137 TYR B CE2   1
+ATOM   2435 O OH    . TYR B 4 137 . 7.918   12.139 -17.186 1.00 15.45 137 TYR B OH    1
+ATOM   2436 C CZ    . TYR B 4 137 . 7.637   12.049 -15.838 1.00 21.08 137 TYR B CZ    1
+ATOM   2437 N N     . GLY B 4 138 . 5.753   10.298 -8.588  1.00 23.96 138 GLY B N     1
+ATOM   2438 C CA    . GLY B 4 138 . 5.411   10.937 -7.269  1.00 15.52 138 GLY B CA    1
+ATOM   2439 C C     . GLY B 4 138 . 6.512   11.914 -6.828  1.00 17.99 138 GLY B C     1
+ATOM   2440 O O     . GLY B 4 138 . 7.144   11.668 -5.792  1.00 15.65 138 GLY B O     1
+ATOM   2441 N N     . ILE B 4 139 . 6.776   13.007 -7.584  1.00 11.66 139 ILE B N     1
+ATOM   2442 C CA    . ILE B 4 139 . 8.028   13.771 -7.472  1.00 13.04 139 ILE B CA    1
+ATOM   2443 C C     . ILE B 4 139 . 7.834   15.263 -7.180  1.00 11.83 139 ILE B C     1
+ATOM   2444 C CB    . ILE B 4 139 . 8.765   13.348 -8.858  1.00 14.54 139 ILE B CB    1
+ATOM   2445 O O     . ILE B 4 139 . 6.854   15.866 -7.633  1.00 18.03 139 ILE B O     1
+ATOM   2446 C CG1   . ILE B 4 139 . 9.781   12.365 -8.399  1.00 9.95  139 ILE B CG1   1
+ATOM   2447 C CG2   . ILE B 4 139 . 9.447   14.397 -9.744  1.00 12.54 139 ILE B CG2   1
+ATOM   2448 C CD1   . ILE B 4 139 . 9.251   10.933 -8.370  1.00 12.91 139 ILE B CD1   1
+ATOM   2449 N N     . PRO B 4 140 . 8.685   15.934 -6.390  1.00 10.94 140 PRO B N     1
+ATOM   2450 C CA    . PRO B 4 140 . 8.643   17.379 -6.226  1.00 13.32 140 PRO B CA    1
+ATOM   2451 C C     . PRO B 4 140 . 8.969   18.179 -7.518  1.00 11.57 140 PRO B C     1
+ATOM   2452 C CB    . PRO B 4 140 . 9.628   17.622 -5.078  1.00 12.02 140 PRO B CB    1
+ATOM   2453 O O     . PRO B 4 140 . 9.764   17.730 -8.346  1.00 11.32 140 PRO B O     1
+ATOM   2454 C CG    . PRO B 4 140 . 9.958   16.286 -4.471  1.00 10.53 140 PRO B CG    1
+ATOM   2455 C CD    . PRO B 4 140 . 9.791   15.353 -5.632  1.00 10.65 140 PRO B CD    1
+ATOM   2456 N N     . TYR B 4 141 . 8.340   19.345 -7.755  1.00 13.16 141 TYR B N     1
+ATOM   2457 C CA    . TYR B 4 141 . 8.656   20.216 -8.881  1.00 7.27  141 TYR B CA    1
+ATOM   2458 C C     . TYR B 4 141 . 9.159   21.542 -8.321  1.00 8.80  141 TYR B C     1
+ATOM   2459 C CB    . TYR B 4 141 . 7.414   20.483 -9.780  1.00 8.95  141 TYR B CB    1
+ATOM   2460 O O     . TYR B 4 141 . 8.432   22.239 -7.597  1.00 10.68 141 TYR B O     1
+ATOM   2461 C CG    . TYR B 4 141 . 7.670   21.475 -10.948 1.00 11.64 141 TYR B CG    1
+ATOM   2462 C CD1   . TYR B 4 141 . 8.694   21.258 -11.854 1.00 9.84  141 TYR B CD1   1
+ATOM   2463 C CD2   . TYR B 4 141 . 6.926   22.638 -11.053 1.00 8.77  141 TYR B CD2   1
+ATOM   2464 C CE1   . TYR B 4 141 . 8.979   22.176 -12.836 1.00 7.53  141 TYR B CE1   1
+ATOM   2465 C CE2   . TYR B 4 141 . 7.220   23.569 -12.038 1.00 11.20 141 TYR B CE2   1
+ATOM   2466 O OH    . TYR B 4 141 . 8.539   24.247 -13.900 1.00 10.62 141 TYR B OH    1
+ATOM   2467 C CZ    . TYR B 4 141 . 8.243   23.328 -12.919 1.00 8.27  141 TYR B CZ    1
+ATOM   2468 N N     . ILE B 4 142 . 10.440  21.840 -8.594  1.00 3.78  142 ILE B N     1
+ATOM   2469 C CA    . ILE B 4 142 . 10.927  23.142 -8.240  1.00 10.52 142 ILE B CA    1
+ATOM   2470 C C     . ILE B 4 142 . 11.549  23.957 -9.406  1.00 11.97 142 ILE B C     1
+ATOM   2471 C CB    . ILE B 4 142 . 11.911  22.996 -6.916  1.00 11.09 142 ILE B CB    1
+ATOM   2472 O O     . ILE B 4 142 . 12.327  23.473 -10.223 1.00 11.42 142 ILE B O     1
+ATOM   2473 C CG1   . ILE B 4 142 . 13.277  23.422 -7.207  1.00 8.58  142 ILE B CG1   1
+ATOM   2474 C CG2   . ILE B 4 142 . 11.976  21.591 -6.343  1.00 11.82 142 ILE B CG2   1
+ATOM   2475 C CD1   . ILE B 4 142 . 13.282  24.829 -6.658  1.00 6.28  142 ILE B CD1   1
+ATOM   2476 N N     . GLU B 4 143 . 11.114  25.213 -9.588  1.00 10.41 143 GLU B N     1
+ATOM   2477 C CA    . GLU B 4 143 . 11.737  26.098 -10.564 1.00 11.85 143 GLU B CA    1
+ATOM   2478 C C     . GLU B 4 143 . 13.010  26.810 -10.090 1.00 13.98 143 GLU B C     1
+ATOM   2479 C CB    . GLU B 4 143 . 10.762  27.153 -10.998 1.00 12.62 143 GLU B CB    1
+ATOM   2480 O O     . GLU B 4 143 . 13.078  27.294 -8.947  1.00 13.02 143 GLU B O     1
+ATOM   2481 C CG    . GLU B 4 143 . 9.567   26.565 -11.701 1.00 11.46 143 GLU B CG    1
+ATOM   2482 C CD    . GLU B 4 143 . 8.834   27.536 -12.621 1.00 12.67 143 GLU B CD    1
+ATOM   2483 O OE1   . GLU B 4 143 . 9.127   28.716 -12.616 1.00 11.46 143 GLU B OE1   1
+ATOM   2484 O OE2   . GLU B 4 143 . 7.948   27.108 -13.356 1.00 16.35 143 GLU B OE2   1
+ATOM   2485 N N     . THR B 4 144 . 14.020  26.894 -10.976 1.00 11.94 144 THR B N     1
+ATOM   2486 C CA    . THR B 4 144 . 15.306  27.465 -10.639 1.00 10.34 144 THR B CA    1
+ATOM   2487 C C     . THR B 4 144 . 15.811  28.480 -11.655 1.00 14.75 144 THR B C     1
+ATOM   2488 C CB    . THR B 4 144 . 16.379  26.377 -10.521 1.00 12.63 144 THR B CB    1
+ATOM   2489 O O     . THR B 4 144 . 15.299  28.567 -12.769 1.00 16.15 144 THR B O     1
+ATOM   2490 C CG2   . THR B 4 144 . 16.177  25.401 -9.368  1.00 11.34 144 THR B CG2   1
+ATOM   2491 O OG1   . THR B 4 144 . 16.368  25.722 -11.773 1.00 11.68 144 THR B OG1   1
+ATOM   2492 N N     . SER B 4 145 . 16.817  29.278 -11.290 1.00 14.30 145 SER B N     1
+ATOM   2493 C CA    . SER B 4 145 . 17.534  30.140 -12.233 1.00 14.12 145 SER B CA    1
+ATOM   2494 C C     . SER B 4 145 . 19.002  30.053 -11.817 1.00 15.11 145 SER B C     1
+ATOM   2495 C CB    . SER B 4 145 . 17.107  31.610 -12.159 1.00 11.68 145 SER B CB    1
+ATOM   2496 O O     . SER B 4 145 . 19.391  30.427 -10.696 1.00 16.51 145 SER B O     1
+ATOM   2497 O OG    . SER B 4 145 . 18.090  32.362 -12.872 1.00 11.02 145 SER B OG    1
+ATOM   2498 N N     . ALA B 4 146 . 19.853  29.510 -12.685 1.00 15.14 146 ALA B N     1
+ATOM   2499 C CA    . ALA B 4 146 . 21.280  29.461 -12.373 1.00 16.36 146 ALA B CA    1
+ATOM   2500 C C     . ALA B 4 146 . 21.804  30.891 -12.477 1.00 17.69 146 ALA B C     1
+ATOM   2501 C CB    . ALA B 4 146 . 22.020  28.568 -13.370 1.00 14.29 146 ALA B CB    1
+ATOM   2502 O O     . ALA B 4 146 . 22.814  31.258 -11.855 1.00 18.27 146 ALA B O     1
+ATOM   2503 N N     . LYS B 4 147 . 21.067  31.719 -13.235 1.00 19.32 147 LYS B N     1
+ATOM   2504 C CA    . LYS B 4 147 . 21.386  33.116 -13.343 1.00 20.18 147 LYS B CA    1
+ATOM   2505 C C     . LYS B 4 147 . 21.197  33.880 -12.040 1.00 24.36 147 LYS B C     1
+ATOM   2506 C CB    . LYS B 4 147 . 20.544  33.757 -14.395 1.00 23.23 147 LYS B CB    1
+ATOM   2507 O O     . LYS B 4 147 . 22.161  34.510 -11.589 1.00 24.62 147 LYS B O     1
+ATOM   2508 C CG    . LYS B 4 147 . 21.173  35.081 -14.759 1.00 25.60 147 LYS B CG    1
+ATOM   2509 C CD    . LYS B 4 147 . 20.346  35.694 -15.816 1.00 31.19 147 LYS B CD    1
+ATOM   2510 C CE    . LYS B 4 147 . 20.911  37.026 -16.230 1.00 36.61 147 LYS B CE    1
+ATOM   2511 N NZ    . LYS B 4 147 . 22.152  36.887 -16.980 1.00 40.61 147 LYS B NZ    1
+ATOM   2512 N N     . THR B 4 148 . 20.015  33.874 -11.404 1.00 21.90 148 THR B N     1
+ATOM   2513 C CA    . THR B 4 148 . 19.879  34.640 -10.191 1.00 23.08 148 THR B CA    1
+ATOM   2514 C C     . THR B 4 148 . 20.169  33.818 -8.925  1.00 24.38 148 THR B C     1
+ATOM   2515 C CB    . THR B 4 148 . 18.432  35.298 -10.143 1.00 24.11 148 THR B CB    1
+ATOM   2516 O O     . THR B 4 148 . 20.218  34.408 -7.841  1.00 24.35 148 THR B O     1
+ATOM   2517 C CG2   . THR B 4 148 . 18.065  36.056 -11.396 1.00 24.15 148 THR B CG2   1
+ATOM   2518 O OG1   . THR B 4 148 . 17.482  34.281 -9.998  1.00 26.09 148 THR B OG1   1
+ATOM   2519 N N     . ARG B 4 149 . 20.443  32.500 -9.013  1.00 19.04 149 ARG B N     1
+ATOM   2520 C CA    . ARG B 4 149 . 20.593  31.584 -7.891  1.00 19.12 149 ARG B CA    1
+ATOM   2521 C C     . ARG B 4 149 . 19.252  31.304 -7.189  1.00 19.74 149 ARG B C     1
+ATOM   2522 C CB    . ARG B 4 149 . 21.615  32.113 -6.850  1.00 18.84 149 ARG B CB    1
+ATOM   2523 O O     . ARG B 4 149 . 19.176  30.675 -6.126  1.00 20.42 149 ARG B O     1
+ATOM   2524 C CG    . ARG B 4 149 . 22.313  30.980 -6.122  1.00 20.30 149 ARG B CG    1
+ATOM   2525 C CD    . ARG B 4 149 . 23.474  31.408 -5.239  1.00 21.64 149 ARG B CD    1
+ATOM   2526 N NE    . ARG B 4 149 . 24.410  30.301 -5.009  1.00 25.63 149 ARG B NE    1
+ATOM   2527 N NH1   . ARG B 4 149 . 23.349  29.617 -3.068  1.00 25.82 149 ARG B NH1   1
+ATOM   2528 N NH2   . ARG B 4 149 . 25.233  28.491 -3.774  1.00 25.98 149 ARG B NH2   1
+ATOM   2529 C CZ    . ARG B 4 149 . 24.328  29.473 -3.952  1.00 26.14 149 ARG B CZ    1
+ATOM   2530 N N     . GLN B 4 150 . 18.151  31.779 -7.797  1.00 20.02 150 GLN B N     1
+ATOM   2531 C CA    . GLN B 4 150 . 16.799  31.494 -7.336  1.00 17.94 150 GLN B CA    1
+ATOM   2532 C C     . GLN B 4 150 . 16.569  29.995 -7.415  1.00 14.12 150 GLN B C     1
+ATOM   2533 C CB    . GLN B 4 150 . 15.770  32.174 -8.219  1.00 22.20 150 GLN B CB    1
+ATOM   2534 O O     . GLN B 4 150 . 16.745  29.355 -8.453  1.00 15.86 150 GLN B O     1
+ATOM   2535 C CG    . GLN B 4 150 . 14.839  33.079 -7.444  1.00 29.43 150 GLN B CG    1
+ATOM   2536 C CD    . GLN B 4 150 . 13.462  32.504 -7.171  1.00 34.51 150 GLN B CD    1
+ATOM   2537 N NE2   . GLN B 4 150 . 13.250  31.640 -6.165  1.00 38.03 150 GLN B NE2   1
+ATOM   2538 O OE1   . GLN B 4 150 . 12.517  32.866 -7.870  1.00 34.61 150 GLN B OE1   1
+ATOM   2539 N N     . GLY B 4 151 . 16.269  29.423 -6.265  1.00 12.15 151 GLY B N     1
+ATOM   2540 C CA    . GLY B 4 151 . 15.969  28.013 -6.134  1.00 10.31 151 GLY B CA    1
+ATOM   2541 C C     . GLY B 4 151 . 17.108  26.994 -6.248  1.00 9.62  151 GLY B C     1
+ATOM   2542 O O     . GLY B 4 151 . 16.816  25.804 -6.048  1.00 7.72  151 GLY B O     1
+ATOM   2543 N N     . VAL B 4 152 . 18.385  27.335 -6.509  1.00 11.67 152 VAL B N     1
+ATOM   2544 C CA    . VAL B 4 152 . 19.353  26.277 -6.727  1.00 10.80 152 VAL B CA    1
+ATOM   2545 C C     . VAL B 4 152 . 19.635  25.477 -5.441  1.00 10.74 152 VAL B C     1
+ATOM   2546 C CB    . VAL B 4 152 . 20.718  26.854 -7.410  1.00 12.11 152 VAL B CB    1
+ATOM   2547 O O     . VAL B 4 152 . 19.505  24.255 -5.542  1.00 11.26 152 VAL B O     1
+ATOM   2548 C CG1   . VAL B 4 152 . 20.370  27.978 -8.380  1.00 9.61  152 VAL B CG1   1
+ATOM   2549 C CG2   . VAL B 4 152 . 21.711  27.362 -6.410  1.00 16.14 152 VAL B CG2   1
+ATOM   2550 N N     . GLU B 4 153 . 19.943  25.968 -4.223  1.00 9.78  153 GLU B N     1
+ATOM   2551 C CA    . GLU B 4 153 . 20.157  25.105 -3.036  1.00 13.69 153 GLU B CA    1
+ATOM   2552 C C     . GLU B 4 153 . 18.899  24.337 -2.647  1.00 13.06 153 GLU B C     1
+ATOM   2553 C CB    . GLU B 4 153 . 20.571  25.921 -1.820  1.00 15.97 153 GLU B CB    1
+ATOM   2554 O O     . GLU B 4 153 . 18.921  23.218 -2.127  1.00 11.99 153 GLU B O     1
+ATOM   2555 C CG    . GLU B 4 153 . 21.998  26.491 -1.851  1.00 19.02 153 GLU B CG    1
+ATOM   2556 C CD    . GLU B 4 153 . 22.288  27.624 -0.837  1.00 22.78 153 GLU B CD    1
+ATOM   2557 O OE1   . GLU B 4 153 . 21.398  28.424 -0.548  1.00 26.10 153 GLU B OE1   1
+ATOM   2558 O OE2   . GLU B 4 153 . 23.412  27.752 -0.357  1.00 21.79 153 GLU B OE2   1
+ATOM   2559 N N     . ASP B 4 154 . 17.762  24.974 -2.918  1.00 14.79 154 ASP B N     1
+ATOM   2560 C CA    . ASP B 4 154 . 16.450  24.390 -2.758  1.00 15.79 154 ASP B CA    1
+ATOM   2561 C C     . ASP B 4 154 . 16.286  23.088 -3.550  1.00 15.19 154 ASP B C     1
+ATOM   2562 C CB    . ASP B 4 154 . 15.491  25.410 -3.219  1.00 21.20 154 ASP B CB    1
+ATOM   2563 O O     . ASP B 4 154 . 16.055  22.010 -2.981  1.00 18.48 154 ASP B O     1
+ATOM   2564 C CG    . ASP B 4 154 . 14.201  25.484 -2.455  1.00 25.70 154 ASP B CG    1
+ATOM   2565 O OD1   . ASP B 4 154 . 14.227  25.960 -1.333  1.00 29.77 154 ASP B OD1   1
+ATOM   2566 O OD2   . ASP B 4 154 . 13.166  25.145 -3.013  1.00 28.55 154 ASP B OD2   1
+ATOM   2567 N N     . ALA B 4 155 . 16.397  23.162 -4.879  1.00 13.79 155 ALA B N     1
+ATOM   2568 C CA    . ALA B 4 155 . 16.391  21.994 -5.751  1.00 6.66  155 ALA B CA    1
+ATOM   2569 C C     . ALA B 4 155 . 17.368  20.943 -5.252  1.00 10.59 155 ALA B C     1
+ATOM   2570 C CB    . ALA B 4 155 . 16.823  22.359 -7.161  1.00 13.44 155 ALA B CB    1
+ATOM   2571 O O     . ALA B 4 155 . 16.970  19.810 -5.072  1.00 10.68 155 ALA B O     1
+ATOM   2572 N N     . PHE B 4 156 . 18.637  21.261 -4.961  1.00 15.94 156 PHE B N     1
+ATOM   2573 C CA    . PHE B 4 156 . 19.629  20.292 -4.462  1.00 12.73 156 PHE B CA    1
+ATOM   2574 C C     . PHE B 4 156 . 19.364  19.784 -3.036  1.00 12.73 156 PHE B C     1
+ATOM   2575 C CB    . PHE B 4 156 . 21.034  20.928 -4.552  1.00 12.43 156 PHE B CB    1
+ATOM   2576 O O     . PHE B 4 156 . 19.544  18.593 -2.813  1.00 13.37 156 PHE B O     1
+ATOM   2577 C CG    . PHE B 4 156 . 21.712  20.913 -5.960  1.00 13.21 156 PHE B CG    1
+ATOM   2578 C CD1   . PHE B 4 156 . 22.429  19.783 -6.385  1.00 10.26 156 PHE B CD1   1
+ATOM   2579 C CD2   . PHE B 4 156 . 21.667  22.034 -6.794  1.00 9.23  156 PHE B CD2   1
+ATOM   2580 C CE1   . PHE B 4 156 . 23.083  19.782 -7.614  1.00 10.17 156 PHE B CE1   1
+ATOM   2581 C CE2   . PHE B 4 156 . 22.327  22.024 -8.015  1.00 10.02 156 PHE B CE2   1
+ATOM   2582 C CZ    . PHE B 4 156 . 23.040  20.900 -8.431  1.00 7.46  156 PHE B CZ    1
+ATOM   2583 N N     . TYR B 4 157 . 18.912  20.574 -2.038  1.00 13.64 157 TYR B N     1
+ATOM   2584 C CA    . TYR B 4 157 . 18.666  20.060 -0.702  1.00 10.09 157 TYR B CA    1
+ATOM   2585 C C     . TYR B 4 157 . 17.437  19.220 -0.642  1.00 10.41 157 TYR B C     1
+ATOM   2586 C CB    . TYR B 4 157 . 18.502  21.158 0.255   1.00 13.41 157 TYR B CB    1
+ATOM   2587 O O     . TYR B 4 157 . 17.424  18.187 0.039   1.00 8.74  157 TYR B O     1
+ATOM   2588 C CG    . TYR B 4 157 . 19.770  21.925 0.536   1.00 13.86 157 TYR B CG    1
+ATOM   2589 C CD1   . TYR B 4 157 . 20.971  21.580 -0.064  1.00 18.91 157 TYR B CD1   1
+ATOM   2590 C CD2   . TYR B 4 157 . 19.699  22.993 1.413   1.00 15.24 157 TYR B CD2   1
+ATOM   2591 C CE1   . TYR B 4 157 . 22.107  22.307 0.198   1.00 18.77 157 TYR B CE1   1
+ATOM   2592 C CE2   . TYR B 4 157 . 20.836  23.712 1.686   1.00 18.05 157 TYR B CE2   1
+ATOM   2593 O OH    . TYR B 4 157 . 23.138  24.089 1.336   1.00 19.96 157 TYR B OH    1
+ATOM   2594 C CZ    . TYR B 4 157 . 22.014  23.361 1.078   1.00 17.38 157 TYR B CZ    1
+ATOM   2595 N N     . THR B 4 158 . 16.438  19.626 -1.444  1.00 12.84 158 THR B N     1
+ATOM   2596 C CA    . THR B 4 158 . 15.219  18.838 -1.587  1.00 13.60 158 THR B CA    1
+ATOM   2597 C C     . THR B 4 158 . 15.563  17.423 -2.029  1.00 13.77 158 THR B C     1
+ATOM   2598 C CB    . THR B 4 158 . 14.256  19.512 -2.615  1.00 12.52 158 THR B CB    1
+ATOM   2599 O O     . THR B 4 158 . 15.039  16.454 -1.462  1.00 12.56 158 THR B O     1
+ATOM   2600 C CG2   . THR B 4 158 . 13.033  18.714 -3.003  1.00 11.07 158 THR B CG2   1
+ATOM   2601 O OG1   . THR B 4 158 . 13.855  20.704 -1.981  1.00 9.58  158 THR B OG1   1
+ATOM   2602 N N     . LEU B 4 159 . 16.475  17.288 -3.004  1.00 13.78 159 LEU B N     1
+ATOM   2603 C CA    . LEU B 4 159 . 16.865  15.963 -3.470  1.00 11.21 159 LEU B CA    1
+ATOM   2604 C C     . LEU B 4 159 . 17.626  15.245 -2.354  1.00 8.24  159 LEU B C     1
+ATOM   2605 C CB    . LEU B 4 159 . 17.750  16.044 -4.721  1.00 5.93  159 LEU B CB    1
+ATOM   2606 O O     . LEU B 4 159 . 17.330  14.094 -2.125  1.00 8.72  159 LEU B O     1
+ATOM   2607 C CG    . LEU B 4 159 . 18.185  14.692 -5.355  1.00 11.33 159 LEU B CG    1
+ATOM   2608 C CD1   . LEU B 4 159 . 16.982  13.866 -5.720  1.00 10.10 159 LEU B CD1   1
+ATOM   2609 C CD2   . LEU B 4 159 . 19.029  14.964 -6.605  1.00 10.02 159 LEU B CD2   1
+ATOM   2610 N N     . VAL B 4 160 . 18.601  15.799 -1.639  1.00 12.54 160 VAL B N     1
+ATOM   2611 C CA    . VAL B 4 160 . 19.198  15.096 -0.506  1.00 14.56 160 VAL B CA    1
+ATOM   2612 C C     . VAL B 4 160 . 18.088  14.647 0.500   1.00 13.87 160 VAL B C     1
+ATOM   2613 C CB    . VAL B 4 160 . 20.235  16.057 0.144   1.00 10.27 160 VAL B CB    1
+ATOM   2614 O O     . VAL B 4 160 . 18.186  13.537 1.012   1.00 16.41 160 VAL B O     1
+ATOM   2615 C CG1   . VAL B 4 160 . 20.646  15.553 1.531   1.00 12.21 160 VAL B CG1   1
+ATOM   2616 C CG2   . VAL B 4 160 . 21.453  16.171 -0.752  1.00 10.25 160 VAL B CG2   1
+ATOM   2617 N N     . ARG B 4 161 . 17.038  15.399 0.868   1.00 10.97 161 ARG B N     1
+ATOM   2618 C CA    . ARG B 4 161 . 16.037  14.889 1.786   1.00 11.89 161 ARG B CA    1
+ATOM   2619 C C     . ARG B 4 161 . 15.178  13.780 1.183   1.00 14.30 161 ARG B C     1
+ATOM   2620 C CB    . ARG B 4 161 . 15.164  16.053 2.252   1.00 17.63 161 ARG B CB    1
+ATOM   2621 O O     . ARG B 4 161 . 14.625  12.943 1.912   1.00 15.58 161 ARG B O     1
+ATOM   2622 C CG    . ARG B 4 161 . 15.971  16.917 3.210   1.00 18.69 161 ARG B CG    1
+ATOM   2623 C CD    . ARG B 4 161 . 15.230  18.057 3.883   1.00 23.57 161 ARG B CD    1
+ATOM   2624 N NE    . ARG B 4 161 . 14.957  19.151 2.986   1.00 24.73 161 ARG B NE    1
+ATOM   2625 N NH1   . ARG B 4 161 . 16.460  20.653 3.998   1.00 20.57 161 ARG B NH1   1
+ATOM   2626 N NH2   . ARG B 4 161 . 15.181  21.278 2.200   1.00 21.96 161 ARG B NH2   1
+ATOM   2627 C CZ    . ARG B 4 161 . 15.542  20.355 3.086   1.00 23.78 161 ARG B CZ    1
+ATOM   2628 N N     . GLU B 4 162 . 15.023  13.701 -0.147  1.00 13.61 162 GLU B N     1
+ATOM   2629 C CA    . GLU B 4 162 . 14.312  12.587 -0.777  1.00 15.14 162 GLU B CA    1
+ATOM   2630 C C     . GLU B 4 162 . 15.109  11.313 -0.571  1.00 12.85 162 GLU B C     1
+ATOM   2631 C CB    . GLU B 4 162 . 14.146  12.778 -2.300  1.00 17.49 162 GLU B CB    1
+ATOM   2632 O O     . GLU B 4 162 . 14.528  10.254 -0.332  1.00 14.53 162 GLU B O     1
+ATOM   2633 C CG    . GLU B 4 162 . 13.283  13.929 -2.737  1.00 16.17 162 GLU B CG    1
+ATOM   2634 C CD    . GLU B 4 162 . 11.843  13.721 -2.317  1.00 20.39 162 GLU B CD    1
+ATOM   2635 O OE1   . GLU B 4 162 . 11.158  12.860 -2.861  1.00 24.09 162 GLU B OE1   1
+ATOM   2636 O OE2   . GLU B 4 162 . 11.383  14.409 -1.420  1.00 21.88 162 GLU B OE2   1
+ATOM   2637 N N     . ILE B 4 163 . 16.446  11.391 -0.655  1.00 11.78 163 ILE B N     1
+ATOM   2638 C CA    . ILE B 4 163 . 17.271  10.204 -0.489  1.00 12.76 163 ILE B CA    1
+ATOM   2639 C C     . ILE B 4 163 . 17.170  9.764  0.964   1.00 19.76 163 ILE B C     1
+ATOM   2640 C CB    . ILE B 4 163 . 18.721  10.476 -0.826  1.00 11.66 163 ILE B CB    1
+ATOM   2641 O O     . ILE B 4 163 . 17.045  8.559  1.253   1.00 22.54 163 ILE B O     1
+ATOM   2642 C CG1   . ILE B 4 163 . 18.848  10.848 -2.310  1.00 6.69  163 ILE B CG1   1
+ATOM   2643 C CG2   . ILE B 4 163 . 19.561  9.231  -0.455  1.00 8.19  163 ILE B CG2   1
+ATOM   2644 C CD1   . ILE B 4 163 . 20.173  11.603 -2.625  1.00 7.92  163 ILE B CD1   1
+ATOM   2645 N N     . ARG B 4 164 . 17.228  10.725 1.898   1.00 20.40 164 ARG B N     1
+ATOM   2646 C CA    . ARG B 4 164 . 16.985  10.466 3.323   1.00 19.18 164 ARG B CA    1
+ATOM   2647 C C     . ARG B 4 164 . 15.677  9.708  3.623   1.00 19.38 164 ARG B C     1
+ATOM   2648 C CB    . ARG B 4 164 . 16.966  11.790 4.059   1.00 16.56 164 ARG B CB    1
+ATOM   2649 O O     . ARG B 4 164 . 15.653  8.709  4.322   1.00 17.51 164 ARG B O     1
+ATOM   2650 C CG    . ARG B 4 164 . 18.376  12.266 4.043   1.00 18.30 164 ARG B CG    1
+ATOM   2651 C CD    . ARG B 4 164 . 18.719  12.728 5.422   1.00 19.04 164 ARG B CD    1
+ATOM   2652 N NE    . ARG B 4 164 . 18.273  14.082 5.562   1.00 17.19 164 ARG B NE    1
+ATOM   2653 N NH1   . ARG B 4 164 . 20.412  15.146 5.474   1.00 18.28 164 ARG B NH1   1
+ATOM   2654 N NH2   . ARG B 4 164 . 18.452  16.309 5.697   1.00 11.33 164 ARG B NH2   1
+ATOM   2655 C CZ    . ARG B 4 164 . 19.075  15.151 5.565   1.00 16.83 164 ARG B CZ    1
+ATOM   2656 N N     . GLN B 4 165 . 14.564  10.166 3.047   1.00 22.82 165 GLN B N     1
+ATOM   2657 C CA    . GLN B 4 165 . 13.249  9.618  3.291   1.00 23.58 165 GLN B CA    1
+ATOM   2658 C C     . GLN B 4 165 . 12.955  8.350  2.473   1.00 24.93 165 GLN B C     1
+ATOM   2659 C CB    . GLN B 4 165 . 12.314  10.851 3.051   1.00 25.17 165 GLN B CB    1
+ATOM   2660 O O     . GLN B 4 165 . 11.901  7.727  2.636   1.00 28.14 165 GLN B O     1
+ATOM   2661 C CG    . GLN B 4 165 . 12.449  11.898 4.246   1.00 26.24 165 GLN B CG    1
+ATOM   2662 C CD    . GLN B 4 165 . 12.795  13.412 4.082   1.00 26.62 165 GLN B CD    1
+ATOM   2663 N NE2   . GLN B 4 165 . 13.704  14.011 4.882   1.00 22.90 165 GLN B NE2   1
+ATOM   2664 O OE1   . GLN B 4 165 . 12.206  14.147 3.282   1.00 26.70 165 GLN B OE1   1
+ATOM   2665 N N     . HIS B 4 166 . 13.919  7.863  1.671   1.00 21.62 166 HIS B N     1
+ATOM   2666 C CA    . HIS B 4 166 . 13.737  6.673  0.850   1.00 21.37 166 HIS B CA    1
+ATOM   2667 C C     . HIS B 4 166 . 13.844  5.338  1.609   1.00 19.47 166 HIS B C     1
+ATOM   2668 C CB    . HIS B 4 166 . 14.755  6.704  -0.328  1.00 17.56 166 HIS B CB    1
+ATOM   2669 O O     . HIS B 4 166 . 14.554  5.249  2.603   1.00 21.43 166 HIS B O     1
+ATOM   2670 C CG    . HIS B 4 166 . 14.527  5.613  -1.384  1.00 19.13 166 HIS B CG    1
+ATOM   2671 C CD2   . HIS B 4 166 . 13.408  5.511  -2.175  1.00 20.04 166 HIS B CD2   1
+ATOM   2672 N ND1   . HIS B 4 166 . 15.280  4.544  -1.682  1.00 18.96 166 HIS B ND1   1
+ATOM   2673 C CE1   . HIS B 4 166 . 14.671  3.817  -2.584  1.00 13.05 166 HIS B CE1   1
+ATOM   2674 N NE2   . HIS B 4 166 . 13.555  4.407  -2.869  1.00 16.04 166 HIS B NE2   1
+ATOM   2675 O OXT   . HIS B 4 166 . 13.168  4.387  1.214   1.00 19.69 166 HIS B OXT   1
+HETATM 2676 M MG    . MG  B 4 167 . 26.913  20.907 -19.192 1.00 16.19 167 MG  B MG    1
+HETATM 2677 P PG    . GNP B 4 168 . 25.191  20.494 -22.021 1.00 9.27  168 GNP B PG    1
+HETATM 2678 O O1G   . GNP B 4 168 . 25.650  20.466 -23.420 1.00 17.15 168 GNP B O1G   1
+HETATM 2679 O O2G   . GNP B 4 168 . 26.199  19.947 -21.132 1.00 9.55  168 GNP B O2G   1
+HETATM 2680 O O3G   . GNP B 4 168 . 24.130  19.303 -21.973 1.00 10.53 168 GNP B O3G   1
+HETATM 2681 N N3B   . GNP B 4 168 . 24.445  21.906 -21.582 1.00 8.97  168 GNP B N3B   1
+HETATM 2682 P PB    . GNP B 4 168 . 23.948  22.265 -20.024 1.00 9.99  168 GNP B PB    1
+HETATM 2683 O O1B   . GNP B 4 168 . 22.649  21.695 -19.680 1.00 7.09  168 GNP B O1B   1
+HETATM 2684 O O2B   . GNP B 4 168 . 24.917  22.046 -18.959 1.00 8.52  168 GNP B O2B   1
+HETATM 2685 O O3A   . GNP B 4 168 . 23.750  23.842 -19.980 1.00 6.32  168 GNP B O3A   1
+HETATM 2686 P PA    . GNP B 4 168 . 24.817  25.029 -19.557 1.00 10.47 168 GNP B PA    1
+HETATM 2687 O O1A   . GNP B 4 168 . 24.803  25.195 -18.100 1.00 10.38 168 GNP B O1A   1
+HETATM 2688 O O2A   . GNP B 4 168 . 26.110  24.923 -20.303 1.00 11.77 168 GNP B O2A   1
+HETATM 2689 O 'O5'' . GNP B 4 168 . 24.039  26.286 -20.117 1.00 10.69 168 GNP B 'O5'' 1
+HETATM 2690 C 'C5'' . GNP B 4 168 . 23.678  26.500 -21.476 1.00 9.95  168 GNP B 'C5'' 1
+HETATM 2691 C 'C4'' . GNP B 4 168 . 23.340  27.974 -21.659 1.00 12.11 168 GNP B 'C4'' 1
+HETATM 2692 O 'O4'' . GNP B 4 168 . 22.200  28.389 -20.870 1.00 10.56 168 GNP B 'O4'' 1
+HETATM 2693 C 'C3'' . GNP B 4 168 . 24.512  28.871 -21.239 1.00 12.63 168 GNP B 'C3'' 1
+HETATM 2694 O 'O3'' . GNP B 4 168 . 24.628  30.003 -22.086 1.00 13.41 168 GNP B 'O3'' 1
+HETATM 2695 C 'C2'' . GNP B 4 168 . 24.082  29.340 -19.868 1.00 10.98 168 GNP B 'C2'' 1
+HETATM 2696 O 'O2'' . GNP B 4 168 . 24.723  30.566 -19.511 1.00 10.96 168 GNP B 'O2'' 1
+HETATM 2697 C 'C1'' . GNP B 4 168 . 22.562  29.510 -20.069 1.00 10.70 168 GNP B 'C1'' 1
+HETATM 2698 N N9    . GNP B 4 168 . 21.844  29.282 -18.803 1.00 13.20 168 GNP B N9    1
+HETATM 2699 C C8    . GNP B 4 168 . 21.940  28.208 -17.932 1.00 8.66  168 GNP B C8    1
+HETATM 2700 N N7    . GNP B 4 168 . 21.154  28.266 -16.903 1.00 14.05 168 GNP B N7    1
+HETATM 2701 C C5    . GNP B 4 168 . 20.507  29.487 -17.073 1.00 10.73 168 GNP B C5    1
+HETATM 2702 C C6    . GNP B 4 168 . 19.514  30.088 -16.305 1.00 11.14 168 GNP B C6    1
+HETATM 2703 O O6    . GNP B 4 168 . 19.067  29.745 -15.239 1.00 13.80 168 GNP B O6    1
+HETATM 2704 N N1    . GNP B 4 168 . 19.054  31.238 -16.874 1.00 12.41 168 GNP B N1    1
+HETATM 2705 C C2    . GNP B 4 168 . 19.525  31.814 -18.030 1.00 11.82 168 GNP B C2    1
+HETATM 2706 N N2    . GNP B 4 168 . 19.028  33.018 -18.341 1.00 15.41 168 GNP B N2    1
+HETATM 2707 N N3    . GNP B 4 168 . 20.447  31.247 -18.789 1.00 10.31 168 GNP B N3    1
+HETATM 2708 C C4    . GNP B 4 168 . 20.903  30.103 -18.242 1.00 11.85 168 GNP B C4    1
+#

--- a/tests/test_input.py
+++ b/tests/test_input.py
@@ -262,9 +262,9 @@ def test_pdbinput_input():
     # visualizing
 
     mmcif_writing.write_mmcif_from_filepath_and_id(
-        filepath=filepath,
+        input_filepath=filepath,
+        output_filepath=filepath.replace(".cif", "-sampled.cif"),
         file_id=file_id,
-        suffix="sampled",
         gapless_poly_seq=True,
         insert_orig_atom_names=True,
         insert_alphafold_mmcif_metadata=True,


### PR DESCRIPTION
* Adds the code necessary for running overfitting experiments with the AF3 PDB mmCIF training dataset
* First overfitting experiment is running now locally (on two training dataset mmCIFs: `209d-assembly1` (a hybrid DNA-RNA-ligand complex also with modified amino acid residues) and `721p-assembly1` (a two-chain protein-ligand complex)