### PR TITLE
Correct values in `molecule_atom_indices` for training-time ligand `PDBInputs`

### DIFF
--- a/alphafold3_pytorch/inputs.py
+++ b/alphafold3_pytorch/inputs.py
@@ -2626,9 +2626,13 @@ def pdb_input_to_molecule_input(
     distogram_atom_indices = []
     src_tgt_atom_indices = []
 
-    for mol_type, chemid in zip(
+    current_atom_index = 0
+    current_res_index = -1
+
+    for mol_type, chemid, res_index in zip(
         molecule_atom_types,
         biomol.chemid,
+        biomol.residue_index,
     ):
         residue_constants = get_residue_constants(
             mol_type.replace("protein", "peptide").replace("mod_", "")
@@ -2643,9 +2647,15 @@ def pdb_input_to_molecule_input(
 
         if is_atomized_residue(mol_type):
             # collect indices for each ligand and modified polymer residue token (i.e., atom)
+            if current_res_index == res_index:
+                current_atom_index += 1
+            else:
+                current_atom_index = 0
+                current_res_index = res_index
+
             atom_indices_for_frame.append(None)
-            molecule_atom_indices.append(-1)
-            distogram_atom_indices.append(-1)
+            molecule_atom_indices.append(current_atom_index)
+            distogram_atom_indices.append(current_atom_index)
             # NOTE: ligand and modified polymer residue tokens do not have source-target atom indices
         else:
             # collect indices for each polymer residue token


### PR DESCRIPTION
* Corrects the values in `molecule_atom_indices` for training-time ligand `PDBInputs` such that ligands and modified polymer residues are now supervised for distogram prediction and all confidence head outputs.
* **NOTE:** This does not correct the inference-time (MoleculeLength ...) input pathways yet. These will need to be corrected accordingly.
* **NOTE:** Currently for (training-time) ligand and modified polymer residue inputs, we simply give them no atom frame indices via `atom_indices_for_frame.append(None)`. This means we'll need to manually construct (k=2) nearest neighbors for each ligand and modified polymer residue token (i.e., atom). Also, for metal ions that are the only atoms in a particular chain, their frames can simply be ignored.