### PR TITLE
Add MSA and resolution parsing

### DIFF
--- a/alphafold3_pytorch/data/data_pipeline.py
+++ b/alphafold3_pytorch/data/data_pipeline.py
@@ -6,12 +6,19 @@ from loguru import logger
 from typing import MutableMapping, Optional, Tuple
 
 import numpy as np
+import torch
+from torch import Tensor
 
-from alphafold3_pytorch.common.biomolecule import Biomolecule, _from_mmcif_object, to_mmcif
-from alphafold3_pytorch.data import mmcif_parsing
+from alphafold3_pytorch.common import amino_acid_constants
+from alphafold3_pytorch.common.biomolecule import (
+    Biomolecule,
+    _from_mmcif_object,
+    to_mmcif,
+)
+from alphafold3_pytorch.data import mmcif_parsing, msa_parsing
 from alphafold3_pytorch.utils.utils import exists
 
-FeatureDict = MutableMapping[str, np.ndarray]
+FeatureDict = MutableMapping[str, np.ndarray | Tensor]
 
 
 def make_sequence_features(sequence: str, description: str) -> FeatureDict:
@@ -22,9 +29,61 @@ def make_sequence_features(sequence: str, description: str) -> FeatureDict:
     return features
 
 
-def get_assembly(biomol: Biomolecule, assembly_id: Optional[str] = None) -> Biomolecule:
+def make_msa_mask(protein: FeatureDict) -> FeatureDict:
     """
-    Get a specified (Biomolecule) assembly of a given Biomolecule.
+    Make MSA mask features.
+    From: https://github.com/aqlaboratory/openfold/blob/6f63267114435f94ac0604b6d89e82ef45d94484/openfold/data/data_transforms.py#L379
+    NOTE: Openfold Mask features are all ones, but will later be zero-padded.
+
+    :param protein: The protein dictionary.
+    :return: The protein dictionary with MSA mask features.
+    """
+    # get a sequence-length mask
+    protein["msa_mask"] = torch.ones(protein["msa"].shape[1], dtype=torch.float32)
+    protein["msa_row_mask"] = torch.ones((protein["msa"].shape[0]), dtype=torch.float32)
+    return protein
+
+
+def make_msa_features(msas: dict) -> FeatureDict:
+    """
+    Construct a feature dictionary of MSA features.
+    From: https://github.com/aqlaboratory/openfold/blob/6f63267114435f94ac0604b6d89e82ef45d94484/openfold/data/data_pipeline.py#L224
+
+    :param msas: The MSA dictionary.
+    :return: The MSA feature dictionary
+    """
+    if not msas:
+        raise ValueError("At least one MSA must be provided.")
+
+    int_msa = []
+    deletion_matrix = []
+    species_ids = []
+    seen_sequences = set()
+    for msa_index, msa in enumerate(msas):
+        if not msa:
+            raise ValueError(f"MSA {msa_index} must contain at least one sequence.")
+        for sequence_index, sequence in enumerate(msa.sequences):
+            if sequence in seen_sequences:
+                continue
+            seen_sequences.add(sequence)
+            int_msa.append([amino_acid_constants.HHBLITS_AA_TO_ID[res] for res in sequence])
+
+            deletion_matrix.append(msa.deletion_matrix[sequence_index])
+            identifiers = msa_parsing.get_identifiers(msa.descriptions[sequence_index])
+            species_ids.append(identifiers.species_id.encode("utf-8"))
+
+    num_res = len(msas[0].sequences[0])
+    num_alignments = len(int_msa)
+    features = {}
+    features["deletion_matrix_int"] = np.array(deletion_matrix, dtype=np.int32)
+    features["msa"] = torch.tensor(int_msa, dtype=np.int32)
+    features["num_alignments"] = np.array([num_alignments] * num_res, dtype=np.int32)
+    features["msa_species_identifiers"] = np.array(species_ids, dtype=object)
+    return features
+
+
+def get_assembly(biomol: Biomolecule, assembly_id: Optional[str] = None) -> Biomolecule:
+    """Get a specified (Biomolecule) assembly of a given Biomolecule.
 
     Adapted from: https://github.com/biotite-dev/biotite
 

--- a/alphafold3_pytorch/data/msa_parsing.py
+++ b/alphafold3_pytorch/data/msa_parsing.py
@@ -1,0 +1,183 @@
+"""MSA loading functions used in AlphaFold2."""
+
+# From: https://github.com/google-deepmind/alphafold/blob/f251de6613cb478207c732bf9627b1e853c99c2f/alphafold/data/parsers.py#L157
+
+import dataclasses
+import re
+from typing import Optional, Sequence, Tuple
+
+DeletionMatrix = Sequence[Sequence[int]]
+
+# Utilities for extracting identifiers from MSA sequence descriptions.
+
+
+# Sequences coming from UniProtKB database come in the
+# `db|UniqueIdentifier|EntryName` format, e.g. `tr|A0A146SKV9|A0A146SKV9_FUNHE`
+# or `sp|P0C2L1|A3X1_LOXLA` (for TREMBL/Swiss-Prot respectively).
+_UNIPROT_PATTERN = re.compile(
+    r"""
+    ^
+    # UniProtKB/TrEMBL or UniProtKB/Swiss-Prot
+    (?:tr|sp)
+    \|
+    # A primary accession number of the UniProtKB entry.
+    (?P<AccessionIdentifier>[A-Za-z0-9]{6,10})
+    # Occasionally there is a _0 or _1 isoform suffix, which we ignore.
+    (?:_\d)?
+    \|
+    # TREMBL repeats the accession ID here. Swiss-Prot has a mnemonic
+    # protein ID code.
+    (?:[A-Za-z0-9]+)
+    _
+    # A mnemonic species identification code.
+    (?P<SpeciesIdentifier>([A-Za-z0-9]){1,5})
+    # Small BFD uses a final value after an underscore, which we ignore.
+    (?:_\d+)?
+    $
+    """,
+    re.VERBOSE,
+)
+
+
+@dataclasses.dataclass(frozen=True)
+class Identifiers:
+    species_id: str = ""
+
+
+def _parse_sequence_identifier(msa_sequence_identifier: str) -> Identifiers:
+    """Gets species from an msa sequence identifier.
+
+    The sequence identifier has the format specified by
+    _UNIPROT_TREMBL_ENTRY_NAME_PATTERN or _UNIPROT_SWISSPROT_ENTRY_NAME_PATTERN.
+    An example of a sequence identifier: `tr|A0A146SKV9|A0A146SKV9_FUNHE`
+
+    Args:
+      msa_sequence_identifier: a sequence identifier.
+
+    Returns:
+      An `Identifiers` instance with species_id. These
+      can be empty in the case where no identifier was found.
+    """
+    matches = re.search(_UNIPROT_PATTERN, msa_sequence_identifier.strip())
+    if matches:
+        return Identifiers(species_id=matches.group("SpeciesIdentifier"))
+    return Identifiers()
+
+
+def _extract_sequence_identifier(description: str) -> Optional[str]:
+    """Extracts sequence identifier from description.
+
+    Returns None if no match.
+    """
+    split_description = description.split()
+    if split_description:
+        return split_description[0].partition("/")[0]
+    else:
+        return None
+
+
+def get_identifiers(description: str) -> Identifiers:
+    """Computes extra MSA features from the description."""
+    sequence_identifier = _extract_sequence_identifier(description)
+    if sequence_identifier is None:
+        return Identifiers()
+    else:
+        return _parse_sequence_identifier(sequence_identifier)
+
+
+@dataclasses.dataclass(frozen=True)
+class Msa:
+    """Class representing a parsed MSA file."""
+
+    sequences: Sequence[str]
+    deletion_matrix: DeletionMatrix
+    descriptions: Sequence[str]
+
+    def __post_init__(self):
+        if not (len(self.sequences) == len(self.deletion_matrix) == len(self.descriptions)):
+            raise ValueError(
+                "All fields for an MSA must have the same length. "
+                f"Got {len(self.sequences)} sequences, "
+                f"{len(self.deletion_matrix)} rows in the deletion matrix and "
+                f"{len(self.descriptions)} descriptions."
+            )
+
+    def __len__(self):
+        return len(self.sequences)
+
+    def truncate(self, max_seqs: int):
+        return Msa(
+            sequences=self.sequences[:max_seqs],
+            deletion_matrix=self.deletion_matrix[:max_seqs],
+            descriptions=self.descriptions[:max_seqs],
+        )
+
+
+def parse_fasta(fasta_string: str) -> Tuple[Sequence[str], Sequence[str]]:
+    """Parses FASTA string and returns list of strings with amino-acid sequences.
+
+    Arguments:
+      fasta_string: The string contents of a FASTA file.
+
+    Returns:
+      A tuple of two lists:
+      * A list of sequences.
+      * A list of sequence descriptions taken from the comment lines. In the
+        same order as the sequences.
+    """
+    sequences = []
+    descriptions = []
+    index = -1
+    for line in fasta_string.splitlines():
+        line = line.strip()
+        if line.startswith(">"):
+            index += 1
+            descriptions.append(line[1:])  # Remove the '>' at the beginning.
+            sequences.append("")
+            continue
+        elif not line:
+            continue  # Skip blank lines.
+        sequences[index] += line
+
+    return sequences, descriptions
+
+
+def parse_a3m(a3m_string: str) -> Msa:
+    """Parses sequences and deletion matrix from a3m format alignment.
+
+    Args:
+      a3m_string: The string contents of a a3m file. The first sequence in the
+        file should be the query sequence.
+
+    Returns:
+      A tuple of:
+        * A list of sequences that have been aligned to the query. These
+          might contain duplicates.
+        * The deletion matrix for the alignment as a list of lists. The element
+          at `deletion_matrix[i][j]` is the number of residues deleted from
+          the aligned sequence i at residue position j.
+        * A list of descriptions, one per sequence, from the a3m file.
+    """
+
+    sequences, descriptions = parse_fasta(a3m_string)
+    deletion_matrix = []
+    for msa_sequence in sequences:
+        deletion_vec = []
+        deletion_count = 0
+        for j in msa_sequence:
+            if j.islower():
+                deletion_count += 1
+            else:
+                deletion_vec.append(deletion_count)
+                deletion_count = 0
+        deletion_matrix.append(deletion_vec)
+    import string
+
+    # Make the MSA matrix out of aligned (deletion-free) sequences.
+    deletion_table = str.maketrans("", "", string.ascii_lowercase)
+    aligned_sequences = [s.translate(deletion_table) for s in sequences]
+    return Msa(
+        sequences=aligned_sequences,
+        deletion_matrix=deletion_matrix,
+        descriptions=descriptions,
+    )

--- a/alphafold3_pytorch/utils/data_utils.py
+++ b/alphafold3_pytorch/utils/data_utils.py
@@ -2,7 +2,8 @@ from typing import Any, Dict, Literal, Set
 
 import numpy as np
 
-from alphafold3_pytorch.tensor_typing import ChainType, ResidueType, typecheck
+from alphafold3_pytorch.utils.tensor_typing import ChainType, ResidueType, typecheck
+from alphafold3_pytorch.utils.utils import exists
 
 # constants
 
@@ -10,14 +11,16 @@ RESIDUE_MOLECULE_TYPE = Literal["protein", "rna", "dna", "ligand"]
 PDB_INPUT_RESIDUE_MOLECULE_TYPE = Literal[
     "protein", "rna", "dna", "mod_protein", "mod_rna", "mod_dna", "ligand"
 ]
+MMCIF_METADATA_FIELD = Literal[
+    "structure_method", "release_date", "resolution", "structure_connectivity"
+]
 
 
 @typecheck
 def is_polymer(
     res_chem_type: str, polymer_chem_types: Set[str] = {"peptide", "dna", "rna"}
 ) -> bool:
-    """
-    Check if a residue is polymeric using its chemical type string.
+    """Check if a residue is polymeric using its chemical type string.
 
     :param res_chem_type: The chemical type of the residue as a descriptive string.
     :param polymer_chem_types: The set of polymer chemical types.
@@ -28,8 +31,7 @@ def is_polymer(
 
 @typecheck
 def is_water(res_name: str, water_res_names: Set[str] = {"HOH", "WAT"}) -> bool:
-    """
-    Check if a residue is a water residue using its residue name string.
+    """Check if a residue is a water residue using its residue name string.
 
     :param res_name: The name of the residue as a descriptive string.
     :param water_res_names: The set of water residue names.
@@ -83,9 +85,8 @@ def get_pdb_input_residue_molecule_type(
 def get_biopython_chain_residue_by_composite_id(
     chain: ChainType, res_name: str, res_id: int
 ) -> ResidueType:
-    """
-    Get a Biopython `Residue` or `DisorderedResidue` object
-    by its residue name-residue index composite ID.
+    """Get a Biopython `Residue` or `DisorderedResidue` object by its residue name-residue index
+    composite ID.
 
     :param chain: Biopython `Chain` object
     :param res_name: Residue name
@@ -126,8 +127,7 @@ def get_biopython_chain_residue_by_composite_id(
 
 @typecheck
 def matrix_rotate(v: np.ndarray, matrix: np.ndarray) -> np.ndarray:
-    """
-    Perform a rotation using a rotation matrix.
+    """Perform a rotation using a rotation matrix.
 
     :param v: The coordinates to rotate.
     :param matrix: The rotation matrix.
@@ -150,8 +150,7 @@ def matrix_rotate(v: np.ndarray, matrix: np.ndarray) -> np.ndarray:
 def deep_merge_dicts(
     dict1: Dict[Any, Any], dict2: Dict[Any, Any], value_op: Literal["union", "concat"]
 ) -> Dict[Any, Any]:
-    """
-    Deeply merge two dictionaries, merging values where possible.
+    """Deeply merge two dictionaries, merging values where possible.
 
     :param dict1: The first dictionary to merge.
     :param dict2: The second dictionary to merge.
@@ -171,3 +170,63 @@ def deep_merge_dicts(
             # Otherwise, set/overwrite the key in dict1 with dict2's value
             dict1[key] = value
     return dict1
+
+
+@typecheck
+def coerce_to_float(obj: Any) -> float | None:
+    """Coerce an object to a float, returning `None` if the object is not coercible.
+
+    :param obj: The object to coerce to a float.
+    :return: The object coerced to a float if possible, otherwise `None`.
+    """
+    try:
+        if isinstance(obj, (int, float, str)):
+            return float(obj)
+        elif isinstance(obj, list):
+            return float(obj[0])
+        else:
+            return None
+    except (ValueError, TypeError):
+        return None
+
+
+@typecheck
+def extract_mmcif_metadata_field(
+    mmcif_object: Any,
+    metadata_field: MMCIF_METADATA_FIELD,
+    min_resolution: float = 0.0,
+    max_resolution: float = 1000.0,
+) -> str | float | None:
+    """Extract a metadata field from an mmCIF object. If the field is not found, return `None`.
+
+    :param mmcif_object: The mmCIF object to extract the metadata field from.
+    :param metadata_field: The metadata field to extract.
+    :return: The extracted metadata field.
+    """
+    # Extract structure method
+    if metadata_field == "structure_method" and "_exptl.method" in mmcif_object.raw_string:
+        return mmcif_object.raw_string["_exptl.method"]
+
+    # Extract release date
+    if (
+        metadata_field == "release_date"
+        and "_pdbx_audit_revision_history.revision_date" in mmcif_object.raw_string
+    ):
+        return mmcif_object.raw_string["_pdbx_audit_revision_history.revision_date"]
+
+    # Extract resolution
+    if metadata_field == "resolution" and "_refine.ls_d_res_high" in mmcif_object.raw_string:
+        resolution = coerce_to_float(mmcif_object.raw_string["_refine.ls_d_res_high"])
+        if exists(resolution) and min_resolution <= resolution <= max_resolution:
+            return resolution
+    elif (
+        metadata_field == "resolution"
+        and "_em_3d_reconstruction.resolution" in mmcif_object.raw_string
+    ):
+        resolution = coerce_to_float(mmcif_object.raw_string["_em_3d_reconstruction.resolution"])
+        if exists(resolution) and min_resolution <= resolution <= max_resolution:
+            return resolution
+    elif metadata_field == "resolution" and "_reflns.d_resolution_high" in mmcif_object.raw_string:
+        resolution = coerce_to_float(mmcif_object.raw_string["_reflns.d_resolution_high"])
+        if exists(resolution) and min_resolution <= resolution <= max_resolution:
+            return resolution


### PR DESCRIPTION
* Adds MSA parsing functions (credit: @sj900), n.b., these will need to be adapted to handle RNA and DNA chains
* Adds PDB resolution value parsing from mmCIF files, which per AF3 supplement Section 4.3 are used to determine whether or not the model's confidence head outputs are to be supervised (based on whether the model is training on the standard (non-distillation) PDB training dataset and whether the PDB structure was resolved with a resolution value between 0.1 and 4.0)