### PR TITLE
rewriting logic for computing rsa for model selection

### DIFF
--- a/alphafold3_pytorch/alphafold3.py
+++ b/alphafold3_pytorch/alphafold3.py
@@ -5734,10 +5734,6 @@ class ComputeModelSelectionScore(Module):
 
         assert self.can_calculate_unresolved_protein_rasa, "`mkdssp` needs to be installed"
 
-        residue_constants = get_residue_constants(res_chem_index=IS_PROTEIN)
-
-        device = atom_pos.device
-        dtype = atom_pos.dtype
         num_atom = atom_pos.shape[0]
 
         chain_mask = asym_id == unresolved_cid
@@ -5817,7 +5813,7 @@ class ComputeModelSelectionScore(Module):
 
         atom_rel_pos = einx.subtract('i c, j c -> i j c', structure_atom_pos, structure_atom_pos)
 
-        surface_dots = einx.multiply('m, sd c -> m sd c', atom_radii, unit_surface_dots)
+        surface_dots = einx.multiply('m, sd c -> m sd c', atom_radii + water_radii, unit_surface_dots)
 
         dist_from_surface_dots_sq = einx.subtract('i j c, i sd c -> i sd j c', atom_rel_pos, surface_dots).pow(2).sum(dim = -1)
 

--- a/alphafold3_pytorch/alphafold3.py
+++ b/alphafold3_pytorch/alphafold3.py
@@ -5811,7 +5811,7 @@ class ComputeModelSelectionScore(Module):
 
         # overall logic
 
-        atom_rel_pos = einx.subtract('i c, j c -> i j c', structure_atom_pos, structure_atom_pos)
+        atom_rel_pos = einx.subtract('j c, i c -> i j c', structure_atom_pos, structure_atom_pos)
 
         surface_dots = einx.multiply('m, sd c -> m sd c', atom_radii + water_radii, unit_surface_dots)
 

--- a/alphafold3_pytorch/alphafold3.py
+++ b/alphafold3_pytorch/alphafold3.py
@@ -5286,8 +5286,19 @@ class ComputeModelSelectionScore(Module):
         self.register_buffer('lddt_thresholds', torch.tensor([0.5, 1.0, 2.0, 4.0]))
 
         self.dssp_path = dssp_path
+
         self.use_inhouse_rsa_calculation = use_inhouse_rsa_calculation
 
+        atom_type_radii = tensor([
+            1.65,    # 0 - nitrogen
+            1.87,    # 1 - carbon alpha
+            1.76,    # 2 - carbon
+            1.4,     # 3 - oxygen
+            1.8,     # 4 - side atoms
+            1.4      # 5 - water
+        ])
+
+        self.register_buffer('atom_radii', atom_type_radii)
 
     @property
     def is_mkdssp_available(self):

--- a/alphafold3_pytorch/alphafold3.py
+++ b/alphafold3_pytorch/alphafold3.py
@@ -5307,7 +5307,7 @@ class ComputeModelSelectionScore(Module):
             1.4      # 5 - water
         ])
 
-        self.register_buffer('atom_radii', atom_type_radii)
+        self.register_buffer('atom_radii', atom_type_radii, persistent = False)
 
     @property
     def is_mkdssp_available(self):

--- a/alphafold3_pytorch/alphafold3.py
+++ b/alphafold3_pytorch/alphafold3.py
@@ -5762,11 +5762,11 @@ class ComputeModelSelectionScore(Module):
 
         radius = 1.
 
-        atom_rel_pos = einx.subtract('i c, j c-> i j c', atom_pos, atom_pos)
+        atom_rel_pos = einx.subtract('i c, j c -> i j c', atom_pos, atom_pos)
 
         surface_dots = radius * unit_surface_dots
 
-        dist_from_surface_dots_sq = (einx.subtract('i j c, sd c -> i sd j c') ** 2).sum(dim = -1)
+        dist_from_surface_dots_sq = einx.subtract('i j c, sd c -> i sd j c', atom_rel_pos, surface_dots).pow(2).sum(dim = -1)
 
         free = reduce(dist_from_surface_dots_sq > radius, 'i sd j -> i sd', 'all')
 


### PR DESCRIPTION
rewriting [the logic](https://github.com/PDB-REDO/dssp/blob/trunk/libdssp/src/dssp.cpp#L608-L720) for calculating accessible surface area of residues without `mkdssp`, which i still have trouble installing

[the logic](https://github.com/PDB-REDO/dssp/blob/trunk/libdssp/src/dssp.cpp#L583-L597) for including the atoms for rsa calculation, linking for review

will submit a pull request up to [pydssp](https://github.com/ShintaroMinami/PyDSSP) once and if successfully completed

[relevant issue](https://github.com/ShintaroMinami/PyDSSP/issues/4)