### PR TITLE
Correct the `three_atom_indices_for_frame` indices

### DIFF
--- a/alphafold3_pytorch/life.py
+++ b/alphafold3_pytorch/life.py
@@ -31,7 +31,7 @@ HUMAN_AMINO_ACIDS = dict(
         last_atom_idx=4,
         distogram_atom_idx=4,
         token_center_atom_idx=1,
-        three_atom_indices_for_frame = (0, 1, 4)
+        three_atom_indices_for_frame=(0, 1, 2),
     ),
     R=dict(
         resname="ARG",
@@ -40,7 +40,7 @@ HUMAN_AMINO_ACIDS = dict(
         last_atom_idx=10,
         distogram_atom_idx=4,
         token_center_atom_idx=1,
-        three_atom_indices_for_frame = (0, 1, 10)
+        three_atom_indices_for_frame=(0, 1, 2),
     ),
     N=dict(
         resname="ASN",
@@ -49,7 +49,7 @@ HUMAN_AMINO_ACIDS = dict(
         last_atom_idx=7,
         distogram_atom_idx=4,
         token_center_atom_idx=1,
-        three_atom_indices_for_frame = (0, 1, 7)
+        three_atom_indices_for_frame=(0, 1, 2),
     ),
     D=dict(
         resname="ASP",
@@ -58,7 +58,7 @@ HUMAN_AMINO_ACIDS = dict(
         last_atom_idx=7,
         distogram_atom_idx=4,
         token_center_atom_idx=1,
-        three_atom_indices_for_frame = (0, 1, 7)
+        three_atom_indices_for_frame=(0, 1, 2),
     ),
     C=dict(
         resname="CYS",
@@ -67,7 +67,7 @@ HUMAN_AMINO_ACIDS = dict(
         last_atom_idx=5,
         distogram_atom_idx=4,
         token_center_atom_idx=1,
-        three_atom_indices_for_frame = (0, 1, 5)
+        three_atom_indices_for_frame=(0, 1, 2),
     ),
     Q=dict(
         resname="GLN",
@@ -76,7 +76,7 @@ HUMAN_AMINO_ACIDS = dict(
         last_atom_idx=8,
         distogram_atom_idx=4,
         token_center_atom_idx=1,
-        three_atom_indices_for_frame = (0, 1, 8)
+        three_atom_indices_for_frame=(0, 1, 2),
     ),
     E=dict(
         resname="GLU",
@@ -85,7 +85,7 @@ HUMAN_AMINO_ACIDS = dict(
         last_atom_idx=8,
         distogram_atom_idx=4,
         token_center_atom_idx=1,
-        three_atom_indices_for_frame = (0, 1, 8)
+        three_atom_indices_for_frame=(0, 1, 2),
     ),
     G=dict(
         resname="GLY",
@@ -94,7 +94,7 @@ HUMAN_AMINO_ACIDS = dict(
         last_atom_idx=3,
         distogram_atom_idx=1,
         token_center_atom_idx=1,
-        three_atom_indices_for_frame = (0, 1, 3)
+        three_atom_indices_for_frame=(0, 1, 2),
     ),
     H=dict(
         resname="HIS",
@@ -103,7 +103,7 @@ HUMAN_AMINO_ACIDS = dict(
         last_atom_idx=9,
         distogram_atom_idx=4,
         token_center_atom_idx=1,
-        three_atom_indices_for_frame = (0, 1, 9)
+        three_atom_indices_for_frame=(0, 1, 2),
     ),
     I=dict(
         resname="ILE",
@@ -112,7 +112,7 @@ HUMAN_AMINO_ACIDS = dict(
         last_atom_idx=7,
         distogram_atom_idx=4,
         token_center_atom_idx=1,
-        three_atom_indices_for_frame = (0, 1, 7)
+        three_atom_indices_for_frame=(0, 1, 2),
     ),
     L=dict(
         resname="LEU",
@@ -121,7 +121,7 @@ HUMAN_AMINO_ACIDS = dict(
         last_atom_idx=7,
         distogram_atom_idx=4,
         token_center_atom_idx=1,
-        three_atom_indices_for_frame = (0, 1, 7)
+        three_atom_indices_for_frame=(0, 1, 2),
     ),
     K=dict(
         resname="LYS",
@@ -130,7 +130,7 @@ HUMAN_AMINO_ACIDS = dict(
         last_atom_idx=8,
         distogram_atom_idx=4,
         token_center_atom_idx=1,
-        three_atom_indices_for_frame = (0, 1, 8)
+        three_atom_indices_for_frame=(0, 1, 2),
     ),
     M=dict(
         resname="MET",
@@ -139,7 +139,7 @@ HUMAN_AMINO_ACIDS = dict(
         last_atom_idx=7,
         distogram_atom_idx=4,
         token_center_atom_idx=1,
-        three_atom_indices_for_frame = (0, 1, 7)
+        three_atom_indices_for_frame=(0, 1, 2),
     ),
     F=dict(
         resname="PHE",
@@ -148,7 +148,7 @@ HUMAN_AMINO_ACIDS = dict(
         last_atom_idx=10,
         distogram_atom_idx=4,
         token_center_atom_idx=1,
-        three_atom_indices_for_frame = (0, 1, 10)
+        three_atom_indices_for_frame=(0, 1, 2),
     ),
     P=dict(
         resname="PRO",
@@ -157,7 +157,7 @@ HUMAN_AMINO_ACIDS = dict(
         last_atom_idx=6,
         distogram_atom_idx=4,
         token_center_atom_idx=1,
-        three_atom_indices_for_frame = (0, 1, 6)
+        three_atom_indices_for_frame=(0, 1, 2),
     ),
     S=dict(
         resname="SER",
@@ -166,7 +166,7 @@ HUMAN_AMINO_ACIDS = dict(
         last_atom_idx=5,
         distogram_atom_idx=4,
         token_center_atom_idx=1,
-        three_atom_indices_for_frame = (0, 1, 5)
+        three_atom_indices_for_frame=(0, 1, 2),
     ),
     T=dict(
         resname="THR",
@@ -175,7 +175,7 @@ HUMAN_AMINO_ACIDS = dict(
         last_atom_idx=6,
         distogram_atom_idx=4,
         token_center_atom_idx=1,
-        three_atom_indices_for_frame = (0, 1, 6)
+        three_atom_indices_for_frame=(0, 1, 2),
     ),
     W=dict(
         resname="TRP",
@@ -184,7 +184,7 @@ HUMAN_AMINO_ACIDS = dict(
         last_atom_idx=13,
         distogram_atom_idx=4,
         token_center_atom_idx=1,
-        three_atom_indices_for_frame = (0, 1, 13)
+        three_atom_indices_for_frame=(0, 1, 2),
     ),
     Y=dict(
         resname="TYR",
@@ -193,7 +193,7 @@ HUMAN_AMINO_ACIDS = dict(
         last_atom_idx=11,
         distogram_atom_idx=4,
         token_center_atom_idx=1,
-        three_atom_indices_for_frame = (0, 1, 11)
+        three_atom_indices_for_frame=(0, 1, 2),
     ),
     V=dict(
         resname="VAL",
@@ -202,7 +202,7 @@ HUMAN_AMINO_ACIDS = dict(
         last_atom_idx=6,
         distogram_atom_idx=4,
         token_center_atom_idx=1,
-        three_atom_indices_for_frame = (0, 1, 6)
+        three_atom_indices_for_frame=(0, 1, 2),
     ),
     X=dict(
         resname="UNK",
@@ -211,7 +211,7 @@ HUMAN_AMINO_ACIDS = dict(
         last_atom_idx=4,
         distogram_atom_idx=4,
         token_center_atom_idx=1,
-        three_atom_indices_for_frame = None
+        three_atom_indices_for_frame=None,
     ),
 )
 
@@ -226,7 +226,7 @@ DNA_NUCLEOTIDES = dict(
         complement="T",
         distogram_atom_idx=21,
         token_center_atom_idx=11,
-        three_atom_indices_for_frame = (8, 19, 20)
+        three_atom_indices_for_frame=(11, 8, 6),
     ),
     C=dict(
         resname="DC",
@@ -236,7 +236,7 @@ DNA_NUCLEOTIDES = dict(
         complement="G",
         distogram_atom_idx=13,
         token_center_atom_idx=11,
-        three_atom_indices_for_frame = (6, 18, 17)
+        three_atom_indices_for_frame=(11, 8, 6),
     ),
     G=dict(
         resname="DG",
@@ -246,7 +246,7 @@ DNA_NUCLEOTIDES = dict(
         complement="C",
         distogram_atom_idx=22,
         token_center_atom_idx=11,
-        three_atom_indices_for_frame = (8, 9, 10)
+        three_atom_indices_for_frame=(11, 8, 6),
     ),
     T=dict(
         resname="DT",
@@ -256,7 +256,7 @@ DNA_NUCLEOTIDES = dict(
         complement="A",
         distogram_atom_idx=13,
         token_center_atom_idx=11,
-        three_atom_indices_for_frame = (6, 19, 18)
+        three_atom_indices_for_frame=(11, 8, 6),
     ),
     X=dict(
         resname="DN",
@@ -266,7 +266,7 @@ DNA_NUCLEOTIDES = dict(
         complement="N",
         distogram_atom_idx=21,
         token_center_atom_idx=11,
-        three_atom_indices_for_frame = None
+        three_atom_indices_for_frame=None,
     ),
 )
 
@@ -279,7 +279,7 @@ RNA_NUCLEOTIDES = dict(
         complement="U",
         distogram_atom_idx=22,
         token_center_atom_idx=12,
-        three_atom_indices_for_frame = (8, 19, 21)
+        three_atom_indices_for_frame=(12, 8, 6),
     ),
     C=dict(
         resname="C",
@@ -289,7 +289,7 @@ RNA_NUCLEOTIDES = dict(
         complement="G",
         distogram_atom_idx=14,
         token_center_atom_idx=12,
-        three_atom_indices_for_frame = (8, 17, 19)
+        three_atom_indices_for_frame=(12, 8, 6),
     ),
     G=dict(
         resname="G",
@@ -299,7 +299,7 @@ RNA_NUCLEOTIDES = dict(
         complement="C",
         distogram_atom_idx=23,
         token_center_atom_idx=12,
-        three_atom_indices_for_frame = (8, 20, 22)
+        three_atom_indices_for_frame=(12, 8, 6),
     ),
     U=dict(
         resname="U",
@@ -309,7 +309,7 @@ RNA_NUCLEOTIDES = dict(
         complement="A",
         distogram_atom_idx=14,
         token_center_atom_idx=12,
-        three_atom_indices_for_frame = (8, 17, 19)
+        three_atom_indices_for_frame=(12, 8, 6),
     ),
     X=dict(
         resname="N",
@@ -319,7 +319,7 @@ RNA_NUCLEOTIDES = dict(
         complement="N",
         distogram_atom_idx=22,
         token_center_atom_idx=12,
-        three_atom_indices_for_frame = None
+        three_atom_indices_for_frame=None,
     ),
 )
 


### PR DESCRIPTION
* Makes the `three_atom_indices_for_frame` indices match the polymer residue type-specific atom orderings defined in the corresponding `{amino_acid,rna,dna}_constants.py` files.
* For example, for all amino acids in these `*_constants.py` files, their `N`, `Ca`, and `C` atoms are located at indices 0, 1, and 2.
* To my best knowledge, we rely on these polymer residue type-specific atom orderings in all other places in the code (including `life.py` lower in the file).