### PR TITLE
Remove zero initialization of `to_attn_bias` weights, since for these `bias=False`

### DIFF
--- a/alphafold3_pytorch/alphafold3.py
+++ b/alphafold3_pytorch/alphafold3.py
@@ -767,11 +767,8 @@ class AttentionPairBias(Module):
 
         # line 8 of Algorithm 24
 
-        to_attn_bias_linear = LinearNoBias(dim_pairwise, heads)
-        nn.init.zeros_(to_attn_bias_linear.weight)
-
         self.to_attn_bias_norm = nn.LayerNorm(dim_pairwise)
-        self.to_attn_bias = nn.Sequential(to_attn_bias_linear, Rearrange("b ... h -> b h ..."))
+        self.to_attn_bias = nn.Sequential(LinearNoBias(dim_pairwise, heads), Rearrange("b ... h -> b h ..."))
 
     @typecheck
     def forward(


### PR DESCRIPTION
Line 8 of Algorithm 24 uses a `LinearNoBias` layer following `LayerNorm` to merge pairwise with attention bias representations, as follows
![image](https://github.com/user-attachments/assets/341a32fa-5e5f-47e4-a66f-b204ab59f362)
However, the code has the `LinearNoBias` weights also initialized with zeros, meaning both the weights and biases of these modules are initially zero (or null) which leads to these weights receiving no gradients throughout training.