### PR TITLE
Remove zero initialization for `adaln_zero_gamma_linear`

### DIFF
--- a/alphafold3_pytorch/alphafold3.py
+++ b/alphafold3_pytorch/alphafold3.py
@@ -663,7 +663,6 @@ class ConditionWrapper(Module):
         self.adaptive_norm = AdaptiveLayerNorm(dim = dim, dim_cond = dim_cond)
 
         adaln_zero_gamma_linear = Linear(dim_cond, dim)
-        nn.init.zeros_(adaln_zero_gamma_linear.weight)
         nn.init.constant_(adaln_zero_gamma_linear.bias, adaln_zero_bias_init_value)
 
         self.to_adaln_zero_gamma = nn.Sequential(


### PR DESCRIPTION
Zero initialization here differs from the paper (as shown below) and also prevents any non-zero gradients from being associated with `adaln_zero_gamma_linear` (since the gradient of a constant bias with no associated weights - i.e., -2.0 is 0.0).
![image](https://github.com/user-attachments/assets/22322c28-1fbd-49ee-ae44-f67b324a8bce)
