### PR TITLE
Various template and MSA fixes

### DIFF
--- a/alphafold3_pytorch/alphafold3.py
+++ b/alphafold3_pytorch/alphafold3.py
@@ -6604,6 +6604,7 @@ class Alphafold3(Module):
                     templates = templates,
                     template_mask = template_mask,
                     pairwise_repr = pairwise,
+                    mask = mask
                 )
 
                 pairwise = embedded_template + pairwise
@@ -6616,7 +6617,8 @@ class Alphafold3(Module):
                     single_repr = single,
                     pairwise_repr = pairwise,
                     msa_mask = msa_mask,
-                    additional_msa_feats = additional_msa_feats
+                    additional_msa_feats = additional_msa_feats,
+                    mask = mask
                 )
 
                 pairwise = embedded_msa + pairwise

--- a/alphafold3_pytorch/data/template_parsing.py
+++ b/alphafold3_pytorch/data/template_parsing.py
@@ -398,7 +398,9 @@ def _extract_template_features(
         template_inv_distance_scalar * template_backbone_frame_mask.unsqueeze(-1)
     )
 
+    # NOTE: The unit vectors are initially of shape (j, i, 3), so they need to be transposed
     template_unit_vector = template_backbone_vec * template_inv_distance_scalar.unsqueeze(-1)
+    template_unit_vector = template_unit_vector.transpose(-3, -2)
 
     return {
         "template_restype": template_restype.float(),

--- a/alphafold3_pytorch/data/template_parsing.py
+++ b/alphafold3_pytorch/data/template_parsing.py
@@ -382,7 +382,7 @@ def _extract_template_features(
         template_three_atom_indices_for_frame.unsqueeze(-1).expand(-1, -1, 3),
     )
 
-    rigid_from_reference_3_points = RigidFromReferenceThreePoints()
+    rigid_from_reference_3_points = RigidFromReference3Points()
     template_backbone_frames, template_backbone_points = rigid_from_reference_3_points(
         template_backbone_frame_atom_positions.unbind(-2)
     )

--- a/alphafold3_pytorch/inputs.py
+++ b/alphafold3_pytorch/inputs.py
@@ -2401,7 +2401,7 @@ def load_msa_from_msa_dir(
     file_id: str,
     chain_id_to_residue: Dict[str, Dict[str, List[int]]],
     max_msas_per_chain: int | None = None,
-    randomly_truncate: bool = True,
+    randomly_truncate: bool = False,
     raise_missing_exception: bool = False,
     verbose: bool = False,
 ) -> FeatureDict:


### PR DESCRIPTION
* By default, avoid randomly truncating MSAs since ordering matters
* Also, transpose template unit vectors to have shape (i, j, 3) instead of (j, i, 3)
* Lastly, pass `mask` into `template_embedder` and `msa_embedder`