### PR TITLE
Set `bias=False` for both `LayerNorms` in `AdaptiveLayerNorm`

### DIFF
--- a/alphafold3_pytorch/alphafold3.py
+++ b/alphafold3_pytorch/alphafold3.py
@@ -622,7 +622,7 @@ class AdaptiveLayerNorm(Module):
         dim_cond
     ):
         super().__init__()
-        self.norm = nn.LayerNorm(dim, elementwise_affine = False)
+        self.norm = nn.LayerNorm(dim, elementwise_affine = False, bias = False)
         self.norm_cond = nn.LayerNorm(dim_cond, bias = False)
 
         self.to_gamma = nn.Sequential(


### PR DESCRIPTION
Following Algorithm 26 below
![image](https://github.com/user-attachments/assets/2e7216b9-6bdf-4d2a-a550-1d1faad9e1ae)
both `LayerNorm` modules for `a` and `s`, respectively, should have `bias/offset=False`.