### PR TITLE
Add libxrender, libxtst6, libxext6, libxi6 for ChemDraw to get example code working

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,6 +9,10 @@ RUN apt-get update \
         build-essential \
         git \
         wget \
+        libxrender1 \
+        libxtst6 \
+        libxext6 \
+        libxi6 \
     && rm -rf /var/lib/apt/lists/* \
     && apt-get autoremove -y \
     && apt-get clean


### PR DESCRIPTION
To get the example usage code from the README working, the following libraries needed to be added to the Dockerfile:

```
        libxrender1 \
        libxtst6 \
        libxext6 \
        libxi6 \
```
