### PR TITLE
Potential Bug Fix: AlphaFold3Input_to_Molecule_Lengthed_MolInput  ordering

### DIFF
--- a/alphafold3_pytorch/inputs.py
+++ b/alphafold3_pytorch/inputs.py
@@ -1410,13 +1410,6 @@ def alphafold3_input_to_molecule_lengthed_molecule_input(alphafold3_input: Alpha
 
         chainable_biomol_entries.append(ss_dna_entries)
 
-    # convert metal ions to rdchem.Mol
-
-    metal_ions = alphafold3_input.metal_ions
-    mol_metal_ions = map_int_or_string_indices_to_mol(METALS, metal_ions)
-
-    molecule_ids.append(tensor([MOLECULE_METAL_ION_ID] * len(mol_metal_ions)))
-
     # convert ligands to rdchem.Mol
 
     ligands = list(alphafold3_input.ligands)
@@ -1425,6 +1418,13 @@ def alphafold3_input_to_molecule_lengthed_molecule_input(alphafold3_input: Alpha
     ]
 
     molecule_ids.append(tensor([ligand_id] * len(mol_ligands)))
+    
+    # convert metal ions to rdchem.Mol
+
+    metal_ions = alphafold3_input.metal_ions
+    mol_metal_ions = map_int_or_string_indices_to_mol(METALS, metal_ions)
+
+    molecule_ids.append(tensor([MOLECULE_METAL_ION_ID] * len(mol_metal_ions)))
 
     # create the molecule input
 


### PR DESCRIPTION
Noticed a potential bug in the alphafold3input to atom input function composition which may be of importance to prediction of arbitrary biomolecular inputs. 

As currently implemented the AlphaFold3Input to Batched Atom Input for the Test Input:

```
alphafold3_input = Alphafold3Input(
        proteins = ['MLEICLKLVGCKSKKGLSSSSSCYLEEALQRPVASDF', 'MGKCRGLRTARKLRSHRRDQKWHDKQYKKAHLGTALKANPFGGASHAKGIVLEKVGVEAKQPNSAIRKCVRVQLIKNGKKITAFVPNDGCLNFIEENDEVLVAGFGRKGHAVGDIPGVRFKVVKVANVSLLALYKGKKERPRS'],
        ds_dna = ['ACGTT'],
        ds_rna = ['GCCAU', 'CCAGU'],
        ss_dna = ['GCCTA'],
        ss_rna = ['CGCAUA'],
        metal_ions = ['Na', 'Na', 'Fe'],
        misc_molecule_ids = ['Phospholipid'],
        ligands = ['CC1=C(C=C(C=C1)NC(=O)C2=CC=C(C=C2)CN3CCN(CC3)C)NC4=NC=CC(=N4)C5=CN=CC=C5'],
        add_atom_ids = True,
        add_atompair_ids = True,
        directed_bonds = directed_bonds
    )
```

Returns molecule_ids:

```
tensor([[12, 10,  6,  9,  4, 10, 11, 10, 19,  7,  4, 11, 15, 11, 11,  7, 10, 15,
         15, 15, 15, 15,  4, 18, 10,  6,  6,  0, 10,  5,  1, 14, 19,  0, 15,  3,
         13, 12,  7, 11,  4,  1,  7, 10,  1, 16,  0,  1, 11, 10,  1, 15,  8,  1,
          1,  3,  5, 11, 17,  8,  3, 11,  5, 18, 11, 11,  0,  8, 10,  7, 16,  0,
         10, 11,  0,  2, 14, 13,  7,  7,  0, 15,  8,  0, 11,  7,  9, 19, 10,  6,
         11, 19,  7, 19,  6,  0, 11,  5, 14,  2, 15,  0,  9,  1, 11,  4, 19,  1,
         19,  5, 10,  9, 11,  2,  7, 11, 11,  9, 16,  0, 13, 19, 14,  2,  3,  7,
          4, 10,  2, 13,  9,  6,  6,  2,  3,  6, 19, 10, 19,  0,  7, 13,  7,  1,
         11,  7,  8,  0, 19,  7,  3,  9, 14,  7, 19,  1, 13, 11, 19, 19, 11, 19,
          0,  2, 19, 15, 10, 10,  0, 10, 18, 11,  7, 11, 11,  6,  1, 14,  1, 15,
         22, 23, 22, 21, 24, 21, 23, 22, 22, 21, 24, 21, 24, 23, 23, 22, 22, 22,
         21, 23, 24, 21, 22, 24, 23, 23, 28, 27, 27, 29, 26, 26, 27, 28, 29, 29,
         26, 26, 27, 28, 29, 32, 32, 32, 32, 32, 32, 32, 32, 32, 32, 32, 32, 32,
         32, 32, 32, 32, 32, 32, 32, 32, 32, 32, 32, 32, 32, 32, 32, 32, 32, 32,
         32, 32, 32, 32, 32, 32, 32, 32, 20]])
```

Where the metal ion has been repeated by (GetNumAtoms() times for the Ligand's atoms).

The switched order in the PR returns the desired molecule_ids:

```
tensor([12, 10,  6,  9,  4, 10, 11, 10, 19,  7,  4, 11, 15, 11, 11,  7, 10, 15,
        15, 15, 15, 15,  4, 18, 10,  6,  6,  0, 10,  5,  1, 14, 19,  0, 15,  3,
        13, 12,  7, 11,  4,  1,  7, 10,  1, 16,  0,  1, 11, 10,  1, 15,  8,  1,
         1,  3,  5, 11, 17,  8,  3, 11,  5, 18, 11, 11,  0,  8, 10,  7, 16,  0,
        10, 11,  0,  2, 14, 13,  7,  7,  0, 15,  8,  0, 11,  7,  9, 19, 10,  6,
        11, 19,  7, 19,  6,  0, 11,  5, 14,  2, 15,  0,  9,  1, 11,  4, 19,  1,
        19,  5, 10,  9, 11,  2,  7, 11, 11,  9, 16,  0, 13, 19, 14,  2,  3,  7,
         4, 10,  2, 13,  9,  6,  6,  2,  3,  6, 19, 10, 19,  0,  7, 13,  7,  1,
        11,  7,  8,  0, 19,  7,  3,  9, 14,  7, 19,  1, 13, 11, 19, 19, 11, 19,
         0,  2, 19, 15, 10, 10,  0, 10, 18, 11,  7, 11, 11,  6,  1, 14,  1, 15,
        22, 23, 22, 21, 24, 21, 23, 22, 22, 21, 24, 21, 24, 23, 23, 22, 22, 22,
        21, 23, 24, 21, 22, 24, 23, 23, 28, 27, 27, 29, 26, 26, 27, 28, 29, 29,
        26, 26, 27, 28, 29, 20, 20, 20, 20, 20, 20, 20, 20, 20, 20, 20, 20, 20,
        20, 20, 20, 20, 20, 20, 20, 20, 20, 20, 20, 20, 20, 20, 20, 20, 20, 20,
        20, 20, 20, 20, 20, 20, 32, 32, 32])
```

