### PR TITLE
Fix variable reference

### DIFF
--- a/alphafold3_pytorch/inputs.py
+++ b/alphafold3_pytorch/inputs.py
@@ -773,7 +773,7 @@ def molecule_to_atom_input(mol_input: MoleculeInput) -> AtomInput:
             bonds = mol.GetBonds()
             num_bonds = len(bonds)
 
-            for bond in has_bonds:
+            for bond in bonds:
                 atom_start_index = bond.GetBeginAtomIdx()
                 atom_end_index = bond.GetEndAtomIdx()
 


### PR DESCRIPTION
*  Fixes a variable reference.
* Also, it now looks like `mol_atompair_ids` created in `molecule_lengthed_molecule_input_to_atom_input()` is not updated. It's just set to all zeros after the einx code was commented out.