### PR TITLE
Revert mask creation for `plddt_labels`

### DIFF
--- a/alphafold3_pytorch/alphafold3.py
+++ b/alphafold3_pytorch/alphafold3.py
@@ -6012,8 +6012,12 @@ class Alphafold3(Module):
                 is_nucleotide = is_rna | is_dna
                 is_polymer = is_protein | is_rna | is_dna
 
-                is_any_nucleotide_pair = to_pairwise_mask(is_nucleotide)
-                is_any_polymer_pair = to_pairwise_mask(is_polymer)
+                is_any_nucleotide_pair = einx.logical_and(
+                    '... i, ... j -> ... i j', torch.ones_like(is_nucleotide), is_nucleotide
+                )
+                is_any_polymer_pair = einx.logical_and(
+                    '... i, ... j -> ... i j', torch.ones_like(is_polymer), is_polymer
+                )
 
                 inclusion_radius = torch.where(
                     is_any_nucleotide_pair,
@@ -6023,7 +6027,11 @@ class Alphafold3(Module):
 
                 is_token_center_atom = torch.zeros_like(atom_pos[..., 0], dtype=torch.bool)
                 is_token_center_atom[torch.arange(batch_size).unsqueeze(1), molecule_atom_indices] = True
-                is_any_token_center_atom_pair = to_pairwise_mask(is_token_center_atom)
+                is_any_token_center_atom_pair = einx.logical_and(
+                    '... i, ... j -> ... i j',
+                    torch.ones_like(is_token_center_atom),
+                    is_token_center_atom,
+                )
 
                 # compute masks, avoiding self term
 


### PR DESCRIPTION
* Reverts a recent change to `plddt_labels`, to ensure the construction of the `plddt_mask` follows the following criteria in the AF3 supplement:
```
`l` encompasses **all atoms** and the set of atoms `m ∈ R` is defined as:
• Atoms such that the distance in the ground truth between atom `l` and atom `m` is less than 15 Å if `m` is a protein
atom or less than 30 Å if `m` is a nucleic acid atom.
• Only atoms in polymer chains.
• One atom per token - Cα for standard protein residues and C1′ for standard nucleic acid residues.
```
In other words, the `l` indices in `plddt_mask`'s components need to store a `True` value along this dimension, so indicate that all atoms are considered as source atoms and only a subset of e.g., token center atoms are considered prospective destination atoms