### PR TITLE
Add full constraints set

### DIFF
--- a/alphafold3_pytorch/alphafold3.py
+++ b/alphafold3_pytorch/alphafold3.py
@@ -64,7 +64,7 @@ from alphafold3_pytorch.inputs import (
     IS_LIGAND_INDEX,
     IS_METAL_ION_INDEX,
     IS_BIOMOLECULE_INDICES,
-    IS_NON_PROTEIN_INDICES
+    IS_NON_PROTEIN_INDICES,
     IS_PROTEIN,
     IS_DNA,
     IS_RNA,

--- a/alphafold3_pytorch/alphafold3.py
+++ b/alphafold3_pytorch/alphafold3.py
@@ -61,6 +61,7 @@ from alphafold3_pytorch.inputs import (
     IS_LIGAND_INDEX,
     IS_METAL_ION_INDEX,
     IS_BIOMOLECULE_INDICES,
+    IS_NON_PROTEIN_INDICES
     IS_PROTEIN,
     IS_DNA,
     IS_RNA,
@@ -5955,6 +5956,7 @@ class Alphafold3(Module):
         plm_embeddings: PLMEmbedding | tuple[PLMEmbedding, ...] | None = None,
         plm_kwargs: dict | tuple[dict, ...] | None = None,
         constraint_embeddings: int | None = None,
+        constraint_dropout: float = 0.0,
     ):
         super().__init__()
 
@@ -5986,7 +5988,11 @@ class Alphafold3(Module):
         self.constraint_embeddings = constraint_embeddings
 
         if exists(constraint_embeddings):
-            self.constraint_embeds = LinearNoBias(constraint_embeddings, dim_pairwise)
+            constraint_modules = [
+                LinearNoBias(constraint_embeddings, dim_pairwise),
+                (nn.Dropout(constraint_dropout) if constraint_dropout else nn.Identity()),
+            ]
+            self.constraint_embeds = nn.Sequential(*constraint_modules)
 
         # residue or nucleotide modifications
 
@@ -6550,9 +6556,9 @@ class Alphafold3(Module):
 
         if exists(self.plms):
             molecule_aa_ids = torch.where(
-                molecule_ids < 0,
-                NUM_HUMAN_AMINO_ACIDS,
-                molecule_ids.clamp(max=NUM_HUMAN_AMINO_ACIDS),
+                is_molecule_types[..., IS_NON_PROTEIN_INDICES].any(dim=-1),
+                -1,
+                molecule_ids,
             )
 
             plm_embeds = [plm(molecule_aa_ids) for plm in self.plms]

--- a/alphafold3_pytorch/alphafold3.py
+++ b/alphafold3_pytorch/alphafold3.py
@@ -54,6 +54,9 @@ from alphafold3_pytorch.attention import (
 )
 
 from alphafold3_pytorch.inputs import (
+    CONSTRAINT_DIMS,
+    CONSTRAINTS,
+    CONSTRAINTS_MASK_VALUE,
     IS_MOLECULE_TYPES,
     IS_PROTEIN_INDEX,
     IS_DNA_INDEX,
@@ -5955,8 +5958,7 @@ class Alphafold3(Module):
         pdb_training_set=True,
         plm_embeddings: PLMEmbedding | tuple[PLMEmbedding, ...] | None = None,
         plm_kwargs: dict | tuple[dict, ...] | None = None,
-        constraint_embeddings: int | None = None,
-        constraint_dropout: float = 0.0,
+        constraints: List[CONSTRAINTS] | None = None,
     ):
         super().__init__()
 
@@ -5985,14 +5987,18 @@ class Alphafold3(Module):
 
         # optional pairwise token constraint embeddings
 
-        self.constraint_embeddings = constraint_embeddings
+        self.constraints = constraints
 
-        if exists(constraint_embeddings):
-            constraint_modules = [
-                LinearNoBias(constraint_embeddings, dim_pairwise),
-                (nn.Dropout(constraint_dropout) if constraint_dropout else nn.Identity()),
-            ]
-            self.constraint_embeds = nn.Sequential(*constraint_modules)
+        if exists(constraints):
+            self.constraint_embeds = nn.ModuleList(
+                [
+                    LinearNoBias(CONSTRAINT_DIMS[constraint], dim_pairwise)
+                    for constraint in constraints
+                ]
+            )
+            self.learnable_constraint_masks = nn.ParameterList(
+                [nn.Parameter(torch.randn(1)) for _ in constraints]
+            )
 
         # residue or nucleotide modifications
 
@@ -6544,13 +6550,22 @@ class Alphafold3(Module):
 
         # handle maybe pairwise token constraint embeddings
 
-        if exists(self.constraint_embeddings):
+        if exists(self.constraints):
             assert exists(
                 token_constraints
             ), "`token_constraints` must be provided to use constraint embeddings."
 
-            pairwise_constraint_embeds = self.constraint_embeds(token_constraints)
-            pairwise_init = pairwise_init + pairwise_constraint_embeds
+            for i, constraint in enumerate(self.constraints):
+                constraint_slice = slice(i, i + CONSTRAINT_DIMS[constraint])
+
+                token_constraint = torch.where(
+                    # replace fixed constraint mask values with learnable mask
+                    token_constraints[..., constraint_slice] == CONSTRAINTS_MASK_VALUE,
+                    self.learnable_constraint_masks[i],
+                    token_constraints[..., constraint_slice],
+                )
+
+                pairwise_init = pairwise_init + self.constraint_embeds[i](token_constraint)
 
         # handle maybe protein language model (PLM) embeddings
 

--- a/alphafold3_pytorch/data/template_parsing.py
+++ b/alphafold3_pytorch/data/template_parsing.py
@@ -121,13 +121,8 @@ def parse_m8(
             template_release_date = extract_mmcif_metadata_field(
                 template_mmcif_object, "release_date"
             )
-            if not (
-                exists(template_cutoff_date)
-                and datetime.strptime(template_release_date, "%Y-%m-%d") <= template_cutoff_date
-            ):
+            if exists(template_cutoff_date) and datetime.strptime(template_release_date, "%Y-%m-%d") > template_cutoff_date:
                 continue
-            elif not_exists(template_cutoff_date):
-                pass
             template_biomol = _from_mmcif_object(
                 template_mmcif_object, chain_ids=set(template_chain)
             )

--- a/alphafold3_pytorch/data/weighted_pdb_sampler.py
+++ b/alphafold3_pytorch/data/weighted_pdb_sampler.py
@@ -192,7 +192,7 @@ class WeightedPDBSampler(Sampler[List[str]]):
         alpha_prot: float = 3.0,
         alpha_nuc: float = 3.0,
         alpha_ligand: float = 1.0,
-        pdb_ids_to_skip: List[str] = [],
+        pdb_ids_to_skip: List[str] | None = None,
         pdb_ids_to_keep: list[str] | None = None,
     ):
         # Load chain and interface mappings
@@ -211,7 +211,7 @@ class WeightedPDBSampler(Sampler[List[str]]):
         interface_mapping = pl.read_csv(interface_mapping_path)
 
         # Filter out unwanted PDB IDs
-        if len(pdb_ids_to_skip) > 0:
+        if exists(pdb_ids_to_skip) and len(pdb_ids_to_skip) > 0:
             chain_mapping = chain_mapping.filter(pl.col("pdb_id").is_in(pdb_ids_to_skip).not_())
             interface_mapping = interface_mapping.filter(
                 pl.col("pdb_id").is_in(pdb_ids_to_skip).not_()

--- a/alphafold3_pytorch/plm.py
+++ b/alphafold3_pytorch/plm.py
@@ -36,6 +36,9 @@ def remove_plms(fn):
 aa_constants = get_residue_constants(res_chem_index=IS_PROTEIN)
 restypes = aa_constants.restypes + ["X"]
 
+ESM_MASK_TOKEN = "-"
+PROST_T5_MASK_TOKEN = "X"
+
 # class
 
 
@@ -72,7 +75,7 @@ class ESMWrapper(Module):
         sequence_data = [
             (
                 f"molecule{mol_idx}",
-                join([(restypes[i] if 0 <= i < len(restypes) else "X") for i in ids]),
+                join([(ESM_MASK_TOKEN if i == -1 else restypes[i]) for i in ids]),
             )
             for mol_idx, ids in enumerate(aa_ids)
         ]
@@ -119,7 +122,7 @@ class ProstT5Wrapper(Module):
         device, seq_len = self.dummy.device, aa_ids.shape[-1]
 
         str_sequences = [
-            join([(restypes[i] if 0 <= i < len(restypes) else "X") for i in ids]) for ids in aa_ids
+            join([(PROST_T5_MASK_TOKEN if i == -1 else restypes[i]) for i in ids]) for ids in aa_ids
         ]
 
         # following the readme at https://github.com/mheinzinger/ProstT5

--- a/tests/test_dataloading.py
+++ b/tests/test_dataloading.py
@@ -31,7 +31,7 @@ def test_data_input():
     sampler = WeightedPDBSampler(
         chain_mapping_paths=chain_mapping_paths,
         interface_mapping_path=interface_mapping_path,
-        batch_size=64,
+        batch_size=4,
     )
 
     sampler_pdb_ids = set(sampler.mappings.get_column("pdb_id").to_list())


### PR DESCRIPTION
* Adds the full constraints set from Chai-1
* Fixes a few discrepancies in how PLM inputs are tokenized
* Adds a stricter training set cutoff date at runtime
* Supports skipping specific PDB IDs now
* Adds a 60 second timeout to `pdb_input_to_molecule_input()`
* Fixes a bug in `molecule_to_atom_input()` that would lead to missing tokens not being properly masked out w.r.t. `distogram_atom_indices`, `molecule_atom_indices`, and `atom_indices_for_frames`