### PR TITLE
Fix `OXT` parsing bug for amino acids, and add new subsetting options

### DIFF
--- a/alphafold3_pytorch/common/amino_acid_constants.py
+++ b/alphafold3_pytorch/common/amino_acid_constants.py
@@ -44,7 +44,8 @@ atom_types = [
     "CZ2",
     "CZ3",
     "NZ",
-    "OXT",
+    # "OXT",  # NOTE: This often appears in mmCIF files, but it will not be used for any amino acid type in AlphaFold.
+    "_",
     "_",
     "_",
     "_",

--- a/alphafold3_pytorch/inputs.py
+++ b/alphafold3_pytorch/inputs.py
@@ -2566,6 +2566,13 @@ def pdb_input_to_molecule_input(
     assert len(molecules) == len(missing_atom_indices)
     assert len(missing_token_indices) == num_tokens
 
+    mol_total_atoms = sum([mol.GetNumAtoms() for mol in molecules])
+    num_missing_atom_indices = sum(
+        len(mol_miss_atom_indices) for mol_miss_atom_indices in missing_atom_indices
+    )
+    num_present_atoms = mol_total_atoms - num_missing_atom_indices
+    assert num_present_atoms == int(biomol.atom_mask.sum())
+
     # TODO: install additional token features once MSAs are available
     # 0: f_profile
     # 1: f_deletion_mean


### PR DESCRIPTION
* Fixes an `OXT` parsing bug for amino acids
* Adds new subsetting options for the `WeightedPDBSampler`