### PR TITLE
Specify test IDs for PDB dataset during tests

### DIFF
--- a/tests/test_msa_loading.py
+++ b/tests/test_msa_loading.py
@@ -1,6 +1,5 @@
-import os
-
 import pytest
+from pathlib import Path
 
 from alphafold3_pytorch.data.weighted_pdb_sampler import WeightedPDBSampler
 from alphafold3_pytorch.inputs import PDBDataset
@@ -10,23 +9,20 @@ from alphafold3_pytorch.utils.utils import exists
 
 def test_msa_loading():
     """Test an MSA-featurized PDBDataset constructed using a WeightedPDBSampler."""
-    data_test = os.path.join("data", "test")
-    data_test_mmcif_dir = os.path.join(data_test, "mmcifs")
-    data_test_clusterings_dir = os.path.join(data_test, "data_caches", "clusterings")
-    data_test_msa_dir = os.path.join(data_test, "data_caches", "msa", "msas")
+    data_test = Path("data", "test")
+    data_test_mmcif_dir = data_test / "mmcifs"
+    data_test_clusterings_dir = data_test / "data_caches" / "clusterings"
+    data_test_msa_dir = data_test / "data_caches" / "msa" / "msas"
 
-    if not os.path.exists(data_test_mmcif_dir):
+    if not data_test_mmcif_dir.exists():
         pytest.skip(f"The directory `{data_test_mmcif_dir}` is not populated yet.")
 
-    interface_mapping_path = os.path.join(data_test_clusterings_dir, "interface_cluster_mapping.csv")
+    interface_mapping_path = str(data_test_clusterings_dir / "interface_cluster_mapping.csv")
     chain_mapping_paths = [
-        os.path.join(data_test_clusterings_dir, "ligand_chain_cluster_mapping.csv"),
-        os.path.join(
-            data_test_clusterings_dir,
-            "nucleic_acid_chain_cluster_mapping.csv",
-        ),
-        os.path.join(data_test_clusterings_dir, "peptide_chain_cluster_mapping.csv"),
-        os.path.join(data_test_clusterings_dir, "protein_chain_cluster_mapping.csv"),
+        str(data_test_clusterings_dir / "ligand_chain_cluster_mapping.csv"),
+        str(data_test_clusterings_dir / "nucleic_acid_chain_cluster_mapping.csv"),
+        str(data_test_clusterings_dir / "peptide_chain_cluster_mapping.csv"),
+        str(data_test_clusterings_dir / "protein_chain_cluster_mapping.csv"),
     ]
 
     sampler = WeightedPDBSampler(
@@ -35,16 +31,22 @@ def test_msa_loading():
         batch_size=64,
     )
 
+    sampler_pdb_ids = set(sampler.mappings.get_column("pdb_id").to_list())
+    test_ids = set(
+        filepath.stem
+        for filepath in data_test_mmcif_dir.glob("**/*.cif")
+        if filepath.stem in sampler_pdb_ids
+    )
+
     pdb_input = PDBDataset(
         folder=data_test_mmcif_dir,
         sampler=sampler,
         sample_type="default",
         crop_size=128,
-        msa_dir=data_test_msa_dir,
+        msa_dir=str(data_test_msa_dir),
+        sample_only_pdb_ids=test_ids,
         training=False,
     )
 
-    sample = pdb_input.__getitem__(0, max_attempts=20)
-
-    batched_atom_input = pdb_inputs_to_batched_atom_input(sample, atoms_per_window=27)
+    batched_atom_input = pdb_inputs_to_batched_atom_input(pdb_input[0], atoms_per_window=27)
     assert exists(batched_atom_input)

--- a/tests/test_template_loading.py
+++ b/tests/test_template_loading.py
@@ -1,5 +1,5 @@
-import os
 import pytest
+from pathlib import Path
 
 from alphafold3_pytorch.inputs import PDBDataset
 from alphafold3_pytorch.data.weighted_pdb_sampler import WeightedPDBSampler
@@ -9,23 +9,20 @@ from alphafold3_pytorch.utils.utils import exists
 
 def test_template_loading():
     """Test a template-featurized PDBDataset constructed using a WeightedPDBSampler."""
-    data_test = os.path.join("data", "test")
-    data_test_mmcif_dir = os.path.join(data_test, "mmcifs")
-    data_test_clusterings_dir = os.path.join(data_test, "data_caches", "clusterings")
-    data_test_template_dir = os.path.join(data_test, "data_caches", "template", "templates")
+    data_test = Path("data", "test")
+    data_test_mmcif_dir = data_test / "mmcifs"
+    data_test_clusterings_dir = data_test / "data_caches" / "clusterings"
+    data_test_template_dir = data_test / "data_caches" / "template" / "templates"
 
-    if not os.path.exists(data_test_mmcif_dir):
+    if not data_test_mmcif_dir.exists():
         pytest.skip(f"The directory `{data_test_mmcif_dir}` is not populated yet.")
 
-    interface_mapping_path = os.path.join(data_test_clusterings_dir, "interface_cluster_mapping.csv")
+    interface_mapping_path = str(data_test_clusterings_dir / "interface_cluster_mapping.csv")
     chain_mapping_paths = [
-        os.path.join(data_test_clusterings_dir, "ligand_chain_cluster_mapping.csv"),
-        os.path.join(
-            data_test_clusterings_dir,
-            "nucleic_acid_chain_cluster_mapping.csv",
-        ),
-        os.path.join(data_test_clusterings_dir, "peptide_chain_cluster_mapping.csv"),
-        os.path.join(data_test_clusterings_dir, "protein_chain_cluster_mapping.csv"),
+        str(data_test_clusterings_dir / "ligand_chain_cluster_mapping.csv"),
+        str(data_test_clusterings_dir / "nucleic_acid_chain_cluster_mapping.csv"),
+        str(data_test_clusterings_dir / "peptide_chain_cluster_mapping.csv"),
+        str(data_test_clusterings_dir / "protein_chain_cluster_mapping.csv"),
     ]
 
     sampler = WeightedPDBSampler(
@@ -34,16 +31,22 @@ def test_template_loading():
         batch_size=64,
     )
 
+    sampler_pdb_ids = set(sampler.mappings.get_column("pdb_id").to_list())
+    test_ids = set(
+        filepath.stem
+        for filepath in data_test_mmcif_dir.glob("**/*.cif")
+        if filepath.stem in sampler_pdb_ids
+    )
+
     pdb_input = PDBDataset(
         folder=data_test_mmcif_dir,
         sampler=sampler,
         sample_type="default",
         crop_size=128,
-        templates_dir=data_test_template_dir,
+        templates_dir=str(data_test_template_dir),
+        sample_only_pdb_ids=test_ids,
         training=False,
     )
 
-    sample = pdb_input.__getitem__(0, max_attempts=20)
-
-    batched_atom_input = pdb_inputs_to_batched_atom_input(sample, atoms_per_window=27)
+    batched_atom_input = pdb_inputs_to_batched_atom_input(pdb_input[0], atoms_per_window=27)
     assert exists(batched_atom_input)


### PR DESCRIPTION
As @amorehead mentioned in #236, I have used the `sample_only_pdb_ids` flag to sample based only on the mmcifs found in the testing data. I also ported this code over to `pathlib`, to make it a bit more readable.