### PR TITLE
Add MSA support for all of life's molecules

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,8 +89,10 @@ molecule_ids = torch.randint(0, 32, (2, seq_len))
 template_feats = torch.randn(2, 2, seq_len, seq_len, 44)
 template_mask = torch.ones((2, 2)).bool()
 
-msa = torch.randn(2, 7, seq_len, 64)
+msa = torch.randn(2, 7, seq_len, 32)
 msa_mask = torch.ones((2, 7)).bool()
+
+additional_msa_feats = torch.randn(2, 7, seq_len, 2)
 
 # required for training, but omitted on inference
 
@@ -109,6 +111,7 @@ loss = alphafold3(
     molecule_ids = molecule_ids,
     molecule_atom_lens = molecule_atom_lens,
     additional_molecule_feats = additional_molecule_feats,
+    additional_msa_feats = additional_msa_feats,
     additional_token_feats = additional_token_feats,
     is_molecule_types = is_molecule_types,
     is_molecule_mod = is_molecule_mod,
@@ -134,6 +137,7 @@ sampled_atom_pos = alphafold3(
     molecule_ids = molecule_ids,
     molecule_atom_lens = molecule_atom_lens,
     additional_molecule_feats = additional_molecule_feats,
+    additional_msa_feats = additional_msa_feats,
     additional_token_feats = additional_token_feats,
     is_molecule_types = is_molecule_types,
     is_molecule_mod = is_molecule_mod,

--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ atom_inputs = torch.randn(2, atom_seq_len, 77)
 atompair_inputs = torch.randn(2, atom_seq_len, atom_seq_len, 5)
 
 additional_molecule_feats = torch.randint(0, 2, (2, seq_len, 5))
-additional_token_feats = torch.randn(2, seq_len, 2)
+additional_token_feats = torch.randn(2, seq_len, 33)
 is_molecule_types = torch.randint(0, 2, (2, seq_len, 5)).bool()
 is_molecule_mod = torch.randint(0, 2, (2, seq_len, 4)).bool()
 molecule_ids = torch.randint(0, 32, (2, seq_len))

--- a/alphafold3_pytorch/alphafold3.py
+++ b/alphafold3_pytorch/alphafold3.py
@@ -1061,11 +1061,11 @@ class MSAModule(Module):
     ):
         super().__init__()
 
-        self.max_num_msa = default(max_num_msa, float('inf'))  # cap the number of MSAs, will do sample without replacement if exceeds
+        self.max_num_msa = default(
+            max_num_msa, float('inf')
+        )  # cap the number of MSAs, will do sample without replacement if exceeds
 
-        dim_msa_input += dim_additional_msa_feats
-
-        self.msa_init_proj = LinearNoBias(dim_msa_input, dim_msa)
+        self.msa_init_proj = LinearNoBias(dim_msa_input + dim_additional_msa_feats, dim_msa)
 
         self.single_to_msa_feats = LinearNoBias(dim_single, dim_msa)
 
@@ -4970,7 +4970,6 @@ class Alphafold3(Module):
         msa_module_kwargs: dict = dict(
             depth = 4,
             dim_msa = 64,
-            dim_msa_input = None,
             outer_product_mean_dim_hidden = 32,
             msa_pwa_dropout_row_prob = 0.15,
             msa_pwa_heads = 8,

--- a/alphafold3_pytorch/alphafold3.py
+++ b/alphafold3_pytorch/alphafold3.py
@@ -1049,7 +1049,6 @@ class MSAModule(Module):
         dim_msa = 64,
         dim_msa_input=NUM_MSA_ONE_HOT,
         dim_additional_msa_feats=2,
-        dim_msa_input = None,
         outer_product_mean_dim_hidden = 32,
         msa_pwa_dropout_row_prob = 0.15,
         msa_pwa_heads = 8,

--- a/alphafold3_pytorch/common/amino_acid_constants.py
+++ b/alphafold3_pytorch/common/amino_acid_constants.py
@@ -117,6 +117,35 @@ restype_1to3 = {
     "X": "UNK",
 }
 
+MSA_CHAR_TO_ID = {
+    "A": 0,
+    "R": 1,
+    "N": 2,
+    "D": 3,
+    "C": 4,
+    "Q": 5,
+    "E": 6,
+    "G": 7,
+    "H": 8,
+    "I": 9,
+    "L": 10,
+    "K": 11,
+    "M": 12,
+    "F": 13,
+    "P": 14,
+    "S": 15,
+    "T": 16,
+    "W": 17,
+    "Y": 18,
+    "V": 19,
+    "X": 20,
+    "-": 31,
+    "U": 1,
+    "Z": 3,
+    "J": 20,
+    "O": 20,
+}
+
 BIOMOLECULE_CHAIN: Final[str] = "polypeptide(L)"
 POLYMER_CHAIN: Final[str] = "polymer"
 

--- a/alphafold3_pytorch/common/dna_constants.py
+++ b/alphafold3_pytorch/common/dna_constants.py
@@ -84,6 +84,15 @@ restype_1to3 = {
     "X": "DN",
 }
 
+MSA_CHAR_TO_ID = {
+    "A": 26,
+    "C": 27,
+    "G": 28,
+    "T": 29,
+    "X": 30,
+    "-": 31,
+}
+
 BIOMOLECULE_CHAIN: Final[str] = "polydeoxyribonucleotide"
 POLYMER_CHAIN: Final[str] = "polymer"
 

--- a/alphafold3_pytorch/common/ligand_constants.py
+++ b/alphafold3_pytorch/common/ligand_constants.py
@@ -125,6 +125,11 @@ restype_num = len(amino_acid_constants.restypes)  # := 20.
 
 restype_1to3 = {"X": "UNL"}
 
+MSA_CHAR_TO_ID = {
+    "X": 20,
+    "-": 31,
+}
+
 BIOMOLECULE_CHAIN: Final[str] = "other"
 POLYMER_CHAIN: Final[str] = "non-polymer"
 

--- a/alphafold3_pytorch/common/rna_constants.py
+++ b/alphafold3_pytorch/common/rna_constants.py
@@ -76,6 +76,15 @@ restype_num = min_restype_num + len(restypes)  # := 21 + 4 := 25.
 
 restype_1to3 = {"A": "A", "C": "C", "G": "G", "U": "U", "X": "N"}
 
+MSA_CHAR_TO_ID = {
+    "A": 21,
+    "C": 22,
+    "G": 23,
+    "U": 24,
+    "X": 25,
+    "-": 31,
+}
+
 BIOMOLECULE_CHAIN: Final[str] = "polyribonucleotide"
 POLYMER_CHAIN: Final[str] = "polymer"
 

--- a/alphafold3_pytorch/inputs.py
+++ b/alphafold3_pytorch/inputs.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import copy
+import glob
 import json
 import os
 from pathlib import Path
@@ -41,6 +42,7 @@ from alphafold3_pytorch.common.biomolecule import (
 )
 from alphafold3_pytorch.data import mmcif_parsing, msa_parsing
 from alphafold3_pytorch.data.data_pipeline import (
+    FeatureDict,
     get_assembly,
     make_msa_features,
     make_msa_mask,
@@ -66,6 +68,7 @@ from alphafold3_pytorch.utils.data_utils import (
     get_pdb_input_residue_molecule_type,
     is_atomized_residue,
     is_polymer,
+    make_one_hot,
 )
 from alphafold3_pytorch.utils.model_utils import exclusive_cumsum
 from alphafold3_pytorch.utils.utils import default, exists, first
@@ -98,6 +101,8 @@ IS_PROTEIN, IS_RNA, IS_DNA, IS_LIGAND, IS_METAL_ION = tuple(
 MOLECULE_GAP_ID = len(HUMAN_AMINO_ACIDS) + len(RNA_NUCLEOTIDES) + len(DNA_NUCLEOTIDES)
 MOLECULE_METAL_ION_ID = MOLECULE_GAP_ID + 1
 NUM_MOLECULE_IDS = len(HUMAN_AMINO_ACIDS) + len(RNA_NUCLEOTIDES) + len(DNA_NUCLEOTIDES) + 2
+
+NUM_MSA_ONE_HOT = len(HUMAN_AMINO_ACIDS) + len(RNA_NUCLEOTIDES) + len(DNA_NUCLEOTIDES) + 1
 
 DEFAULT_NUM_MOLECULE_MODS = 4  # `mod_protein`, `mod_rna`, `mod_dna`, and `mod_unk`
 ADDITIONAL_MOLECULE_FEATS = 5
@@ -217,9 +222,10 @@ class AtomInput:
     additional_molecule_feats:  Int[f'n {ADDITIONAL_MOLECULE_FEATS}']
     is_molecule_types:          Bool[f'n {IS_MOLECULE_TYPES}']
     is_molecule_mod:            Bool['n num_mods'] | None = None
+    additional_msa_feats:       Float['s n dmf'] | None = None
     additional_token_feats:     Float['n dtf'] | None = None
     templates:                  Float['t n n dt'] | None = None
-    msa:                        Float['s n dm'] | None = None
+    msa:                        Float['s n dmi'] | None = None
     token_bonds:                Bool['n n'] | None = None
     atom_ids:                   Int[' m'] | None = None
     atom_parent_ids:            Int[' m'] | None = None
@@ -250,9 +256,10 @@ class BatchedAtomInput:
     additional_molecule_feats:  Int[f'b n {ADDITIONAL_MOLECULE_FEATS}']
     is_molecule_types:          Bool[f'b n {IS_MOLECULE_TYPES}']
     is_molecule_mod:            Bool['b n num_mods'] | None = None
+    additional_msa_feats:       Float['b s n dmf'] | None = None
     additional_token_feats:     Float['b n dtf'] | None = None
     templates:                  Float['b t n n dt'] | None = None
-    msa:                        Float['b s n dm'] | None = None
+    msa:                        Float['b s n dmi'] | None = None
     token_bonds:                Bool['b n n'] | None = None
     atom_ids:                   Int['b m'] | None = None
     atom_parent_ids:            Int['b m'] | None = None
@@ -483,9 +490,10 @@ class MoleculeInput:
     missing_atom_indices:       List[Int[' _'] | None] | None = None
     missing_token_indices:      List[Int[' _'] | None] | None = None
     atom_parent_ids:            Int[' m'] | None = None
+    additional_msa_feats:       Float['s n dmf'] | None = None
     additional_token_feats:     Float[f'n dtf'] | None = None
     templates:                  Float['t n n dt'] | None = None
-    msa:                        Float['s n dm'] | None = None
+    msa:                        Float['s n dmi'] | None = None
     atom_pos:                   List[Float['_ 3']] | Float['m 3'] | None = None
     template_mask:              Bool[' t'] | None = None
     msa_mask:                   Bool[' s'] | None = None
@@ -766,6 +774,7 @@ def molecule_to_atom_input(mol_input: MoleculeInput) -> AtomInput:
         msa_mask=i.msa_mask,
         template_mask=i.template_mask,
         missing_atom_mask=missing_atom_mask,
+        additional_msa_feats=i.additional_msa_feats,
         additional_token_feats=i.additional_token_feats,
         additional_molecule_feats=i.additional_molecule_feats,
         is_molecule_types=i.is_molecule_types,
@@ -804,9 +813,10 @@ class MoleculeLengthMoleculeInput:
     missing_atom_indices:       List[Int[' _'] | None] | None = None
     missing_token_indices:      List[Int[' _'] | None] | None = None
     atom_parent_ids:            Int[' m'] | None = None
-    additional_token_feats:     Float[f'n dtf'] | None = None
+    additional_msa_feats:       Float['s n dmf'] | None = None
+    additional_token_feats:     Float['n dtf'] | None = None
     templates:                  Float['t n n dt'] | None = None
-    msa:                        Float['s n dm'] | None = None
+    msa:                        Float['s n dmi'] | None = None
     atom_pos:                   List[Float['_ 3']] | Float['m 3'] | None = None
     template_mask:              Bool[' t'] | None = None
     msa_mask:                   Bool[' s'] | None = None
@@ -894,6 +904,8 @@ def molecule_lengthed_molecule_input_to_atom_input(mol_input: MoleculeLengthMole
         torch.arange(additional_molecule_feats.shape[0]),
         additional_molecule_feats[..., 1:]
     ), 'n *')
+
+    additional_msa_feats = repeat_interleave(i.additional_msa_feats, token_repeats, dim=1)
 
     additional_token_feats = repeat_interleave(i.additional_token_feats, token_repeats, dim = 0)
     molecule_ids = repeat_interleave(i.molecule_ids, token_repeats)
@@ -1212,6 +1224,7 @@ def molecule_lengthed_molecule_input_to_atom_input(mol_input: MoleculeLengthMole
         distogram_atom_indices = distogram_atom_indices,
         atom_indices_for_frame = atom_indices_for_frame,
         missing_atom_mask = missing_atom_mask,
+        additional_msa_feats=additional_msa_feats,
         additional_token_feats = additional_token_feats,
         additional_molecule_feats = additional_molecule_feats,
         is_molecule_mod = is_molecule_mod,
@@ -1246,9 +1259,10 @@ class Alphafold3Input:
     ds_rna:                     List[Int[' _'] | str] = imm_list()
     atom_parent_ids:            Int[' m'] | None = None
     missing_atom_indices:       List[List[int] | None] = imm_list()
+    additional_msa_feats:       Float['s n dmf'] | None = None
     additional_token_feats:     Float[f'n dtf'] | None = None
     templates:                  Float['t n n dt'] | None = None
-    msa:                        Float['s n dm'] | None = None
+    msa:                        Float['s n dmi'] | None = None
     atom_pos:                   List[Float['_ 3']] | Float['m 3'] | None = None
     reorder_atom_pos:           bool = True
     template_mask:              Bool[' t'] | None = None
@@ -1651,6 +1665,10 @@ def alphafold3_input_to_molecule_lengthed_molecule_input(alphafold3_input: Alpha
         assert len(molecules) == len(missing_atom_indices)
         assert len(missing_token_indices) == num_tokens
 
+    # handle MSAs
+
+    num_msas = len(i.msa) if exists(i.msa) else 1
+
     # create molecule input
 
     molecule_input = MoleculeLengthMoleculeInput(
@@ -1659,7 +1677,8 @@ def alphafold3_input_to_molecule_lengthed_molecule_input(alphafold3_input: Alpha
         distogram_atom_indices=distogram_atom_indices,
         molecule_ids=molecule_ids,
         additional_molecule_feats=additional_molecule_feats,
-        additional_token_feats=default(i.additional_token_feats, torch.zeros(num_tokens, 2)),
+        additional_msa_feats=default(i.additional_msa_feats, torch.zeros(num_msas, num_tokens, 2)),
+        additional_token_feats=default(i.additional_token_feats, torch.zeros(num_tokens, 33)),
         is_molecule_types=is_molecule_types,
         missing_atom_indices=missing_atom_indices,
         missing_token_indices=missing_token_indices,
@@ -1699,6 +1718,7 @@ class PDBInput:
     directed_bonds: bool = False
     training: bool = False
     resolution: float | None = None
+    max_msas_per_chain: int | None = None
     extract_atom_feats_fn: Callable[[Atom], Float["m dai"]] = default_extract_atom_feats_fn  # type: ignore
     extract_atompair_feats_fn: Callable[[Mol], Float["m m dapi"]] = default_extract_atompair_feats_fn  # type: ignore
 
@@ -2244,26 +2264,88 @@ def find_mismatched_symmetry(
 def load_msa_from_msa_dir(
     msa_dir: str | None,
     file_id: str,
+    chain_id_to_chem_types: Dict[str, List[int]],
+    max_msas_per_chain: int | None = None,
+    randomly_truncate: bool = True,
     raise_missing_exception: bool = False,
     verbose: bool = False,
-) -> Tuple[torch.Tensor | None, torch.Tensor | None]:
+) -> FeatureDict:
     """Load MSA from a directory containing MSA files."""
     if (not exists(msa_dir) or not os.path.exists(msa_dir)) and raise_missing_exception:
         raise FileNotFoundError(f"{msa_dir} does not exist.")
     elif not exists(msa_dir) or not os.path.exists(msa_dir):
         if verbose:
             logger.warning(f"{msa_dir} does not exist. Skipping MSA loading by returning `Nones`.")
-        return None, None
+        return {}
 
-    msa_fpath = os.path.join(msa_dir, f"{file_id}.a3m")
-    with open(msa_fpath, "r") as f:
-        msa = f.read()
+    msas = {}
+    for chain_id in chain_id_to_chem_types:
+        msa_fpaths = glob.glob(os.path.join(msa_dir, f"{file_id}{chain_id}_*.a3m"))
 
-    msa = msa_parsing.parse_a3m(msa)
-    features = make_msa_features([msa])
-    msa_mask = make_msa_mask(features)
+        if not msa_fpaths:
+            msas[chain_id] = None
+            continue
 
-    return features["msa"], msa_mask["msa_mask"]
+        # NOTE: A single chain-specific MSA file contains alignments for all polymer residues in the chain,
+        # but the ligand (and some "unmappable" modified polymer residues) are not included in the MSA file
+        # and therefore must be manually inserted into the MSAs as unknown amino acid residues.
+        assert len(msa_fpaths) == 1, (
+            f"{len(msa_fpaths)} MSA files found for chain {chain_id} of file {file_id}. "
+            "Please ensure that one MSA file is present for each chain."
+        )
+        msa_fpath = msa_fpaths[0]
+        msa_type = os.path.splitext(os.path.basename(msa_fpath))[0].split("_")[-1]
+
+        with open(msa_fpath, "r") as f:
+            msa = f.read()
+            msa = msa_parsing.parse_a3m(msa, msa_type)
+            msa = (
+                (
+                    msa.random_truncate(max_msas_per_chain)
+                    if randomly_truncate
+                    else msa.truncate(max_msas_per_chain)
+                )
+                if exists(max_msas_per_chain)
+                else msa
+            )
+            msas[chain_id] = msa
+
+    features = make_msa_features(msas, chain_id_to_chem_types)
+    features = make_msa_mask(features)
+
+    return features
+
+
+@typecheck
+def load_templates_from_templates_dir(
+    templates_dir: str | None,
+    file_id: str,
+    raise_missing_exception: bool = False,
+    verbose: bool = False,
+) -> FeatureDict:
+    """Load templates from a directory containing template PDB mmCIF files."""
+    if (
+        not exists(templates_dir) or not os.path.exists(templates_dir)
+    ) and raise_missing_exception:
+        raise FileNotFoundError(f"{templates_dir} does not exist.")
+    elif not exists(templates_dir) or not os.path.exists(templates_dir):
+        if verbose:
+            logger.warning(
+                f"{templates_dir} does not exist. Skipping template loading by returning `Nones`."
+            )
+        return {}
+
+    # template_fpath = os.path.join(templates_dir, f"{file_id}.pdb")
+    # with open(template_fpath, "r") as f:
+    #     template = f.read()
+
+    # template = template_parsing.parse_pdb(template)
+    # features = make_template_features([template])
+    # features = make_template_mask(features)
+
+    # return features
+
+    return {}
 
 
 @typecheck
@@ -2708,19 +2790,72 @@ def pdb_input_to_molecule_input(
     num_present_atoms = mol_total_atoms - num_missing_atom_indices
     assert num_present_atoms == int(biomol.atom_mask.sum())
 
-    # TODO: install additional token features once MSAs are available
-    # 0: f_profile
-    # 1: f_deletion_mean
+    # retrieve multiple sequence alignments (MSAs) for each chain
+    # NOTE: if they are not locally available, `Nones` will be used
+    msa_chain_ids = list(dict.fromkeys(biomol.chain_id.tolist()))
+    chain_id_to_chem_types = {
+        chain_id: biomol.chemtype[biomol.chain_id == chain_id].tolist()
+        for chain_id in msa_chain_ids
+    }
+    msa_features = load_msa_from_msa_dir(
+        i.msa_dir, file_id, chain_id_to_chem_types, max_msas_per_chain=i.max_msas_per_chain
+    )
+
+    msa = msa_features.get("msa")
+    msa_col_mask = msa_features.get("msa_mask")
+    msa_row_mask = msa_features.get("msa_row_mask")
+
+    # collect additional MSA and token features
+    # 0: has_deletion (msa)
+    # 1: deletion_value (msa)
+    # 2: profile (token)
+    # 3: deletion_mean (token)
+
+    additional_msa_feats = None
     additional_token_feats = None
 
-    # retrieve multiple sequence alignments (MSAs) for each chain
-    # NOTE: if they are not locally available, `Nones` will be returned
-    msa, msa_mask = load_msa_from_msa_dir(i.msa_dir, file_id)
+    num_msas = len(msa) if exists(msa) else 1
+
+    if exists(msa):
+        has_deletion = torch.clip(msa_features["deletion_matrix"], 0.0, 1.0)
+        deletion_value = torch.atan(msa_features["deletion_matrix"] / 3.0) * (2.0 / torch.pi)
+
+        additional_msa_feats = torch.stack(
+            [
+                has_deletion,
+                deletion_value,
+            ],
+            dim=-1,
+        )
+
+        # NOTE: assumes each aligned sequence has the same mask values
+        profile_msa_mask = torch.repeat_interleave(msa_col_mask[None, ...], len(msa), dim=0)
+        msa_sum = (profile_msa_mask[:, :, None] * make_one_hot(msa, NUM_MSA_ONE_HOT)).sum(0)
+        mask_counts = 1e-6 + profile_msa_mask.sum(0)
+
+        profile = msa_sum / mask_counts[:, None]
+        deletion_mean = torch.atan(msa_features["deletion_matrix"].mean(0) / 3.0) * (
+            2.0 / torch.pi
+        )
+
+        additional_token_feats = torch.cat(
+            [
+                profile,
+                deletion_mean[:, None],
+            ],
+            dim=-1,
+        )
+
+        # convert the MSA into a one-hot representation
+        msa = make_one_hot(msa, NUM_MSA_ONE_HOT)
+        msa_row_mask = msa_row_mask.bool()
 
     # TODO: retrieve templates for each chain
-    # templates, template_mask = load_templates_from_templates_dir(i.templates_dir)
-    # NOTE: if they are not locally available, `Nones` will be returned
-    templates, template_mask = None, None
+    # NOTE: if they are not locally available, `Nones` will be used
+    template_features = load_templates_from_templates_dir(i.templates_dir, file_id)
+
+    templates = template_features.get("templates")
+    template_mask = template_features.get("template_mask")
 
     # construct atom positions from template molecules after instantiating their 3D conformers
     atom_pos = torch.from_numpy(
@@ -2810,12 +2945,13 @@ def pdb_input_to_molecule_input(
         missing_atom_indices=missing_atom_indices,
         missing_token_indices=missing_token_indices,
         atom_parent_ids=atom_parent_ids,
-        additional_token_feats=default(additional_token_feats, torch.zeros(num_tokens, 2)),
+        additional_msa_feats=default(additional_msa_feats, torch.zeros(num_msas, num_tokens, 2)),
+        additional_token_feats=default(additional_token_feats, torch.zeros(num_tokens, 33)),
         templates=templates,
         msa=msa,
         atom_pos=atom_pos,
         template_mask=template_mask,
-        msa_mask=msa_mask,
+        msa_mask=msa_row_mask,
         resolved_labels=resolved_labels,
         resolution=resolution,
         chains=chains,

--- a/alphafold3_pytorch/mocks.py
+++ b/alphafold3_pytorch/mocks.py
@@ -69,7 +69,7 @@ class MockAtomDataset(Dataset):
         templates = torch.randn(2, seq_len, seq_len, 44)
         template_mask = torch.ones((2,)).bool()
 
-        msa = torch.randn(7, seq_len, 64)
+        msa = torch.randn(7, seq_len, 32)
 
         msa_mask = None
         if random.random() > 0.5:

--- a/alphafold3_pytorch/mocks.py
+++ b/alphafold3_pytorch/mocks.py
@@ -75,6 +75,8 @@ class MockAtomDataset(Dataset):
         if random.random() > 0.5:
             msa_mask = torch.ones((7,)).bool()
 
+        additional_msa_feats = torch.randn(7, seq_len, 2)
+
         # required for training, but omitted on inference
 
         atom_pos = torch.randn(atom_seq_len, 3)
@@ -97,6 +99,7 @@ class MockAtomDataset(Dataset):
             token_bonds = token_bonds,
             molecule_atom_lens = molecule_atom_lens,
             additional_molecule_feats = additional_molecule_feats,
+            additional_msa_feats = additional_msa_feats,
             additional_token_feats = additional_token_feats,
             is_molecule_types = is_molecule_types,
             is_molecule_mod = is_molecule_mod,

--- a/alphafold3_pytorch/mocks.py
+++ b/alphafold3_pytorch/mocks.py
@@ -42,7 +42,7 @@ class MockAtomDataset(Dataset):
         atom_offsets = exclusive_cumsum(molecule_atom_lens)
 
         additional_molecule_feats = torch.randint(0, 2, (seq_len, 5))
-        additional_token_feats = torch.randn(seq_len, 2)
+        additional_token_feats = torch.randn(seq_len, 33)
         is_molecule_types = torch.randint(0, 2, (seq_len, IS_MOLECULE_TYPES)).bool()
 
         # ensure the molecule-atom length mappings match the randomly-sampled atom sequence length

--- a/alphafold3_pytorch/utils/data_utils.py
+++ b/alphafold3_pytorch/utils/data_utils.py
@@ -1,6 +1,8 @@
 from typing import Any, Dict, Literal, Set
 
 import numpy as np
+import torch
+from torch import Tensor
 
 from alphafold3_pytorch.tensor_typing import ChainType, ResidueType, typecheck
 from alphafold3_pytorch.utils.utils import exists
@@ -230,3 +232,16 @@ def extract_mmcif_metadata_field(
         resolution = coerce_to_float(mmcif_object.raw_string["_reflns.d_resolution_high"])
         if exists(resolution) and min_resolution <= resolution <= max_resolution:
             return resolution
+
+
+@typecheck
+def make_one_hot(x: Tensor, num_classes: int) -> Tensor:
+    """Convert a tensor of indices to a one-hot tensor.
+
+    :param x: A tensor of indices.
+    :param num_classes: The number of classes.
+    :return: A one-hot tensor.
+    """
+    x_one_hot = torch.zeros(*x.shape, num_classes, device=x.device)
+    x_one_hot.scatter_(-1, x.unsqueeze(-1), 1)
+    return x_one_hot

--- a/tests/test_af3.py
+++ b/tests/test_af3.py
@@ -497,7 +497,7 @@ def test_input_embedder():
     atompair_inputs = torch.randn(2, atom_seq_len, atom_seq_len, 5)
 
     atom_mask = torch.ones((2, atom_seq_len)).bool()
-    additional_token_feats = torch.randn(2, 16, 2)
+    additional_token_feats = torch.randn(2, 16, 33)
     molecule_ids = torch.randint(0, 32, (2, 16))
 
     embedder = InputFeatureEmbedder(
@@ -559,7 +559,7 @@ def test_alphafold3(
         atompair_inputs = full_pairwise_repr_to_windowed(atompair_inputs, window_size = atoms_per_window)
 
     additional_molecule_feats = torch.randint(0, 2, (2, seq_len, 5))
-    additional_token_feats = torch.randn(2, 16, 2)
+    additional_token_feats = torch.randn(2, 16, 33)
     is_molecule_types = torch.randint(0, 2, (2, seq_len, IS_MOLECULE_TYPES)).bool()
     molecule_ids = torch.randint(0, 32, (2, seq_len))
 
@@ -697,7 +697,7 @@ def test_alphafold3_without_msa_and_templates():
     atom_inputs = torch.randn(2, atom_seq_len, 77)
     atompair_inputs = torch.randn(2, atom_seq_len, atom_seq_len, 5)
     additional_molecule_feats = torch.randint(0, 2, (2, seq_len, 5))
-    additional_token_feats = torch.randn(2, seq_len, 2)
+    additional_token_feats = torch.randn(2, seq_len, 33)
     is_molecule_types = torch.randint(0, 2, (2, seq_len, IS_MOLECULE_TYPES)).bool()
     molecule_ids = torch.randint(0, 32, (2, seq_len))
 
@@ -772,7 +772,7 @@ def test_alphafold3_force_return_loss():
     atom_inputs = torch.randn(2, atom_seq_len, 77)
     atompair_inputs = torch.randn(2, atom_seq_len, atom_seq_len, 5)
     additional_molecule_feats = torch.randint(0, 2, (2, seq_len, 5))
-    additional_token_feats = torch.randn(2, seq_len, 2)
+    additional_token_feats = torch.randn(2, seq_len, 33)
     is_molecule_types = torch.randint(0, 2, (2, seq_len, IS_MOLECULE_TYPES)).bool()
     molecule_ids = torch.randint(0, 32, (2, seq_len))
 
@@ -855,7 +855,7 @@ def test_alphafold3_force_return_loss_with_confidence_logits():
     atom_inputs = torch.randn(2, atom_seq_len, 77)
     atompair_inputs = torch.randn(2, atom_seq_len, atom_seq_len, 5)
     additional_molecule_feats = torch.randint(0, 2, (2, seq_len, 5))
-    additional_token_feats = torch.randn(2, seq_len, 2)
+    additional_token_feats = torch.randn(2, seq_len, 33)
     is_molecule_types = torch.randint(0, 2, (2, seq_len, IS_MOLECULE_TYPES)).bool()
     molecule_ids = torch.randint(0, 32, (2, seq_len))
 
@@ -951,7 +951,7 @@ def test_alphafold3_with_atom_and_bond_embeddings():
     atompair_inputs = torch.randn(2, atom_seq_len, atom_seq_len, 5)
 
     additional_molecule_feats = torch.randint(0, 2, (2, seq_len, 5))
-    additional_token_feats = torch.randn(2, seq_len, 2)
+    additional_token_feats = torch.randn(2, seq_len, 33)
     is_molecule_types = torch.randint(0, 2, (2, seq_len, IS_MOLECULE_TYPES)).bool()
     molecule_ids = torch.randint(0, 32, (2, seq_len))
 

--- a/tests/test_af3.py
+++ b/tests/test_af3.py
@@ -684,6 +684,7 @@ def test_alphafold3(
         atompair_inputs = atompair_inputs,
         is_molecule_types = is_molecule_types,
         additional_molecule_feats = additional_molecule_feats,
+        additional_msa_feats = additional_msa_feats,
         additional_token_feats = additional_token_feats,
         msa = msa,
         templates = template_feats,

--- a/tests/test_af3.py
+++ b/tests/test_af3.py
@@ -251,7 +251,7 @@ def test_msa_module(
 ):
     single = torch.randn(2, 16, 384).requires_grad_()
     pairwise = torch.randn(2, 16, 16, 128).requires_grad_()
-    msa = torch.randn(2, 7, 16, 64)
+    msa = torch.randn(2, 7, 16, 32)
     mask = torch.randint(0, 2, (2, 16)).bool()
     msa_mask = torch.randint(0, 2, (2, 7)).bool()
     additional_msa_feats = torch.randn(2, 7, 16, 2)
@@ -586,8 +586,10 @@ def test_alphafold3(
     template_feats = torch.randn(2, 2, seq_len, seq_len, 44)
     template_mask = torch.ones((2, 2)).bool()
 
-    msa = torch.randn(2, 7, seq_len, 8)
+    msa = torch.randn(2, 7, seq_len, 32)
     msa_mask = torch.ones((2, 7)).bool()
+
+    additional_msa_feats = torch.randn(2, 7, seq_len, 2)
 
     atom_pos = torch.randn(2, atom_seq_len, 3)
     distogram_atom_indices = molecule_atom_lens - 1
@@ -655,6 +657,7 @@ def test_alphafold3(
         is_molecule_types = is_molecule_types,
         is_molecule_mod = is_molecule_mod,
         additional_molecule_feats = additional_molecule_feats,
+        additional_msa_feats = additional_msa_feats,
         additional_token_feats = additional_token_feats,
         token_bonds = token_bonds,
         msa = msa,
@@ -960,8 +963,10 @@ def test_alphafold3_with_atom_and_bond_embeddings():
     template_feats = torch.randn(2, 2, seq_len, seq_len, 44)
     template_mask = torch.ones((2, 2)).bool()
 
-    msa = torch.randn(2, 7, seq_len, 64)
+    msa = torch.randn(2, 7, seq_len, 32)
     msa_mask = torch.ones((2, 7)).bool()
+
+    additional_msa_feats = torch.randn(2, 7, seq_len, 2)
 
     # required for training, but omitted on inference
 
@@ -983,6 +988,7 @@ def test_alphafold3_with_atom_and_bond_embeddings():
         molecule_atom_lens = molecule_atom_lens,
         is_molecule_types = is_molecule_types,
         additional_molecule_feats = additional_molecule_feats,
+        additional_msa_feats = additional_msa_feats,
         additional_token_feats = additional_token_feats,
         msa = msa,
         msa_mask = msa_mask,

--- a/tests/test_af3.py
+++ b/tests/test_af3.py
@@ -254,6 +254,7 @@ def test_msa_module(
     msa = torch.randn(2, 7, 16, 64)
     mask = torch.randint(0, 2, (2, 16)).bool()
     msa_mask = torch.randint(0, 2, (2, 7)).bool()
+    additional_msa_feats = torch.randn(2, 7, 16, 2)
 
     msa_module = MSAModule(
         checkpoint = checkpoint,
@@ -265,7 +266,8 @@ def test_msa_module(
         single_repr = single,
         pairwise_repr = pairwise,
         mask = mask,
-        msa_mask = msa_mask
+        msa_mask = msa_mask,
+        additional_msa_feats = additional_msa_feats
     )
 
     assert pairwise.shape == pairwise_out.shape


### PR DESCRIPTION
* Adds MSA support for all of life's molecules
* Tl;dr is, each MSA file corresponds to one specific polymer chain, and (by way of the clustering script's design) each chain's MSA is of a single molecule type even if the chain contains e.g., some DNA residues mixed with the protein chain's amino acids. In this mixed molecule type scenario, this new MSA parsing code treats these "minority-type" residues in each chain as the corresponding unknown residue type of that molecule's type (e.g., DNA residues in a protein-majority chain are treated as `DN` residues in the final MSA, to give the model some partial additional context about these mixed type chains)
* Ligands and modified polymer residues are simply treated as unknown amino acids (with `restype=20`) in the final MSAs
* **TODO:** For MSA chain pairing, an analogous pattern to `_UNIPROT_PATTERN` in `msa_parsing.py` would need to be defined for RNA & DNA entities (@milot-mirdita)